### PR TITLE
feat: make EFFECTS_THRESHOLD runtime-configurable

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -14,13 +14,12 @@
 //! Runtime-settable (via SET):
 //!   TIMEOUT, TIMEOUT_DEFAULT, TIMEOUT_MAX, RESULTSET_SIZE,
 //!   MAX_QUEUED_QUERIES, QUERY_MEM_CAPACITY, DELTA_MAX_PENDING_CHANGES,
-//!   VKEY_MAX_ENTITY_COUNT, JS_HEAP_SIZE, JS_STACK_SIZE
+//!   VKEY_MAX_ENTITY_COUNT, JS_HEAP_SIZE, JS_STACK_SIZE, EFFECTS_THRESHOLD
 //!
 //! Read-only (SET returns an error):
 //!   THREAD_COUNT, OMP_THREAD_COUNT, CACHE_SIZE, ASYNC_DELETE,
 //!   NODE_CREATION_BUFFER, CMD_INFO, MAX_INFO_QUERIES,
-//!   EFFECTS_THRESHOLD, BOLT_PORT, DELAY_INDEXING,
-//!   IMPORT_FOLDER, TEMP_FOLDER
+//!   BOLT_PORT, DELAY_INDEXING, IMPORT_FOLDER, TEMP_FOLDER
 //!
 //! ## Multi-SET semantics
 //! When multiple name-value pairs are provided in a single SET, all pairs are
@@ -99,7 +98,8 @@ fn validate_config_set(
         | "TIMEOUT_DEFAULT"
         | "TIMEOUT_MAX"
         | "QUERY_MEM_CAPACITY"
-        | "DELTA_MAX_PENDING_CHANGES" => {
+        | "DELTA_MAX_PENDING_CHANGES"
+        | "EFFECTS_THRESHOLD" => {
             let v: i64 = value
                 .parse()
                 .map_err(|_| format!("Failed to set config value {name} to {value}"))?;
@@ -149,7 +149,6 @@ fn validate_config_set(
         | "NODE_CREATION_BUFFER"
         | "CMD_INFO"
         | "MAX_INFO_QUERIES"
-        | "EFFECTS_THRESHOLD"
         | "BOLT_PORT"
         | "DELAY_INDEXING"
         | "IMPORT_FOLDER"
@@ -181,6 +180,7 @@ fn apply_config_set(
         "DELTA_MAX_PENDING_CHANGES" => {
             DELTA_MAX_PENDING_CHANGES.store(val.as_i64(), Ordering::Relaxed);
         }
+        "EFFECTS_THRESHOLD" => EFFECTS_THRESHOLD.store(val.as_i64(), Ordering::Relaxed),
         "VKEY_MAX_ENTITY_COUNT" => {
             *CONFIGURATION_VKEY_MAX_ENTITY_COUNT.lock(ctx) = val.as_i64();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,13 +68,13 @@ pub static TIMEOUT_MAX: AtomicI64 = AtomicI64::new(0);
 pub static RESULTSET_SIZE: AtomicI64 = AtomicI64::new(-1);
 pub static QUERY_MEM_CAPACITY: AtomicI64 = AtomicI64::new(0);
 pub static DELTA_MAX_PENDING_CHANGES: AtomicI64 = AtomicI64::new(10000);
+pub static EFFECTS_THRESHOLD: AtomicI64 = AtomicI64::new(300);
 
 // ── Read-only runtime configs ──
 
 pub static OMP_THREAD_COUNT: AtomicI64 = AtomicI64::new(0);
 pub static ASYNC_DELETE: AtomicI64 = AtomicI64::new(0);
 pub static MAX_INFO_QUERIES: AtomicI64 = AtomicI64::new(1000);
-pub static EFFECTS_THRESHOLD: AtomicI64 = AtomicI64::new(300);
 pub static BOLT_PORT: AtomicI64 = AtomicI64::new(65535);
 
 pub fn get_thread_count(ctx: &redis_module::Context) -> i64 {


### PR DESCRIPTION
## Summary
Split from #359.

- Move `EFFECTS_THRESHOLD` from read-only to runtime-settable configuration
- Allow `GRAPH.CONFIG SET EFFECTS_THRESHOLD <value>` at runtime

## Test plan
- [ ] `cargo check` passes
- [ ] `GRAPH.CONFIG SET EFFECTS_THRESHOLD 100` works at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `EFFECTS_THRESHOLD` is now adjustable at runtime via the SET command. Previously, attempting to set this value would result in an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->