### PR TITLE
fix(query): sanitize NUL bytes in error strings before CString conversion

### DIFF
--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -287,7 +287,9 @@ pub fn query_mut(
                     }
                 }
                 Err(err) => {
-                    let cerr = CString::new(err).unwrap();
+                    let sanitized = err.replace('\0', "");
+                    let cerr = CString::new(sanitized)
+                        .unwrap_or_else(|_| CString::new("query error").unwrap());
                     raw::reply_with_error(ctx.ctx, cerr.as_ptr());
                     drop(bc);
                     unsafe { raw::RedisModule_FreeThreadSafeContext.unwrap()(ctx.ctx) };
@@ -383,7 +385,9 @@ pub fn process_write_queued_query(graph: &Arc<RwLock<ThreadedGraph>>) {
                     }
                 }
                 Err(err) => {
-                    let cerr = CString::new(err).unwrap();
+                    let sanitized = err.replace('\0', "");
+                    let cerr = CString::new(sanitized)
+                        .unwrap_or_else(|_| CString::new("query error").unwrap());
                     raw::reply_with_error(ctx.ctx, cerr.as_ptr());
                     drop(bc);
                     unsafe { raw::RedisModule_FreeThreadSafeContext.unwrap()(ctx.ctx) };

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1865,3 +1865,18 @@ def test_optional_match_null_merge():
         [10, [1]],
         [None, [2]],
     ]
+
+
+def test_nul_byte_in_query():
+    """Queries containing NUL bytes must return an error, not crash the server."""
+
+    # A query with an embedded NUL byte should produce a parse error,
+    # not panic the worker thread via CString::new().unwrap().
+    try:
+        common.g.query("RETURN \"\x00\"")
+    except ResponseError:
+        pass
+
+    # Verify the server is still responsive after the NUL-byte query.
+    res = common.g.query("RETURN 1")
+    assert res.result_set == [[1]]


### PR DESCRIPTION
## Summary

Fix a denial-of-service bug where a Cypher query containing embedded NUL bytes (`\0`) causes `CString::new(err).unwrap()` to panic, killing the worker thread and leaving the Redis client hanging indefinitely. Repeated exploitation exhausts the thread pool.

## Changes

- **`src/graph_core.rs`**: Strip NUL bytes from error strings before passing to `CString::new()` in both the read-query error path (line 290) and the write-queue error path (line 386). Added `unwrap_or_else` fallback for defensive safety.
- **`tests/test_e2e.py`**: Added `test_nul_byte_in_query` — sends a query with an embedded NUL byte and verifies the server remains responsive afterward.

## Testing

- `pytest tests/test_e2e.py::test_nul_byte_in_query -xvs` — PASSED
- `cargo fmt --all -- --check` — clean
- `cargo build` — success

## Memory / Performance Impact

N/A — the fix adds a single `.replace('\0', "")` call on the error path only (not hot path).

## Related Issues

Discovered during security audit — no existing issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling to prevent server crashes when processing queries containing embedded special characters. Error messages now safely fallback to a generic message if sanitization fails.

* **Tests**
  * Added end-to-end test to validate server stability and responsiveness after handling malformed queries with edge-case character sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->