### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-pr-close.yml
+++ b/.github/workflows/rust-pr-close.yml
@@ -1,5 +1,8 @@
 name: Rust PR Closed
 
+permissions:
+  contents: read
+
 on:
     pull_request:
       branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-rs-next-gen/security/code-scanning/33](https://github.com/FalkorDB/falkordb-rs-next-gen/security/code-scanning/33)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not use `GITHUB_TOKEN` directly, we can set minimal permissions (`contents: read`) at the root level of the workflow. This ensures that the workflow does not inadvertently inherit excessive permissions from the repository.

The changes will be made to the `.github/workflows/rust-pr-close.yml` file:
1. Add a `permissions` block at the root level of the workflow.
2. Set `contents: read` as the minimal permission required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for GitHub Actions to explicitly set repository content read access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->