### PR TITLE
docs(readme): add missing build steps and fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,31 @@ cargo build
 
 #### Dependencies:
 
-GraphBLAS & RediSearch must be built and installed before building this project.
+GraphBLAS, LAGraph, and RediSearch must be built and installed before building this project.
 
 - building [GraphBLAS](https://github.com/DrTimothyAldenDavis/GraphBLAS.git)
 
 ```bash
-  ./graphblas.sh
-``
+./graphblas.sh
+```
 
 or
 
 ```bash
-  make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on'
-  sudo make install
+make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on'
+sudo make install
+```
+
+- building [LAGraph](https://github.com/GraphBLAS/LAGraph.git)
+
+```bash
+./lagraph.sh
 ```
 
 - building [RediSearch](https://github.com/RediSearch/RediSearch.git)
 
 ```bash
-  ./redisearch.sh
+./redisearch.sh
 ```
 
 - pytest - create virtualenv and install tests/requirements.txt
@@ -57,14 +63,21 @@ or
 The virtual environment should be activated before running tests.
 
 ```bash
-  python3 -m venv venv
-  source venv/bin/activate
-  pip install -r  tests/requirements.txt
+python3 -m venv venv
+source venv/bin/activate
+pip install -r tests/requirements.txt
 ```
 
 ### Testing
 
-- run e2e tests with `pytest tests/test_e2e.py tests/test_functions.py -vv`
+- run unit tests with `cargo test -p graph`
+
+- run e2e and function tests with `pytest tests/test_e2e.py tests/test_functions.py -vv`
+
+- run MVCC and concurrency tests with `pytest tests/test_mvcc.py tests/test_concurrency.py -vv`
+
+- run flow tests with `./flow.sh`
+
 - run tck tests with `pytest tests/tck/test_tck.py -s`
 
 There is an option to run only part of the TCK tests and stop on the first fail
@@ -78,7 +91,5 @@ To run all passing TCK tests use:
 ```bash
 TCK_DONE=tck_done.txt pytest tests/tck/test_tck.py -s
 ```
-
-- run unit tests with `cargo test -p graph`
 
 - [benchmark](https://falkordb.github.io/falkordb-rs-next-gen/dev/bench/)


### PR DESCRIPTION
## Summary
Update README to include all build dependencies and test commands that match CI.

## Changes
- Add **LAGraph** as a required dependency with `./lagraph.sh` build instructions (was in CI Dockerfile but missing from README)
- Fix broken code fence (two backticks instead of three) in GraphBLAS section
- Add **MVCC and concurrency tests** to Testing section (`pytest tests/test_mvcc.py tests/test_concurrency.py`)
- Add **flow tests** to Testing section (`./flow.sh`)
- Reorder test listing to match CI execution order: unit → e2e → mvcc → flow → tck
- Fix extra whitespace in pip install command

## Testing
Documentation-only change. Verified markdown renders correctly.

## Memory / Performance Impact
N/A

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added LAGraph as a required dependency alongside GraphBLAS and RediSearch
* Introduced new build instruction for LAGraph compilation
* Expanded testing documentation with new test suites including MVCC/concurrency tests, flow tests, and combined end-to-end and function tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->