### PR TITLE
chore: update build deps, flow test configuration, and redis.conf

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,7 +49,7 @@ RUN ln -sf /usr/bin/clang-22 /usr/local/bin/clang && \
 RUN python3 -m venv /data/venv
 
 # Install Python test dependencies (setuptools needed for pkg_resources)
-RUN /data/venv/bin/pip install setuptools behave falkordb hypothesis pytest pytest-benchmark RLTest
+RUN /data/venv/bin/pip install setuptools behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
 # Install Rust (needed before running scripts)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ RUN apt install -y git make cmake curl zlib1g zlib1g-dev libpolly-22-dev libomp-
 
 RUN python3 -m venv venv
 
-RUN venv/bin/pip install behave falkordb hypothesis pytest pytest-benchmark RLTest
+RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
 RUN git clone --branch dev2 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 # RUN git clone --branch v10.3.1 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git

--- a/flow.sh
+++ b/flow.sh
@@ -24,7 +24,15 @@ if [[ "$TESTS_FILE" == "" ]]; then
 fi
 
 STOP_ON_FAILURE=""
-PARALLELISM="--parallelism 8"
+if [[ "$PARALLELISM" == "" ]]; then
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    CORES=$(sysctl -n hw.ncpu)
+  else
+    CORES=$(nproc)
+  fi
+  echo "Running with parallelism: $CORES"
+  PARALLELISM="--parallelism $CORES"
+fi
 if [[ "$FAIL_FAST" == 1 ]]; then
 	STOP_ON_FAILURE="--stop-on-failure"
 	PARALLELISM="--parallelism 1"
@@ -41,8 +49,11 @@ fi
 # To run all tests in a specific file, use:
 # TEST="tests/flow/test_function_calls" FAIL_FAST=1 ./flow.sh
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REDIS_CONF="$SCRIPT_DIR/tests/flow/redis.conf"
+
 if [[ ${#TEST_FILTER[@]} -eq 0 ]]; then
-    RLTest -f "$TESTS_FILE" --module "$TARGET_DIR/$TARGET" --no-progress $PARALLELISM $STOP_ON_FAILURE --clear-logs --log-dir tests/flow/logs $V
+    RLTest -f "$TESTS_FILE" --module "$TARGET_DIR/$TARGET" --no-progress $PARALLELISM $STOP_ON_FAILURE --clear-logs --log-dir tests/flow/logs --enable-debug-command --enable-protected-configs --redis-config-file "$REDIS_CONF" $V
 else
-    RLTest "${TEST_FILTER[@]}" --module "$TARGET_DIR/$TARGET" --no-progress $PARALLELISM $STOP_ON_FAILURE --clear-logs --log-dir tests/flow/logs $V
+    RLTest "${TEST_FILTER[@]}" --module "$TARGET_DIR/$TARGET" --no-progress $PARALLELISM $STOP_ON_FAILURE --clear-logs --log-dir tests/flow/logs --enable-debug-command --enable-protected-configs --redis-config-file "$REDIS_CONF" $V
 fi

--- a/tests/flow/redis.conf
+++ b/tests/flow/redis.conf
@@ -1,0 +1,1 @@
+stop-writes-on-bgsave-error no

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 behave
 falkordb
+falkordb-bulk-loader
 hypothesis
 pytest
 pytest-benchmark


### PR DESCRIPTION
## Summary
Split from #359.

- Add `falkordb-bulk-loader` to Dockerfiles and Python test requirements
- Auto-detect CPU cores for flow test parallelism instead of hardcoding 8
- Enable `--enable-debug-command` and `--enable-protected-configs` in RLTest
- Add `redis.conf` with `stop-writes-on-bgsave-error no` for persistence tests

## Test plan
- [ ] CI passes (no functional code changes)
- [ ] `./flow.sh` runs correctly with auto-detected parallelism