### PR TITLE
implement comparison and add precedence tck

### DIFF
--- a/graph/src/cypher.rs
+++ b/graph/src/cypher.rs
@@ -63,7 +63,9 @@ enum Token {
     Equal,
     NotEqual,
     LessThan,
+    LessThanOrEqual,
     GreaterThan,
+    GreaterThanOrEqual,
     Comma,
     Colon,
     Dot,
@@ -194,10 +196,14 @@ impl<'a> Lexer<'a> {
                     _ => (Token::Equal, 1),
                 },
                 '<' => match chars.next() {
+                    Some('=') => (Token::LessThanOrEqual, 2),
                     Some('>') => (Token::NotEqual, 2),
                     _ => (Token::LessThan, 1),
                 },
-                '>' => (Token::GreaterThan, 1),
+                '>' => match chars.next() {
+                    Some('=') => (Token::GreaterThanOrEqual, 2),
+                    _ => (Token::GreaterThan, 1),
+                },
                 ',' => (Token::Comma, 1),
                 ':' => (Token::Colon, 1),
                 '.' => match chars.next() {
@@ -944,7 +950,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_comparison_expr(&mut self) -> Result<DynTree<ExprIR>, String> {
-        parse_binary_expr!(self.parser_string_list_null_predicate_expr()?, Token::Equal => Eq, Token::NotEqual => Neq);
+        parse_binary_expr!(self.parser_string_list_null_predicate_expr()?, Token::Equal => Eq, Token::NotEqual => Neq, Token::LessThan => Lt, Token::LessThanOrEqual => Le, Token::GreaterThan => Gt, Token::GreaterThanOrEqual => Ge);
     }
 
     fn parse_not_expr(&mut self) -> Result<DynTree<ExprIR>, String> {

--- a/graph/src/runtime.rs
+++ b/graph/src/runtime.rs
@@ -235,21 +235,37 @@ impl<'a> Runtime<'a> {
             },
             ExprIR::Eq => all_equals(ir.children().map(|ir| self.run_expr(ir))),
             ExprIR::Neq => all_not_equals(ir.children().map(|ir| self.run_expr(ir))),
-            ExprIR::Lt => match (self.run_expr(ir.child(0))?, self.run_expr(ir.child(1))?) {
-                (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a < b)),
-                _ => Err(String::from("Lt operator requires two integers")),
+            ExprIR::Lt => match self
+                .run_expr(ir.child(0))?
+                .partial_cmp(&self.run_expr(ir.child(1))?)
+            {
+                Some(Ordering::Less) => Ok(Value::Bool(true)),
+                Some(Ordering::Greater | Ordering::Equal) => Ok(Value::Bool(false)),
+                None => Ok(Value::Null),
             },
-            ExprIR::Gt => match (self.run_expr(ir.child(0))?, self.run_expr(ir.child(1))?) {
-                (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a > b)),
-                _ => Err(String::from("Gt operator requires two integers")),
+            ExprIR::Gt => match self
+                .run_expr(ir.child(0))?
+                .partial_cmp(&self.run_expr(ir.child(1))?)
+            {
+                Some(Ordering::Greater) => Ok(Value::Bool(true)),
+                Some(Ordering::Less | Ordering::Equal) => Ok(Value::Bool(false)),
+                None => Ok(Value::Null),
             },
-            ExprIR::Le => match (self.run_expr(ir.child(0))?, self.run_expr(ir.child(1))?) {
-                (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a <= b)),
-                _ => Err(String::from("Le operator requires two integers")),
+            ExprIR::Le => match self
+                .run_expr(ir.child(0))?
+                .partial_cmp(&self.run_expr(ir.child(1))?)
+            {
+                Some(Ordering::Less | Ordering::Equal) => Ok(Value::Bool(true)),
+                Some(Ordering::Greater) => Ok(Value::Bool(false)),
+                None => Ok(Value::Null),
             },
-            ExprIR::Ge => match (self.run_expr(ir.child(0))?, self.run_expr(ir.child(1))?) {
-                (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a >= b)),
-                _ => Err(String::from("Ge operator requires two integers")),
+            ExprIR::Ge => match self
+                .run_expr(ir.child(0))?
+                .partial_cmp(&self.run_expr(ir.child(1))?)
+            {
+                Some(Ordering::Greater | Ordering::Equal) => Ok(Value::Bool(true)),
+                Some(Ordering::Less) => Ok(Value::Bool(false)),
+                None => Ok(Value::Null),
             },
             ExprIR::In => {
                 let value = self.run_expr(ir.child(0))?;

--- a/tck_done.txt
+++ b/tck_done.txt
@@ -10,6 +10,8 @@ expressions/literals
 expressions/map
 expressions/mathematical
 expressions/null
+expressions/precedence/Precedence2.feature
+expressions/precedence/Precedence4.feature
 expressions/string
 expressions/conditional
 clauses/create/Create1.feature


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for less-than-or-equal (`<=`) and greater-than-or-equal (`>=`) operators in expressions.

- **Improvements**
  - Comparison operators now work with more value types, not just integers. If values cannot be compared, the result is `null` instead of an error.

- **Tests**
  - Marked additional test cases as completed for expression precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->