### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -115,6 +115,8 @@ jobs:
       - check-files
       - docker
     if: ${{ !cancelled() }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Run benchmark


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-rs-next-gen/security/code-scanning/49](https://github.com/FalkorDB/falkordb-rs-next-gen/security/code-scanning/49)

To fix the issue, we need to add a `permissions` block to the `benchmark` job in the workflow file. This block should specify the least privileges required for the job to function correctly. Since the job uses the `GITHUB_TOKEN` to make a commit comment, it requires `contents: write` or `pull-requests: write`. Additionally, other permissions should be set to `read` or omitted entirely if not needed.

The fix involves:
1. Adding a `permissions` block to the `benchmark` job.
2. Setting `contents: write` to allow the job to make a commit comment.
3. Ensuring no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for the benchmark job in GitHub Actions. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->