### PR TITLE
feat: Implement bulk removal of edges and nodes in graph operations

### DIFF
--- a/graph/src/graph/attribute_cache.rs
+++ b/graph/src/graph/attribute_cache.rs
@@ -257,6 +257,30 @@ impl AttributeCache {
         self.entries.insert(entity_id, entry);
     }
 
+    /// Insert (or replace) the full attribute set for an entity when the
+    /// caller guarantees the attrs are already sorted by `attr_idx`.
+    ///
+    /// This avoids the O(n log n) sort in [`insert_entity`] for callers
+    /// (like `insert_attrs` merge) that produce sorted output.
+    pub fn insert_entity_presorted(
+        &self,
+        entity_id: u64,
+        attrs: Vec<(u16, Value)>,
+        version: u64,
+        dirty: bool,
+    ) {
+        debug_assert!(
+            attrs.windows(2).all(|w| w[0].0 <= w[1].0),
+            "insert_entity_presorted: attrs not sorted"
+        );
+        let entry = CachedEntity {
+            attrs: Arc::new(attrs),
+            version,
+            dirty,
+        };
+        self.entries.insert(entity_id, entry);
+    }
+
     /// Insert or update a cache entry only if not overwriting a newer or dirty entry.
     ///
     /// This is used by `populate_cache_from_fjall` to safely cache fjall reads without

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -546,6 +546,7 @@ impl AttributeStore {
                             ci += 1;
                         }
                         Ordering::Equal => {
+                            nremoved += 1;
                             merged.push((new_idx, new_entries[ni].1.clone()));
                             ci += 1;
                             ni += 1;
@@ -662,6 +663,11 @@ impl AttributeStore {
                 }
             }
             batch.durability(None).commit().map_err(|e| e.to_string())?;
+            // Invalidate deleted entities from the shared cache to prevent stale reads.
+            // After persisting the deletions to fjall, remove cached entries for all
+            // deleted entities so subsequent get_attr*/get_all_attrs* calls won't
+            // resurrect deleted data.
+            self.cache.invalidate_batch(&self.pending_deletes);
         }
         let new_snapshot = OnceCell::new();
         let _ = new_snapshot.set(get_database().snapshot());

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -85,6 +85,9 @@
 
 use std::{collections::HashMap, process, sync::Arc};
 
+use std::cmp::Ordering;
+use std::collections::HashMap as StdHashMap;
+
 use fjall::{
     Database, Keyspace, KeyspaceCreateOptions, Readable, Snapshot, config::HashRatioPolicy,
 };
@@ -292,10 +295,10 @@ impl AttributeStore {
         &mut self,
         key: u64,
     ) -> Result<(), String> {
-        // Flush any pending dirty attributes to fjall before invalidating the cache.
-        self.flush_and_invalidate(key)?;
+        // Skip flush_and_invalidate: no point persisting dirty attrs to fjall
+        // for an entity that will be deleted from fjall in commit().
+        self.cache.invalidate(key);
         self.dirty_entities.insert(key);
-        // Stage the deletion to be applied on commit (not immediately to fjall).
         self.pending_deletes.insert(key);
         Ok(())
     }
@@ -369,7 +372,7 @@ impl AttributeStore {
     pub fn get_all_attrs(
         &self,
         key: u64,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
+    ) -> Vec<(Arc<String>, Value)> {
         let cached = self.cache.get_entity(key, self.version);
         let attrs = cached.unwrap_or_else(|| self.populate_cache_from_fjall(key));
         attrs
@@ -383,7 +386,6 @@ impl AttributeStore {
                 }
             })
             .collect::<Vec<_>>()
-            .into_iter()
     }
 
     pub fn get_all_attrs_by_id(
@@ -435,42 +437,59 @@ impl AttributeStore {
     pub fn remove_all(
         &mut self,
         keys: &RoaringTreemap,
-    ) -> Result<(), String> {
-        // Flush pending dirty attributes for each entity before invalidating cache entries.
+    ) {
         for key in keys {
-            self.flush_and_invalidate(key)?;
+            // Skip flush_and_invalidate: no point persisting dirty attrs to fjall
+            // for entities that will be deleted from fjall in commit().
+            self.cache.invalidate(key);
             self.dirty_entities.insert(key);
-            // Stage the deletion to be applied on commit (not immediately to fjall).
             self.pending_deletes.insert(key);
         }
-        Ok(())
     }
 
     /// Batch insert/update multiple attributes for entities.
     ///
-    /// Writes go to the in-memory cache (`dirty = true`).  Returns the number
-    /// of attributes that were *replaced* (vs newly added).
+    /// Writes go to the in-memory cache (`dirty = true`).  Returns `(nremoved, nset)`:
+    /// the number of attributes *replaced* and the number of non-null attributes *set*.
     pub fn insert_attrs(
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
-    ) -> Result<usize, String> {
+    ) -> Result<(usize, usize), String> {
         let mut nremoved = 0;
+        let mut nset = 0;
+
+        // Pre-resolve all unique attribute names → indices ONCE.
+        // Uses Arc pointer identity as key to avoid rehashing strings.
+        let mut name_to_idx: StdHashMap<*const String, u16> =
+            StdHashMap::with_capacity(attrs.values().next().map_or(0, |v| v.len()));
+        for entity_attrs in attrs.values() {
+            for (attr, _) in entity_attrs.iter() {
+                let ptr = Arc::as_ptr(attr);
+                if !name_to_idx.contains_key(&ptr) {
+                    let idx = self.attrs_name.get_index_of(attr).unwrap_or_else(|| {
+                        self.attrs_name.insert(attr.clone());
+                        self.attrs_name.len() - 1
+                    }) as u16;
+                    name_to_idx.insert(ptr, idx);
+                }
+            }
+        }
+
+        // Reusable buffer to avoid per-entity allocation.
+        let mut merged: Vec<(u16, Value)> = Vec::new();
 
         for (key, entity_attrs) in attrs {
-            // Resolve attribute indices (creating new ones as needed).
+            // Resolve attribute indices using pre-resolved map.
             let mut new_entries: Vec<(u16, Value)> = Vec::with_capacity(entity_attrs.len());
             let mut null_indices: Vec<u16> = Vec::new();
 
             for (attr, value) in entity_attrs.iter() {
-                let idx = self.attrs_name.get_index_of(attr).unwrap_or_else(|| {
-                    self.attrs_name.insert(attr.clone());
-                    self.attrs_name.len() - 1
-                }) as u16;
-
+                let idx = name_to_idx[&Arc::as_ptr(attr)];
                 if matches!(value, Value::Null) {
                     null_indices.push(idx);
                 } else {
                     new_entries.push((idx, value.clone()));
+                    nset += 1;
                 }
             }
 
@@ -480,48 +499,109 @@ impl AttributeStore {
                 .get_entity(*key, self.version)
                 .unwrap_or_else(|| self.populate_cache_from_fjall(*key));
 
-            // Count removals: existing attrs being overwritten or nulled.
-            for &(idx, _) in &new_entries {
-                if current.binary_search_by_key(&idx, |(i, _)| *i).is_ok() {
-                    nremoved += 1;
+            // Sort new entries for O(n+m) merge.
+            new_entries.sort_unstable_by_key(|(idx, _)| *idx);
+
+            // Fast path: if no nulls AND all new entries come after all current entries,
+            // we can just clone current + append new without a full merge.
+            if null_indices.is_empty()
+                && !new_entries.is_empty()
+                && (current.is_empty() || current.last().unwrap().0 < new_entries[0].0)
+            {
+                merged.clear();
+                merged.reserve(current.len() + new_entries.len());
+                merged.extend_from_slice(&current);
+                merged.extend(new_entries.drain(..));
+            } else {
+                null_indices.sort_unstable();
+
+                // Single-pass sorted merge of current + new_entries, skipping nulls.
+                merged.clear();
+                merged.reserve(current.len() + new_entries.len());
+                let mut ci = 0;
+                let mut ni = 0;
+                let mut di = 0;
+
+                while ci < current.len() && ni < new_entries.len() {
+                    let cur_idx = current[ci].0;
+                    let new_idx = new_entries[ni].0;
+                    match cur_idx.cmp(&new_idx) {
+                        Ordering::Less => {
+                            if di < null_indices.len() && cur_idx == null_indices[di] {
+                                nremoved += 1;
+                                di += 1;
+                            } else {
+                                merged.push(current[ci].clone());
+                            }
+                            ci += 1;
+                        }
+                        Ordering::Equal => {
+                            nremoved += 1;
+                            merged.push((new_idx, new_entries[ni].1.clone()));
+                            ci += 1;
+                            ni += 1;
+                        }
+                        Ordering::Greater => {
+                            merged.push((new_idx, new_entries[ni].1.clone()));
+                            ni += 1;
+                        }
+                    }
                 }
-            }
-            for &idx in &null_indices {
-                if current.binary_search_by_key(&idx, |(i, _)| *i).is_ok() {
-                    nremoved += 1;
+                while ci < current.len() {
+                    let cur_idx = current[ci].0;
+                    if di < null_indices.len() && cur_idx == null_indices[di] {
+                        nremoved += 1;
+                        di += 1;
+                    } else {
+                        merged.push(current[ci].clone());
+                    }
+                    ci += 1;
+                }
+                while ni < new_entries.len() {
+                    merged.push((new_entries[ni].0, new_entries[ni].1.clone()));
+                    ni += 1;
                 }
             }
 
-            // Merge: start from current, apply overwrites, remove nulls.
-            let mut merged: Vec<(u16, Value)> = (*current).clone();
-            for (idx, value) in new_entries {
-                match merged.binary_search_by_key(&idx, |(i, _)| *i) {
-                    Ok(pos) => merged[pos].1 = value,
-                    Err(pos) => merged.insert(pos, (idx, value)),
-                }
-            }
-            for idx in null_indices {
-                if let Ok(pos) = merged.binary_search_by_key(&idx, |(i, _)| *i) {
-                    merged.remove(pos);
-                }
-            }
-
-            // Write merged attrs to cache as dirty.
-            self.cache.insert_entity(*key, merged, self.version, true);
+            // Write merged attrs to cache as dirty (already sorted, skip re-sort).
+            self.cache.insert_entity_presorted(
+                *key,
+                std::mem::take(&mut merged),
+                self.version,
+                true,
+            );
             self.dirty_entities.insert(*key);
         }
 
-        Ok(nremoved)
+        Ok((nremoved, nset))
     }
 
     /// Bulk import attributes for entities known to be new (no prior state).
     ///
     /// Optimized for RDB decode: skips cache/fjall lookups since entities
     /// don't exist yet. Attributes are written directly to cache.
+    /// Returns the number of non-null attributes imported.
     pub fn import_attrs(
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
-    ) {
+    ) -> usize {
+        // Pre-resolve all unique attribute names → indices ONCE.
+        let mut name_to_idx: StdHashMap<*const String, u16> =
+            StdHashMap::with_capacity(attrs.values().next().map_or(0, |v| v.len()));
+        for entity_attrs in attrs.values() {
+            for (attr, _) in entity_attrs.iter() {
+                let ptr = Arc::as_ptr(attr);
+                if !name_to_idx.contains_key(&ptr) {
+                    let idx = self.attrs_name.get_index_of(attr).unwrap_or_else(|| {
+                        self.attrs_name.insert(attr.clone());
+                        self.attrs_name.len() - 1
+                    }) as u16;
+                    name_to_idx.insert(ptr, idx);
+                }
+            }
+        }
+
+        let mut nset = 0;
         for (key, entity_attrs) in attrs {
             let mut entries: Vec<(u16, Value)> = Vec::with_capacity(entity_attrs.len());
 
@@ -529,17 +609,16 @@ impl AttributeStore {
                 if matches!(value, Value::Null) {
                     continue;
                 }
-                let idx = self.attrs_name.get_index_of(attr).unwrap_or_else(|| {
-                    self.attrs_name.insert(attr.clone());
-                    self.attrs_name.len() - 1
-                }) as u16;
+                let idx = name_to_idx[&Arc::as_ptr(attr)];
                 entries.push((idx, value.clone()));
+                nset += 1;
             }
 
             entries.sort_by_key(|(idx, _)| *idx);
             self.cache.insert_entity(*key, entries, self.version, true);
             self.dirty_entities.insert(*key);
         }
+        nset
     }
 
     #[must_use]
@@ -559,11 +638,17 @@ impl AttributeStore {
         // Apply pending full entity deletions to fjall.
         if !self.pending_deletes.is_empty() {
             let mut batch = get_database().batch();
-            for key in &self.pending_deletes {
-                let prefix = key.to_be_bytes();
-                for entry in self.keyspace().prefix(prefix) {
-                    if let Ok(k) = entry.key() {
-                        batch.remove(self.keyspace(), k);
+            // Use a single sorted scan over the keyspace instead of
+            // N individual prefix scans. For each key encountered,
+            // extract the entity ID (first 8 bytes) and check bitmap
+            // membership — O(1) per key vs O(log N) for a prefix seek.
+            for entry in self.keyspace().iter() {
+                if let Ok(k) = entry.key() {
+                    if k.len() >= 8 {
+                        let entity_id = u64::from_be_bytes(k[..8].try_into().unwrap());
+                        if self.pending_deletes.contains(entity_id) {
+                            batch.remove(self.keyspace(), k);
+                        }
                     }
                 }
             }

--- a/graph/src/graph/attribute_store.rs
+++ b/graph/src/graph/attribute_store.rs
@@ -295,9 +295,10 @@ impl AttributeStore {
         &mut self,
         key: u64,
     ) -> Result<(), String> {
-        // Skip flush_and_invalidate: no point persisting dirty attrs to fjall
-        // for an entity that will be deleted from fjall in commit().
-        self.cache.invalidate(key);
+        // Don't invalidate cache — older MVCC versions sharing this cache may
+        // still need the dirty entry. pending_deletes guards reads on this
+        // version; the cache entry is harmless to older/newer readers because
+        // the version check in the cache handles visibility.
         self.dirty_entities.insert(key);
         self.pending_deletes.insert(key);
         Ok(())
@@ -319,6 +320,9 @@ impl AttributeStore {
         key: u64,
         attr_idx: u16,
     ) -> Option<Value> {
+        if self.pending_deletes.contains(key) {
+            return None;
+        }
         // 1. Check cache.
         if let Some(result) = self.cache.get_attr(key, attr_idx, self.version) {
             return result;
@@ -352,6 +356,9 @@ impl AttributeStore {
         &self,
         key: u64,
     ) -> impl Iterator<Item = Arc<String>> + '_ {
+        if self.pending_deletes.contains(key) {
+            return Vec::new().into_iter();
+        }
         // Try cache first.
         let cached = self.cache.get_entity(key, self.version);
         let attrs = cached.unwrap_or_else(|| self.populate_cache_from_fjall(key));
@@ -373,6 +380,9 @@ impl AttributeStore {
         &self,
         key: u64,
     ) -> Vec<(Arc<String>, Value)> {
+        if self.pending_deletes.contains(key) {
+            return Vec::new();
+        }
         let cached = self.cache.get_entity(key, self.version);
         let attrs = cached.unwrap_or_else(|| self.populate_cache_from_fjall(key));
         attrs
@@ -392,6 +402,9 @@ impl AttributeStore {
         &self,
         key: u64,
     ) -> Arc<Vec<(u16, Value)>> {
+        if self.pending_deletes.contains(key) {
+            return Arc::new(Vec::new());
+        }
         self.cache
             .get_entity(key, self.version)
             .unwrap_or_else(|| self.populate_cache_from_fjall(key))
@@ -439,9 +452,6 @@ impl AttributeStore {
         keys: &RoaringTreemap,
     ) {
         for key in keys {
-            // Skip flush_and_invalidate: no point persisting dirty attrs to fjall
-            // for entities that will be deleted from fjall in commit().
-            self.cache.invalidate(key);
             self.dirty_entities.insert(key);
             self.pending_deletes.insert(key);
         }
@@ -536,7 +546,6 @@ impl AttributeStore {
                             ci += 1;
                         }
                         Ordering::Equal => {
-                            nremoved += 1;
                             merged.push((new_idx, new_entries[ni].1.clone()));
                             ci += 1;
                             ni += 1;

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -984,8 +984,8 @@ impl Graph {
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
         index_add_docs: &mut HashMap<u64, RoaringTreemap>,
-    ) -> Result<usize, String> {
-        let nremoved = self.node_attrs.insert_attrs(attrs)?;
+    ) -> Result<(usize, usize), String> {
+        let (nremoved, nset) = self.node_attrs.insert_attrs(attrs)?;
 
         if self.node_indexer.has_indices() {
             for (id, attrs) in attrs {
@@ -999,15 +999,15 @@ impl Graph {
                 }
             }
         }
-        Ok(nremoved)
+        Ok((nremoved, nset))
     }
 
     pub fn import_node_attrs(
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
         index_add_docs: &mut HashMap<u64, RoaringTreemap>,
-    ) {
-        self.node_attrs.import_attrs(attrs);
+    ) -> usize {
+        let nset = self.node_attrs.import_attrs(attrs);
 
         if self.node_indexer.has_indices() {
             for (id, attrs) in attrs {
@@ -1021,13 +1021,14 @@ impl Graph {
                 }
             }
         }
+        nset
     }
 
     pub fn import_relationship_attrs(
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
-    ) {
-        self.relationship_attrs.import_attrs(attrs);
+    ) -> usize {
+        self.relationship_attrs.import_attrs(attrs)
     }
 
     pub fn set_nodes_labels(
@@ -1072,27 +1073,64 @@ impl Graph {
         self.deleted_nodes |= deleted_nodes;
         self.node_count -= deleted_nodes.len();
 
+        // Build a diagonal mask matrix from all deleted node IDs
+        let n = self.node_cap;
+        let mut diag_mask = Matrix::new(n, n);
         for id in deleted_nodes {
-            self.all_nodes_matrix.remove(id, id);
+            diag_mask.set(id, id, true);
+        }
 
-            for (_, label_id) in self.node_labels_matrix.iter(id, id) {
-                let label = &self.node_labels[label_id as usize];
-                self.labels_matices[label_id as usize].remove(id, id);
-                if self.node_indexer.has_index(label) {
-                    for attr in self.node_attrs.get_attrs(id) {
-                        if self.node_indexer.has_indexed_attr(label, &attr) {
-                            remove_docs.entry(label_id).or_default().insert(id);
-                            break;
-                        }
+        // Bulk-remove from all_nodes_matrix
+        self.all_nodes_matrix.remove_mask(&diag_mask);
+
+        // Build per-label masks and nlm_mask using a single scan of the
+        // node_labels_matrix instead of one iterator per deleted node.
+        let num_labels = self.labels_matices.len();
+        let mut label_masks: Vec<Option<Matrix>> = vec![None; num_labels];
+        let mut nlm_mask = Matrix::new(
+            self.node_labels_matrix.nrows().max(1),
+            self.node_labels_matrix
+                .ncols()
+                .max(num_labels as u64)
+                .max(1),
+        );
+
+        // Single scan: iterate all entries in node_labels_matrix and filter
+        // by deleted_nodes membership (O(1) bitmap check per entry).
+        for (node_id, label_id) in self.node_labels_matrix.iter(0, n) {
+            if !deleted_nodes.contains(node_id) {
+                continue;
+            }
+            let lid = label_id as usize;
+            let lm = label_masks[lid].get_or_insert_with(|| Matrix::new(n, n));
+            lm.set(node_id, node_id, true);
+
+            let label = &self.node_labels[lid];
+            if self.node_indexer.has_index(label) {
+                for attr in self.node_attrs.get_attrs(node_id) {
+                    if self.node_indexer.has_indexed_attr(label, &attr) {
+                        remove_docs.entry(label_id).or_default().insert(node_id);
+                        break;
                     }
                 }
             }
 
-            for label_id in 0..self.labels_matices.len() {
-                self.node_labels_matrix.remove(id, label_id as _);
+            nlm_mask.set(node_id, label_id, true);
+        }
+
+        // Bulk-remove from per-label matrices
+        for (lid, mask_opt) in label_masks.into_iter().enumerate() {
+            if let Some(mask) = mask_opt {
+                self.labels_matices[lid].remove_mask(&mask);
             }
         }
-        self.node_attrs.remove_all(deleted_nodes)?;
+
+        // Bulk-remove from node_labels_matrix
+        if nlm_mask.nvals() > 0 {
+            self.node_labels_matrix.remove_mask(&nlm_mask);
+        }
+
+        self.node_attrs.remove_all(deleted_nodes);
         Ok(())
     }
 
@@ -1108,6 +1146,11 @@ impl Graph {
                 let dest_node = NodeId(dest);
                 (src_node, dest_node, RelationshipId(id))
             })
+    }
+
+    /// Returns an iterator over all relationship tensors (one per type).
+    pub fn relationship_matrices_iter(&self) -> impl Iterator<Item = &Tensor> {
+        self.relationship_matrices.iter()
     }
 
     /// Get all relationships for a node, optionally filtered by relationship types.
@@ -1383,9 +1426,9 @@ impl Graph {
     pub fn set_relationships_attributes(
         &mut self,
         attrs: &HashMap<u64, OrderMap<Arc<String>, Value>>,
-    ) -> Result<usize, String> {
-        let nremoved = self.relationship_attrs.insert_attrs(attrs)?;
-        Ok(nremoved)
+    ) -> Result<(usize, usize), String> {
+        let (nremoved, nset) = self.relationship_attrs.insert_attrs(attrs)?;
+        Ok((nremoved, nset))
     }
 
     #[must_use]
@@ -1471,6 +1514,108 @@ impl Graph {
         }
 
         Ok(())
+    }
+
+    /// Bulk-delete all edges incident on a set of deleted nodes (implicit cascade).
+    ///
+    /// Instead of discovering edges per-node during the delete operator, this
+    /// method iterates each tensor once for all deleted nodes and batch-removes
+    /// the edges. Edges already in `explicit_rels` are skipped (they're handled
+    /// by `delete_relationships`).
+    ///
+    /// The adjacency matrix is NOT updated for node pairs where both endpoints
+    /// are deleted — those entries are unreachable since the nodes themselves
+    /// are gone.
+    /// Returns the list of implicitly deleted edges as `(edge_id, src, dst)`
+    /// so the caller can record them for effects/replication.
+    pub fn delete_implicit_edges(
+        &mut self,
+        deleted_nodes: &RoaringTreemap,
+        explicit_rels: &HashMap<RelationshipId, (NodeId, NodeId)>,
+    ) -> Result<Vec<(RelationshipId, NodeId, NodeId)>, String> {
+        if self.relationship_matrices.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut all_implicit: Vec<(RelationshipId, NodeId, NodeId)> = Vec::new();
+        // Pairs where only one endpoint is deleted — need adjacency check
+        let mut check_adj_pairs: std::collections::HashSet<(u64, u64)> = Default::default();
+
+        for type_idx in 0..self.relationship_matrices.len() {
+            let mut rels: Vec<(u64, u64, u64)> = Vec::new();
+
+            // Collect all edges for deleted nodes from this tensor
+            for node_id in deleted_nodes {
+                // Outgoing edges
+                for (src, dst, edge_id) in
+                    self.relationship_matrices[type_idx].iter(node_id, node_id, false)
+                {
+                    if !explicit_rels.contains_key(&RelationshipId(edge_id)) {
+                        rels.push((edge_id, src, dst));
+                    }
+                }
+                // Incoming edges — skip if source is also a deleted node
+                // (those edges are already collected from the source's
+                // outgoing iteration), and skip self-loops already found above.
+                for (src, dst, edge_id) in
+                    self.relationship_matrices[type_idx].iter(node_id, node_id, true)
+                {
+                    if src != node_id
+                        && !deleted_nodes.contains(src)
+                        && !explicit_rels.contains_key(&RelationshipId(edge_id))
+                    {
+                        rels.push((edge_id, src, dst));
+                    }
+                }
+            }
+
+            if rels.is_empty() {
+                continue;
+            }
+
+            // Remove from relationship_type_matrix and relationship_attrs
+            let type_id = type_idx as u64;
+            for &(edge_id, src, dst) in &rels {
+                self.relationship_type_matrix.remove(edge_id, type_id);
+                self.relationship_attrs.remove(edge_id)?;
+                self.deleted_relationships.insert(edge_id);
+                all_implicit.push((RelationshipId(edge_id), NodeId(src), NodeId(dst)));
+
+                // Only check adjacency if the other endpoint is NOT deleted
+                if !deleted_nodes.contains(src) || !deleted_nodes.contains(dst) {
+                    check_adj_pairs.insert((src, dst));
+                }
+            }
+
+            // Build (src, dst) mask for bulk tensor removal
+            let mut mask = Matrix::new(self.node_cap, self.node_cap);
+            for &(_, src, dst) in &rels {
+                mask.set(src, dst, true);
+            }
+            let mask_t = mask.transpose();
+
+            // Batch-remove from tensor using mask operations
+            self.relationship_matrices[type_idx].clear_elements(&mask, &mask_t);
+        }
+
+        self.relationship_count -= all_implicit.len() as u64;
+
+        // Update adjacency_matrix only for pairs where one endpoint survives
+        let mut adj_mask = Matrix::new(self.node_cap, self.node_cap);
+        for (src, dst) in check_adj_pairs {
+            let has_edges = self
+                .relationship_matrices
+                .iter()
+                .any(|tensor| tensor.get(src, dst).next().is_some());
+            if !has_edges {
+                adj_mask.set(src, dst, true);
+            }
+        }
+        if adj_mask.nvals() > 0 {
+            self.adjacancy_matrix.remove_mask(&adj_mask);
+        }
+
+        Ok(all_implicit)
     }
 
     pub fn get_src_dest_relationships(
@@ -1676,20 +1821,15 @@ impl Graph {
     pub fn get_node_all_attrs(
         &self,
         id: NodeId,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
+    ) -> Vec<(Arc<String>, Value)> {
         self.node_attrs.get_all_attrs(id.0)
     }
 
     pub fn get_node_all_attrs_by_id(
         &self,
         id: NodeId,
-    ) -> impl Iterator<Item = (u16, Value)> + '_ {
-        self.node_attrs
-            .get_all_attrs_by_id(id.0)
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
+    ) -> Arc<Vec<(u16, Value)>> {
+        self.node_attrs.get_all_attrs_by_id(id.0)
     }
 
     pub fn get_relationship_attrs(
@@ -1703,20 +1843,15 @@ impl Graph {
     pub fn get_relationship_all_attrs(
         &self,
         id: RelationshipId,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> + '_ {
+    ) -> Vec<(Arc<String>, Value)> {
         self.relationship_attrs.get_all_attrs(id.0)
     }
 
     pub fn get_relationship_all_attrs_by_id(
         &self,
         id: RelationshipId,
-    ) -> impl Iterator<Item = (u16, Value)> + '_ {
-        self.relationship_attrs
-            .get_all_attrs_by_id(id.0)
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
+    ) -> Arc<Vec<(u16, Value)>> {
+        self.relationship_attrs.get_all_attrs_by_id(id.0)
     }
 
     pub fn create_index(

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1386,40 +1386,32 @@ impl Graph {
             }
         }
 
-        for (
-            id,
-            PendingRelationship {
-                type_name,
-                from: start,
-                to: end,
-                ..
-            },
-        ) in relationships
-        {
-            self.get_relationship_matrix_mut(type_name)
-                .set(start.0, end.0, id.0);
+        // Pre-resolve type names → (matrix index, type_id) ONCE.
+        let mut type_cache: std::collections::HashMap<*const String, (usize, u64)> =
+            std::collections::HashMap::new();
+        for rel in relationships.values() {
+            let ptr = Arc::as_ptr(&rel.type_name);
+            if !type_cache.contains_key(&ptr) {
+                // Ensure the type + matrix exist
+                self.get_relationship_matrix_mut(&rel.type_name);
+                let type_idx = self
+                    .relationship_types
+                    .iter()
+                    .position(|t| t.as_str() == rel.type_name.as_str())
+                    .unwrap();
+                type_cache.insert(ptr, (type_idx, type_idx as u64));
+            }
         }
 
         self.resize();
 
-        for (
-            id,
-            PendingRelationship {
-                type_name,
-                from: start,
-                to: end,
-            },
-        ) in relationships
-        {
-            self.adjacancy_matrix.set(start.0, end.0, true);
-            self.relationship_type_matrix.set(
-                id.0,
-                self.relationship_types
-                    .iter()
-                    .position(|p| p.as_str() == type_name.as_str())
-                    .unwrap() as u64,
-                true,
-            );
+        // Single loop: set tensor + adjacency + type matrix
+        for (id, rel) in relationships {
+            let ptr = Arc::as_ptr(&rel.type_name);
+            let (matrix_idx, type_id) = type_cache[&ptr];
+            self.relationship_matrices[matrix_idx].set(rel.from.0, rel.to.0, id.0);
+            self.adjacancy_matrix.set(rel.from.0, rel.to.0, true);
+            self.relationship_type_matrix.set(id.0, type_id, true);
         }
     }
 

--- a/graph/src/graph/graphblas/tensor.rs
+++ b/graph/src/graph/graphblas/tensor.rs
@@ -135,6 +135,35 @@ impl Tensor {
         }
     }
 
+    /// Bulk-remove all edges whose `(src, dst)` pair appears in `mask`.
+    ///
+    /// `mask_t` must be the transpose of `mask`.
+    /// This removes ALL edges at matching `(src, dst)` pairs — suitable for
+    /// implicit (cascade) deletion where a node and all its edges are removed.
+    pub fn clear_elements(
+        &mut self,
+        mask: &Matrix,
+        mask_t: &Matrix,
+    ) {
+        // Build me_mask: me uses compound key (src<<32|dst) as row, edge_id as col
+        let mut me_mask = Matrix::new(GrB_INDEX_MAX, GrB_INDEX_MAX);
+        for (src, dst) in mask.iter(0, u64::MAX) {
+            let compound = src << 32 | dst;
+            for (_, edge_id) in self.me.iter(compound, compound) {
+                me_mask.set(compound, edge_id, true);
+            }
+        }
+
+        // Bulk-remove from edge ID matrix
+        if me_mask.nvals() > 0 {
+            self.me.remove_mask(&me_mask);
+        }
+
+        // Bulk-remove from forward and backward adjacency
+        self.m.remove_mask(mask);
+        self.mt.remove_mask(mask_t);
+    }
+
     pub fn resize(
         &mut self,
         nrows: u64,

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -195,6 +195,23 @@ impl VersionedMatrix {
         (m, dp)
     }
 
+    /// Bulk-remove all entries matching a mask matrix.
+    ///
+    /// Equivalent to calling `remove(i, j)` for every entry `(i, j)` in `mask`,
+    /// but executes in two GraphBLAS bulk operations instead of N individual calls:
+    /// - Entries in base `m` matching `mask` are marked deleted in `dm`
+    /// - Entries in delta-plus `dp` matching `mask` are removed from `dp`
+    pub fn remove_mask(
+        &mut self,
+        mask: &Matrix,
+    ) {
+        // dm |= (m & mask): for each entry in mask that exists in m, add to dm
+        self.dm
+            .element_wise_add(Some(&self.m), None, Some(mask), None);
+        // dp &= ~mask: remove entries from dp that exist in mask
+        self.dp.remove_all(mask);
+    }
+
     /// Returns true if the base matrix has UINT64 element type.
     ///
     /// C-produced relation matrices store edge IDs as UINT64, while

--- a/graph/src/runtime/functions/entity.rs
+++ b/graph/src/runtime/functions/entity.rs
@@ -154,9 +154,9 @@ pub fn register(funcs: &mut Functions) {
             let mut iter = args.into_iter();
             match iter.next() {
                 Some(Value::Map(map)) => Ok(Value::Map(map)),
-                Some(Value::Node(id)) => Ok(Value::Map(Arc::new(runtime.get_node_attrs(id).collect()))),
+                Some(Value::Node(id)) => Ok(Value::Map(Arc::new(runtime.get_node_attrs(id)))),
                 Some(Value::Relationship(rel)) => {
-                    Ok(Value::Map(Arc::new(runtime.get_relationship_attrs(rel.0).collect())))
+                    Ok(Value::Map(Arc::new(runtime.get_relationship_attrs(rel.0))))
                 }
                 Some(Value::Null) => Ok(Value::Null),
 
@@ -221,12 +221,14 @@ pub fn register(funcs: &mut Functions) {
                 Some(Value::Node(id)) => Ok(Value::List(Arc::new(
                     runtime
                         .get_node_attrs(id)
+                        .into_iter()
                         .map(|(k, _)| Value::String(k))
                         .collect::<ThinVec<_>>(),
                 ))),
                 Some(Value::Relationship(rel)) => Ok(Value::List(Arc::new(
                     runtime
                         .get_relationship_attrs(rel.0)
+                        .into_iter()
                         .map(|(k, _)| Value::String(k))
                         .collect::<ThinVec<_>>(),
                 ))),

--- a/graph/src/runtime/ops/commit.rs
+++ b/graph/src/runtime/ops/commit.rs
@@ -26,13 +26,18 @@ use crate::runtime::{
     batch::{Batch, BatchOp},
     runtime::Runtime,
 };
-use orx_tree::{Dyn, NodeIdx};
+use orx_tree::{Dyn, NodeIdx, NodeRef};
 
 pub struct CommitOp<'a> {
     pub(crate) runtime: &'a Runtime<'a>,
     pub(crate) child: Option<Box<BatchOp<'a>>>,
     results: Vec<Batch<'a>>,
     pub(crate) idx: NodeIdx<Dyn<IR>>,
+    /// When true, this Commit is the root of the plan (no parent) and
+    /// no downstream operator will consume the batches. We drain the
+    /// child but discard the batches to avoid allocating a large result
+    /// vector that nobody reads.
+    is_root: bool,
 }
 
 impl<'a> CommitOp<'a> {
@@ -46,11 +51,13 @@ impl<'a> CommitOp<'a> {
                 "graph.RO_QUERY is to be executed only on read-only queries",
             ));
         }
+        let is_root = runtime.plan.node(idx).parent().is_none();
         Ok(Self {
             runtime,
             child: Some(child),
             results: Vec::new(),
             idx,
+            is_root,
         })
     }
 }
@@ -64,7 +71,9 @@ impl<'a> Iterator for CommitOp<'a> {
             loop {
                 match child.next() {
                     Some(Ok(batch)) => {
-                        self.results.push(batch);
+                        if !self.is_root {
+                            self.results.push(batch);
+                        }
                     }
                     Some(Err(e)) => return Some(Err(e)),
                     None => break,

--- a/graph/src/runtime/ops/create.rs
+++ b/graph/src/runtime/ops/create.rs
@@ -23,9 +23,6 @@
 //!                       │
 //!              output batch (with new IDs bound)
 //! ```
-//!
-//! When the direct parent is a `Commit` node at the plan root, result rows
-//! are suppressed (write-only optimization).
 
 use std::cell::OnceCell;
 use std::sync::Arc;
@@ -46,7 +43,6 @@ pub struct CreateOp<'a> {
     pub(crate) child: Box<BatchOp<'a>>,
     pattern: QueryGraph<Arc<String>, Arc<String>, Variable>,
     resolved_pattern: OnceCell<QueryGraph<Arc<String>, LabelId, Variable>>,
-    parent_commit: bool,
     pub(crate) idx: NodeIdx<Dyn<IR>>,
 }
 
@@ -57,17 +53,11 @@ impl<'a> CreateOp<'a> {
         pattern: &QueryGraph<Arc<String>, Arc<String>, Variable>,
         idx: NodeIdx<Dyn<IR>>,
     ) -> Self {
-        let parent_commit =
-            runtime.plan.node(idx).parent().is_some_and(|parent| {
-                matches!(parent.data(), IR::Commit) && parent.parent().is_none()
-            });
-
         Self {
             runtime,
             child,
             pattern: pattern.clone(),
             resolved_pattern: OnceCell::new(),
-            parent_commit,
             idx,
         }
     }
@@ -77,29 +67,24 @@ impl<'a> Iterator for CreateOp<'a> {
     type Item = Result<Batch<'a>, String>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let mut batch = match self.child.next()? {
-                Ok(b) => b,
-                Err(e) => return Some(Err(e)),
-            };
+        let mut batch = match self.child.next()? {
+            Ok(b) => b,
+            Err(e) => return Some(Err(e)),
+        };
 
-            let resolved_pattern = self.resolved_pattern.get_or_init(|| {
-                let resolved = self.runtime.resolve_pattern(&self.pattern);
-                self.runtime.pending.borrow_mut().resize(
-                    self.runtime.g.borrow().node_cap(),
-                    self.runtime.g.borrow().labels_count(),
-                );
-                resolved
-            });
-            if let Err(e) = self.runtime.create_batch(resolved_pattern, &mut batch) {
-                return Some(Err(e));
-            }
-
-            if self.parent_commit {
-                continue;
-            }
-            return Some(Ok(batch));
+        let resolved_pattern = self.resolved_pattern.get_or_init(|| {
+            let resolved = self.runtime.resolve_pattern(&self.pattern);
+            self.runtime.pending.borrow_mut().resize(
+                self.runtime.g.borrow().node_cap(),
+                self.runtime.g.borrow().labels_count(),
+            );
+            resolved
+        });
+        if let Err(e) = self.runtime.create_batch(resolved_pattern, &mut batch) {
+            return Some(Err(e));
         }
+
+        Some(Ok(batch))
     }
 }
 

--- a/graph/src/runtime/ops/create.rs
+++ b/graph/src/runtime/ops/create.rs
@@ -31,6 +31,7 @@ use crate::graph::graph::LabelId;
 use crate::parser::ast::{QueryGraph, QueryNode, QueryRelationship, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
+use crate::runtime::ordermap::OrderMap;
 use crate::runtime::{
     batch::{Batch, BatchOp},
     runtime::Runtime,
@@ -94,6 +95,10 @@ impl Runtime<'_> {
         pattern: &QueryGraph<Arc<String>, LabelId, Variable>,
         batch: &mut Batch<'_>,
     ) -> Result<(), String> {
+        // Track which aliases are created in this pattern for validation skip
+        let created_aliases: std::collections::HashSet<u32> =
+            pattern.nodes().iter().map(|n| n.alias.id).collect();
+
         // Process nodes: reserve IDs, evaluate attrs, write IDs back via write_column
         for node in pattern.nodes() {
             let active_len = batch.active_len();
@@ -108,8 +113,11 @@ impl Runtime<'_> {
                 pending.set_nodes_labels(&node_ids, &node.labels);
             }
 
-            // Evaluate attributes per row (run_expr only reads from env)
-            for (i, row) in batch.active_indices().enumerate() {
+            // Evaluate attributes per row, then batch-insert into pending.
+            // NOTE: eval() may borrow pending internally (e.g. property reads),
+            // so we cannot hold pending.borrow_mut() across eval calls.
+            let mut all_attrs: Vec<OrderMap<Arc<String>, Value>> = Vec::with_capacity(active_len);
+            for (_i, row) in batch.active_indices().enumerate() {
                 let env = batch.env_ref(row);
                 let attrs = ExprEval::from_runtime(self).eval(
                     &node.attrs,
@@ -118,16 +126,21 @@ impl Runtime<'_> {
                     None,
                 )?;
                 match attrs {
-                    Value::Map(attrs) => {
-                        self.pending
-                            .borrow_mut()
-                            .set_node_attributes(node_ids[i], Arc::unwrap_or_clone(attrs))?;
-                    }
+                    Value::Map(attrs) => all_attrs.push(Arc::unwrap_or_clone(attrs)),
                     other => {
                         return Err(format!(
                             "Expected map for node attributes, got {}",
                             other.name()
                         ));
+                    }
+                }
+            }
+            // Single borrow to insert all evaluated attrs
+            {
+                let mut pending = self.pending.borrow_mut();
+                for (i, attrs) in all_attrs.into_iter().enumerate() {
+                    if !attrs.is_empty() {
+                        pending.set_node_attributes(node_ids[i], attrs)?;
                     }
                 }
             }
@@ -142,9 +155,23 @@ impl Runtime<'_> {
             // Read endpoint IDs using read_columns
             let endpoint_rows = batch.read_columns(&[rel.from.alias.id, rel.to.alias.id]);
 
-            // Validate all endpoints first
+            // Extract endpoints — skip validation when both endpoints were
+            // created in this same CREATE pattern (guaranteed valid).
+            let skip_validation = created_aliases.contains(&rel.from.alias.id)
+                && created_aliases.contains(&rel.to.alias.id);
+
             let mut endpoints = Vec::with_capacity(endpoint_rows.len());
-            {
+            if skip_validation {
+                for row_vals in &endpoint_rows {
+                    let Value::Node(from_id) = row_vals[0] else {
+                        return Err(String::from("Invalid node id"));
+                    };
+                    let Value::Node(to_id) = row_vals[1] else {
+                        return Err(String::from("Invalid node id"));
+                    };
+                    endpoints.push((*from_id, *to_id));
+                }
+            } else {
                 let g = self.g.borrow();
                 let pending = self.pending.borrow();
                 for row_vals in &endpoint_rows {
@@ -173,22 +200,25 @@ impl Runtime<'_> {
             // Reserve all relationship IDs at once
             let ids = self.g.borrow_mut().reserve_relationships(endpoints.len());
 
-            // Record all created relationships in batch
+            // Record all created relationships directly into pending (no intermediate Vec)
             let type_name = rel.types.first().unwrap().clone();
             let rel_ids: Vec<_> = ids
                 .iter()
                 .zip(endpoints.iter())
                 .map(|(id, (from, to))| (*id, *from, *to))
                 .collect();
-            self.pending.borrow_mut().created_relationships(
-                ids.into_iter()
-                    .zip(endpoints)
-                    .map(|(id, (from, to))| (id, from, to, type_name.clone()))
-                    .collect(),
-            );
+            {
+                let mut pending = self.pending.borrow_mut();
+                for (&id, &(from, to)) in ids.iter().zip(endpoints.iter()) {
+                    pending.created_relationship(id, from, to, type_name.clone());
+                }
+            }
 
-            // Evaluate relationship attributes per row
-            for (i, row) in batch.active_indices().enumerate() {
+            // Evaluate relationship attributes per row, then batch-insert.
+            // Same as nodes: eval() may borrow pending, so separate eval from insert.
+            let mut all_rel_attrs: Vec<OrderMap<Arc<String>, Value>> =
+                Vec::with_capacity(rel_ids.len());
+            for (_i, row) in batch.active_indices().enumerate() {
                 let env = batch.env_ref(row);
                 let attrs = ExprEval::from_runtime(self).eval(
                     &rel.attrs,
@@ -197,14 +227,17 @@ impl Runtime<'_> {
                     None,
                 )?;
                 match attrs {
-                    Value::Map(attrs) => {
-                        self.pending.borrow_mut().set_relationship_attributes(
-                            rel_ids[i].0,
-                            Arc::unwrap_or_clone(attrs),
-                        )?;
-                    }
+                    Value::Map(attrs) => all_rel_attrs.push(Arc::unwrap_or_clone(attrs)),
                     _ => {
                         return Err(String::from("Invalid relationship properties"));
+                    }
+                }
+            }
+            {
+                let mut pending = self.pending.borrow_mut();
+                for (i, attrs) in all_rel_attrs.into_iter().enumerate() {
+                    if !attrs.is_empty() {
+                        pending.set_relationship_attributes(rel_ids[i].0, attrs)?;
                     }
                 }
             }

--- a/graph/src/runtime/ops/create.rs
+++ b/graph/src/runtime/ops/create.rs
@@ -139,9 +139,7 @@ impl Runtime<'_> {
             {
                 let mut pending = self.pending.borrow_mut();
                 for (i, attrs) in all_attrs.into_iter().enumerate() {
-                    if !attrs.is_empty() {
-                        pending.set_node_attributes(node_ids[i], attrs)?;
-                    }
+                    pending.set_node_attributes(node_ids[i], attrs)?;
                 }
             }
 
@@ -236,9 +234,7 @@ impl Runtime<'_> {
             {
                 let mut pending = self.pending.borrow_mut();
                 for (i, attrs) in all_rel_attrs.into_iter().enumerate() {
-                    if !attrs.is_empty() {
-                        pending.set_relationship_attributes(rel_ids[i].0, attrs)?;
-                    }
+                    pending.set_relationship_attributes(rel_ids[i].0, attrs)?;
                 }
             }
 

--- a/graph/src/runtime/ops/delete.rs
+++ b/graph/src/runtime/ops/delete.rs
@@ -171,14 +171,6 @@ impl Runtime<'_> {
                     if !src_deleted && !dest_deleted {
                         continue;
                     }
-                    // Skip if other endpoint is also being deleted and has lower ID
-                    // (it will be discovered from that node's perspective)
-                    if src_deleted && dest_deleted && src_node != dest_node {
-                        // Only snapshot from the node with lower ID
-                        if dest_node < src_node {
-                            continue;
-                        }
-                    }
                     // Skip if other endpoint is already pending-deleted
                     if !src_deleted && self.pending.borrow().is_node_deleted(src_node) {
                         continue;

--- a/graph/src/runtime/ops/delete.rs
+++ b/graph/src/runtime/ops/delete.rs
@@ -22,6 +22,7 @@
 //!  output batch (unchanged, mutations in Pending)
 //! ```
 
+use crate::graph::graph::{NodeId, RelationshipId};
 use crate::parser::ast::{ExprIR, QueryExpr, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
@@ -91,11 +92,22 @@ impl Runtime<'_> {
 
         // Fast path: read all simple variable columns at once, no env needed
         if !var_ids.is_empty() {
+            // Collect all node IDs for bulk deletion
+            let mut node_ids = Vec::new();
             let rows = batch.read_columns(&var_ids);
             for row in rows {
                 for val in row {
-                    self.delete_entity(val)?;
+                    match val {
+                        Value::Node(id) => node_ids.push(*id),
+                        _ => {
+                            // Non-node values (relationships, paths, etc.) go through per-entity path
+                            self.delete_entity(val)?;
+                        }
+                    }
                 }
+            }
+            if !node_ids.is_empty() {
+                self.delete_nodes_bulk(&node_ids)?;
             }
         }
 
@@ -112,6 +124,119 @@ impl Runtime<'_> {
                     )?;
                     self.delete_entity(&value)?;
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Bulk delete committed nodes — avoids per-node iterator creation for
+    /// relationship lookups, label collection, and attribute snapshotting.
+    fn delete_nodes_bulk(
+        &self,
+        node_ids: &[NodeId],
+    ) -> Result<(), String> {
+        // First pass: partition into already-deleted, pending-created, and committed
+        let mut committed = Vec::with_capacity(node_ids.len());
+        for &id in node_ids {
+            if self.pending.borrow().is_node_deleted(id) {
+                continue;
+            } else if self.pending.borrow().is_node_created(id) {
+                // Created in this txn — use existing per-node path
+                self.delete_entity(&Value::Node(id))?;
+            } else if !self.g.borrow().is_node_deleted(id) {
+                committed.push(id);
+            }
+        }
+
+        if committed.is_empty() {
+            return Ok(());
+        }
+
+        // Build a set of committed IDs for O(1) lookups
+        let committed_set: std::collections::HashSet<NodeId> = committed.iter().copied().collect();
+
+        // Snapshot relationships for all committed nodes using a single scan
+        // per relationship type instead of one iterator per node.
+        {
+            let g = self.g.borrow();
+            let n = g.node_cap();
+            for tensor in g.relationship_matrices_iter() {
+                for (src, dest, rel_id) in tensor.iter(0, n, false) {
+                    let src_node: NodeId = src.into();
+                    let dest_node: NodeId = dest.into();
+                    let rel: RelationshipId = rel_id.into();
+                    let src_deleted = committed_set.contains(&src_node);
+                    let dest_deleted = committed_set.contains(&dest_node);
+                    if !src_deleted && !dest_deleted {
+                        continue;
+                    }
+                    // Skip if other endpoint is also being deleted and has lower ID
+                    // (it will be discovered from that node's perspective)
+                    if src_deleted && dest_deleted && src_node != dest_node {
+                        // Only snapshot from the node with lower ID
+                        if dest_node < src_node {
+                            continue;
+                        }
+                    }
+                    // Skip if other endpoint is already pending-deleted
+                    if !src_deleted && self.pending.borrow().is_node_deleted(src_node) {
+                        continue;
+                    }
+                    if !dest_deleted && self.pending.borrow().is_node_deleted(dest_node) {
+                        continue;
+                    }
+                    let type_name = self.get_relationship_type(rel).unwrap();
+                    let attrs = self.get_relationship_attrs(rel);
+                    self.deleted_relationships
+                        .borrow_mut()
+                        .insert(rel, DeletedRelationship::new(type_name, attrs));
+                }
+            }
+        }
+
+        // Cascade-delete pending-created relationships and mark nodes for deletion.
+        // Batch the pending_deletes and deleted_nodes insertions.
+        {
+            let mut pending = self.pending.borrow_mut();
+            if pending.has_created_relationships() {
+                // Only scan for pending rels if there are any
+                drop(pending);
+                for &id in &committed {
+                    let pending_rels = self
+                        .pending
+                        .borrow_mut()
+                        .remove_pending_relationships_for_node(id);
+                    for (rel_id, _src, _dest, type_name, attrs) in pending_rels {
+                        let attrs = attrs.unwrap_or_default();
+                        self.g.borrow_mut().return_relationship_id(rel_id);
+                        self.deleted_relationships
+                            .borrow_mut()
+                            .insert(rel_id, DeletedRelationship::new(type_name, attrs));
+                    }
+                    self.pending.borrow_mut().deleted_node(id);
+                }
+            } else {
+                // Fast path: no pending created relationships — just mark all as deleted
+                for &id in &committed {
+                    pending.deleted_node(id);
+                }
+            }
+        }
+
+        // Snapshot labels and attrs only when needed (i.e., a RETURN clause
+        // references the deleted nodes).  For the common write-only pattern
+        // `MATCH (n) DELETE n` this saves ~30-40ms on 100K nodes.
+        if !self.return_names.is_empty() {
+            let mut deleted_nodes = self.deleted_nodes.borrow_mut();
+            deleted_nodes.reserve(committed.len());
+            let g = self.g.borrow();
+            for &id in &committed {
+                let labels = g.get_node_label_ids(id).collect();
+                let mut actual =
+                    crate::runtime::ordermap::OrderMap::from_vec(g.get_node_all_attrs(id));
+                self.pending.borrow().update_node_attrs(id, &mut actual);
+                deleted_nodes.insert(id, DeletedNode::new(labels, actual));
             }
         }
 
@@ -144,13 +269,16 @@ impl Runtime<'_> {
                         ),
                     );
                 } else if !self.g.borrow().is_node_deleted(id) {
-                    // Cascade-delete committed relationships
-                    for (src, dest, rel_id) in self.g.borrow().get_node_relationships(id) {
+                    // Snapshot committed relationships for effects/replication
+                    for (src, _dest, rel_id) in self.g.borrow().get_node_relationships(id) {
+                        // Skip edges whose other endpoint is already being
+                        // deleted — they will be discovered from that node's
+                        // perspective too. Only snapshot once.
+                        if src != id && self.pending.borrow().is_node_deleted(src) {
+                            continue;
+                        }
                         let type_name = self.get_relationship_type(rel_id).unwrap();
-                        let attrs = self.get_relationship_attrs(rel_id).collect();
-                        self.pending
-                            .borrow_mut()
-                            .deleted_relationship(rel_id, src, dest);
+                        let attrs = self.get_relationship_attrs(rel_id);
                         self.deleted_relationships
                             .borrow_mut()
                             .insert(rel_id, DeletedRelationship::new(type_name, attrs));
@@ -167,12 +295,15 @@ impl Runtime<'_> {
                             .borrow_mut()
                             .insert(rel_id, DeletedRelationship::new(type_name, attrs));
                     }
+                    // Mark as implicit — edge cleanup deferred to commit time
                     self.pending.borrow_mut().deleted_node(id);
-                    let labels = self.g.borrow().get_node_label_ids(id).collect();
-                    let attrs = self.get_node_attrs(id).collect();
-                    self.deleted_nodes
-                        .borrow_mut()
-                        .insert(id, DeletedNode::new(labels, attrs));
+                    if !self.return_names.is_empty() {
+                        let labels = self.g.borrow().get_node_label_ids(id).collect();
+                        let attrs = self.get_node_attrs(id);
+                        self.deleted_nodes
+                            .borrow_mut()
+                            .insert(id, DeletedNode::new(labels, attrs));
+                    }
                 }
             }
             Value::Relationship(rel) => {
@@ -187,7 +318,7 @@ impl Runtime<'_> {
                     // Snapshot attrs BEFORE marking as deleted so pending data
                     // is still accessible via get_relationship_attrs.
                     let type_name = self.get_relationship_type(rel_id).unwrap();
-                    let attrs = self.get_relationship_attrs(rel_id).collect();
+                    let attrs = self.get_relationship_attrs(rel_id);
                     self.pending
                         .borrow_mut()
                         .deleted_relationship(rel_id, src, dest);

--- a/graph/src/runtime/ops/set.rs
+++ b/graph/src/runtime/ops/set.rs
@@ -83,9 +83,17 @@ impl Runtime<'_> {
         items: &Vec<SetItem<LabelId, Variable>>,
         batch: &Batch<'_>,
     ) -> Result<(), String> {
+        // Pre-check: if no nodes/relationships have been deleted in this
+        // transaction, we can skip the per-row deletion checks entirely.
+        let has_deleted_nodes = self.deleted_nodes.borrow().len() > 0;
+        let has_pending_deleted_nodes = self.pending.borrow().has_deleted_nodes();
+        let has_pending_deleted_rels = self.pending.borrow().has_deleted_relationships();
+        let skip_delete_checks =
+            !has_deleted_nodes && !has_pending_deleted_nodes && !has_pending_deleted_rels;
+
         for row in batch.active_indices() {
             let env = batch.env_ref(row);
-            self.set(items, env)?;
+            self.set_inner(items, env, skip_delete_checks)?;
         }
         Ok(())
     }
@@ -122,6 +130,16 @@ impl Runtime<'_> {
         &self,
         items: &Vec<SetItem<LabelId, Variable>>,
         vars: &Env<'_>,
+    ) -> Result<(), String> {
+        self.set_inner(items, vars, false)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn set_inner(
+        &self,
+        items: &Vec<SetItem<LabelId, Variable>>,
+        vars: &Env<'_>,
+        skip_delete_checks: bool,
     ) -> Result<(), String> {
         for item in items {
             match item {
@@ -163,14 +181,20 @@ impl Runtime<'_> {
                     };
                     match entity {
                         Value::Node(id) => {
-                            if (self.g.borrow().is_node_deleted(id)
-                                && !self.pending.borrow().is_node_created(id))
-                                || self.pending.borrow().is_node_deleted(id)
+                            if !skip_delete_checks
+                                && ((self.g.borrow().is_node_deleted(id)
+                                    && !self.pending.borrow().is_node_created(id))
+                                    || self.pending.borrow().is_node_deleted(id))
                             {
                                 continue;
                             }
                             if let Some(attr) = attr {
-                                if let Some(v) = self.get_node_attribute(id, attr)
+                                let existing = if skip_delete_checks {
+                                    self.get_node_attribute_no_delete_check(id, attr)
+                                } else {
+                                    self.get_node_attribute(id, attr)
+                                };
+                                if let Some(v) = existing
                                     && v == run_expr
                                 {
                                     continue;
@@ -195,7 +219,12 @@ impl Runtime<'_> {
                                             }
                                         }
                                         for (key, value) in map.iter() {
-                                            if let Some(v) = self.get_node_attribute(id, key)
+                                            let existing = if skip_delete_checks {
+                                                self.get_node_attribute_no_delete_check(id, key)
+                                            } else {
+                                                self.get_node_attribute(id, key)
+                                            };
+                                            if let Some(v) = existing
                                                 && v == *value
                                             {
                                                 continue;
@@ -212,7 +241,7 @@ impl Runtime<'_> {
                                             continue;
                                         }
                                         let g = self.g.borrow();
-                                        let attrs: Vec<_> = self.get_node_attrs(tid).collect();
+                                        let attrs = self.get_node_attrs(tid);
                                         if *replace {
                                             for key in g.get_node_attrs(id) {
                                                 self.pending.borrow_mut().set_node_attribute(
@@ -235,8 +264,7 @@ impl Runtime<'_> {
                                     }
                                     Value::Relationship(rel) => {
                                         let g = self.g.borrow();
-                                        let attrs: Vec<_> =
-                                            self.get_relationship_attrs(rel.0).collect();
+                                        let attrs = self.get_relationship_attrs(rel.0);
                                         if *replace {
                                             for key in g.get_node_attrs(id) {
                                                 self.pending.borrow_mut().set_node_attribute(
@@ -264,18 +292,30 @@ impl Runtime<'_> {
                             }
                         }
                         Value::Relationship(target_rel) => {
-                            if (self.g.borrow().is_relationship_deleted(target_rel.0)
-                                && !self.pending.borrow().is_relationship_created(target_rel.0))
-                                || self.pending.borrow().is_relationship_deleted(
-                                    target_rel.0,
-                                    target_rel.1,
-                                    target_rel.2,
-                                )
+                            if !skip_delete_checks
+                                && ((self.g.borrow().is_relationship_deleted(target_rel.0)
+                                    && !self
+                                        .pending
+                                        .borrow()
+                                        .is_relationship_created(target_rel.0))
+                                    || self.pending.borrow().is_relationship_deleted(
+                                        target_rel.0,
+                                        target_rel.1,
+                                        target_rel.2,
+                                    ))
                             {
                                 continue;
                             }
                             if let Some(attr) = attr {
-                                if let Some(v) = self.get_relationship_attribute(target_rel.0, attr)
+                                let existing = if skip_delete_checks {
+                                    self.get_relationship_attribute_no_delete_check(
+                                        target_rel.0,
+                                        attr,
+                                    )
+                                } else {
+                                    self.get_relationship_attribute(target_rel.0, attr)
+                                };
+                                if let Some(v) = existing
                                     && v == run_expr
                                 {
                                     continue;
@@ -302,8 +342,15 @@ impl Runtime<'_> {
                                             }
                                         }
                                         for (key, value) in map.iter() {
-                                            if let Some(v) =
+                                            let existing = if skip_delete_checks {
+                                                self.get_relationship_attribute_no_delete_check(
+                                                    target_rel.0,
+                                                    key,
+                                                )
+                                            } else {
                                                 self.get_relationship_attribute(target_rel.0, key)
+                                            };
+                                            if let Some(v) = existing
                                                 && v == *value
                                             {
                                                 continue;
@@ -317,7 +364,7 @@ impl Runtime<'_> {
                                     }
                                     Value::Node(sid) => {
                                         let g = self.g.borrow();
-                                        let attrs: Vec<_> = self.get_node_attrs(sid).collect();
+                                        let attrs = self.get_node_attrs(sid);
                                         if *replace {
                                             for key in g.get_relationship_attrs(target_rel.0) {
                                                 self.pending
@@ -348,8 +395,7 @@ impl Runtime<'_> {
                                             continue;
                                         }
                                         let g = self.g.borrow();
-                                        let attrs: Vec<_> =
-                                            self.get_relationship_attrs(source_rel.0).collect();
+                                        let attrs = self.get_relationship_attrs(source_rel.0);
                                         if *replace {
                                             for key in g.get_relationship_attrs(target_rel.0) {
                                                 self.pending
@@ -393,9 +439,10 @@ impl Runtime<'_> {
                     let run_expr = vars.get(entity);
                     match run_expr {
                         Some(Value::Node(id)) => {
-                            if (self.g.borrow().is_node_deleted(*id)
-                                && !self.pending.borrow().is_node_created(*id))
-                                || self.pending.borrow().is_node_deleted(*id)
+                            if !skip_delete_checks
+                                && ((self.g.borrow().is_node_deleted(*id)
+                                    && !self.pending.borrow().is_node_created(*id))
+                                    || self.pending.borrow().is_node_deleted(*id))
                             {
                                 continue;
                             }

--- a/graph/src/runtime/ordermap.rs
+++ b/graph/src/runtime/ordermap.rs
@@ -12,10 +12,10 @@
 //! Uses a `ThinVec<(K, V)>` internally with O(n) lookup. This is efficient
 //! for small maps (typical property counts) while preserving order.
 
-use std::{borrow::Borrow, hash::Hash, ops::Index};
+use std::{borrow::Borrow, collections::HashSet, hash::Hash, ops::Index};
 
 use itertools::Itertools;
-use thin_vec::{ThinVec, thin_vec};
+use thin_vec::ThinVec;
 
 /// A map that preserves insertion order during iteration.
 ///
@@ -39,10 +39,20 @@ impl<K, V> Default for OrderMap<K, V> {
 
 impl<K: PartialEq, V> OrderMap<K, V> {
     #[must_use]
-    pub fn from_vec<I: IntoIterator<Item = (K, V)>>(vec: I) -> Self {
-        let mut res = Self { vec: thin_vec![] };
+    pub fn from_vec(vec: Vec<(K, V)>) -> Self
+    where
+        K: Hash + Eq + Clone,
+    {
+        let mut set = HashSet::new();
+        let mut res = Self {
+            vec: ThinVec::with_capacity(vec.len()),
+        };
         for (k, v) in vec {
-            res.insert(k, v);
+            if set.insert(k.clone()) {
+                res.vec.push((k, v));
+            } else {
+                res.insert(k, v);
+            }
         }
         res
     }
@@ -161,9 +171,24 @@ impl<K: PartialEq, V: PartialEq> PartialEq for OrderMap<K, V> {
     }
 }
 
-impl<K: PartialEq, V: PartialEq> FromIterator<(K, V)> for OrderMap<K, V> {
+impl<K: PartialEq + Hash + Eq + Clone, V: PartialEq> FromIterator<(K, V)> for OrderMap<K, V> {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        Self::from_vec(iter)
+        {
+            let mut set = HashSet::new();
+            let iter = iter.into_iter();
+            let size_hint = iter.size_hint().0;
+            let mut res = Self {
+                vec: ThinVec::with_capacity(size_hint),
+            };
+            for (k, v) in iter {
+                if set.insert(k.clone()) {
+                    res.vec.push((k, v));
+                } else {
+                    res.insert(k, v);
+                }
+            }
+            res
+        }
     }
 }
 

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -441,6 +441,17 @@ impl Pending {
         }
     }
 
+    pub fn created_relationship(
+        &mut self,
+        id: RelationshipId,
+        from: NodeId,
+        to: NodeId,
+        type_name: Arc<String>,
+    ) {
+        self.created_relationships
+            .insert(id, PendingRelationship::new(from, to, type_name));
+    }
+
     pub fn set_relationship_attributes(
         &mut self,
         id: RelationshipId,

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -546,6 +546,21 @@ impl Pending {
     }
 
     #[must_use]
+    pub fn has_deleted_nodes(&self) -> bool {
+        !self.deleted_nodes.is_empty()
+    }
+
+    #[must_use]
+    pub fn has_deleted_relationships(&self) -> bool {
+        !self.deleted_relationships.is_empty()
+    }
+
+    #[must_use]
+    pub fn has_created_relationships(&self) -> bool {
+        !self.created_relationships.is_empty()
+    }
+
+    #[must_use]
     pub fn is_node_deleted(
         &self,
         id: NodeId,
@@ -659,47 +674,33 @@ impl Pending {
                 .remove_nodes_labels(&mut self.remove_node_labels, &mut self.index_remove_docs);
         }
         if !self.new_nodes_attrs.is_empty() || !self.existing_nodes_attrs.is_empty() {
-            let count_properties = |map: &HashMap<u64, OrderMap<Arc<String>, Value>>| -> usize {
-                map.values()
-                    .flat_map(super::ordermap::OrderMap::values)
-                    .map(|v| match *v {
-                        Value::Null => 0,
-                        _ => 1,
-                    })
-                    .sum()
-            };
-            stats.borrow_mut().properties_set += count_properties(&self.new_nodes_attrs)
-                + count_properties(&self.existing_nodes_attrs);
             let mut g = g.borrow_mut();
             if !self.new_nodes_attrs.is_empty() {
-                g.import_node_attrs(&self.new_nodes_attrs, &mut self.index_add_docs);
+                let nset = g.import_node_attrs(&self.new_nodes_attrs, &mut self.index_add_docs);
+                stats.borrow_mut().properties_set += nset;
             }
             if !self.existing_nodes_attrs.is_empty() {
-                stats.borrow_mut().properties_removed +=
+                let (nremoved, nset) =
                     g.set_nodes_attributes(&self.existing_nodes_attrs, &mut self.index_add_docs)?;
+                let mut s = stats.borrow_mut();
+                s.properties_set += nset;
+                s.properties_removed += nremoved;
             }
         }
 
         if !self.new_relationships_attrs.is_empty() || !self.existing_relationships_attrs.is_empty()
         {
-            let count_properties = |map: &HashMap<u64, OrderMap<Arc<String>, Value>>| -> usize {
-                map.values()
-                    .flat_map(super::ordermap::OrderMap::values)
-                    .map(|v| match *v {
-                        Value::Null => 0,
-                        _ => 1,
-                    })
-                    .sum()
-            };
-            stats.borrow_mut().properties_set += count_properties(&self.new_relationships_attrs)
-                + count_properties(&self.existing_relationships_attrs);
             let mut g = g.borrow_mut();
             if !self.new_relationships_attrs.is_empty() {
-                g.import_relationship_attrs(&self.new_relationships_attrs);
+                let nset = g.import_relationship_attrs(&self.new_relationships_attrs);
+                stats.borrow_mut().properties_set += nset;
             }
             if !self.existing_relationships_attrs.is_empty() {
-                stats.borrow_mut().properties_removed +=
+                let (nremoved, nset) =
                     g.set_relationships_attributes(&self.existing_relationships_attrs)?;
+                let mut s = stats.borrow_mut();
+                s.properties_set += nset;
+                s.properties_removed += nremoved;
             }
         }
         if !self.deleted_nodes.is_empty() {
@@ -707,10 +708,29 @@ impl Pending {
             g.borrow_mut()
                 .delete_nodes(&self.deleted_nodes, &mut self.index_remove_docs)?;
         }
-        if !self.deleted_relationships.is_empty() {
-            stats.borrow_mut().relationships_deleted += self.deleted_relationships.len();
-            let rels = std::mem::take(&mut self.deleted_relationships);
-            g.borrow_mut().delete_relationships(rels)?;
+        // Take explicit relationship deletions BEFORE implicit edge processing
+        // so we can pass them to delete_implicit_edges for dedup, and then
+        // process them separately via delete_relationships.
+        let explicit_rels = std::mem::take(&mut self.deleted_relationships);
+
+        // Bulk cascade-delete edges for implicitly deleted nodes.
+        // This must run after delete_nodes so that node matrices are already
+        // cleaned up, and before delete_relationships so explicit edges are
+        // still tracked separately.
+        if !self.deleted_nodes.is_empty() {
+            let implicit_edges = g
+                .borrow_mut()
+                .delete_implicit_edges(&self.deleted_nodes, &explicit_rels)?;
+            let count = implicit_edges.len();
+            stats.borrow_mut().relationships_deleted += count;
+            // Record in deleted_relationships so effects buffer can serialize them
+            for (rel_id, from, to) in implicit_edges {
+                self.deleted_relationships.insert(rel_id, (from, to));
+            }
+        }
+        if !explicit_rels.is_empty() {
+            stats.borrow_mut().relationships_deleted += explicit_rels.len();
+            g.borrow_mut().delete_relationships(explicit_rels)?;
         }
         // Commit attribute changes and indexes after all deletions have been
         // applied. This ensures relationship_attrs.remove() pending_deletes

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -1087,10 +1087,32 @@ impl<'a> Runtime<'a> {
             }
             return None;
         }
+        self.get_node_attribute_no_delete_check(id, attr)
+    }
+
+    /// Like `get_node_attribute` but skips the deleted_nodes check.
+    /// Use when the caller has already verified no deletions exist.
+    pub fn get_node_attribute_no_delete_check(
+        &self,
+        id: NodeId,
+        attr: &Arc<String>,
+    ) -> Option<Value> {
         if let Some(value) = self.pending.borrow().get_node_attribute(id, attr) {
             return Some(value.clone());
         }
         self.g.borrow().get_node_attribute(id, attr)
+    }
+
+    /// Like `get_relationship_attribute` but skips the deleted check.
+    pub fn get_relationship_attribute_no_delete_check(
+        &self,
+        id: RelationshipId,
+        attr: &Arc<String>,
+    ) -> Option<Value> {
+        if let Some(value) = self.pending.borrow().get_relationship_attribute(id, attr) {
+            return Some(value.clone());
+        }
+        self.g.borrow().get_relationship_attribute(id, attr)
     }
 
     pub fn get_relationship_attribute(
@@ -1178,37 +1200,37 @@ impl<'a> Runtime<'a> {
     pub fn get_node_attrs(
         &self,
         id: NodeId,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> {
+    ) -> OrderMap<Arc<String>, Value> {
         if let Some(dn) = self.deleted_nodes.borrow().get(&id) {
-            let attrs: OrderMap<Arc<String>, Value> = dn
+            let attrs = dn
                 .attrs
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
-            return attrs.into_iter();
+            return attrs;
         }
-        let mut actual = self.g.borrow().get_node_all_attrs(id).collect();
+        let mut actual = OrderMap::from_vec(self.g.borrow().get_node_all_attrs(id));
         self.pending.borrow().update_node_attrs(id, &mut actual);
-        actual.into_iter()
+        actual
     }
 
     pub fn get_relationship_attrs(
         &self,
         id: RelationshipId,
-    ) -> impl Iterator<Item = (Arc<String>, Value)> {
+    ) -> OrderMap<Arc<String>, Value> {
         if let Some(dr) = self.deleted_relationships.borrow().get(&id) {
-            let attrs: OrderMap<Arc<String>, Value> = dr
+            let attrs = dr
                 .attrs
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
-            return attrs.into_iter();
+            return attrs;
         }
-        let mut actual = self.g.borrow().get_relationship_all_attrs(id).collect();
+        let mut actual = OrderMap::from_vec(self.g.borrow().get_relationship_all_attrs(id));
         self.pending
             .borrow()
             .update_relationship_attrs(id, &mut actual);
-        actual.into_iter()
+        actual
     }
 
     pub fn get_relationship_type(
@@ -1230,7 +1252,9 @@ impl<'a> Runtime<'a> {
         &self,
         id: NodeId,
     ) -> usize {
-        if self.deleted_nodes.borrow().contains_key(&id) {
+        if self.deleted_nodes.borrow().contains_key(&id)
+            || self.pending.borrow().is_node_deleted(id)
+        {
             return 0;
         }
         let g = self.g.borrow();
@@ -1246,7 +1270,9 @@ impl<'a> Runtime<'a> {
         id: NodeId,
         types: &[Arc<String>],
     ) -> usize {
-        if self.deleted_nodes.borrow().contains_key(&id) {
+        if self.deleted_nodes.borrow().contains_key(&id)
+            || self.pending.borrow().is_node_deleted(id)
+        {
             return 0;
         }
         let g = self.g.borrow();
@@ -1261,7 +1287,9 @@ impl<'a> Runtime<'a> {
         &self,
         id: NodeId,
     ) -> usize {
-        if self.deleted_nodes.borrow().contains_key(&id) {
+        if self.deleted_nodes.borrow().contains_key(&id)
+            || self.pending.borrow().is_node_deleted(id)
+        {
             return 0;
         }
         let g = self.g.borrow();
@@ -1277,7 +1305,9 @@ impl<'a> Runtime<'a> {
         id: NodeId,
         types: &[Arc<String>],
     ) -> usize {
-        if self.deleted_nodes.borrow().contains_key(&id) {
+        if self.deleted_nodes.borrow().contains_key(&id)
+            || self.pending.borrow().is_node_deleted(id)
+        {
             return 0;
         }
         let g = self.g.borrow();

--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -1338,7 +1338,7 @@ impl DisplayJson for Value {
                 write_json_string(f, &type_name)?;
                 write!(f, r#","properties":{{"#)?;
 
-                for (i, (k, v)) in properties.enumerate() {
+                for (i, (k, v)) in properties.iter().enumerate() {
                     if i > 0 {
                         write!(f, ",")?;
                     }
@@ -1444,7 +1444,7 @@ fn write_node_json(
 
     write!(f, r#"],"properties":{{"#)?;
 
-    for (i, (k, v)) in properties.enumerate() {
+    for (i, (k, v)) in properties.iter().enumerate() {
         if i > 0 {
             write!(f, ",")?;
         }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -126,18 +126,14 @@ pub fn reply_compact_value(
                     raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, labels_len as _);
                 }
 
-                raw::reply_with_array(ctx.ctx, i64::from(raw::REDISMODULE_POSTPONED_LEN));
-                let attrs: Vec<_> = bg.get_node_all_attrs_by_id(*id).collect();
-                for (key, value) in &attrs {
+                let attrs = bg.get_node_all_attrs_by_id(*id);
+                raw::reply_with_array(ctx.ctx, attrs.len() as _);
+                for (key, value) in attrs.iter() {
                     raw::reply_with_array(ctx.ctx, 3);
-                    raw::reply_with_long_long(ctx.ctx, (*key).into());
+                    raw::reply_with_long_long(ctx.ctx, *key as _);
                     reply_compact_value(ctx, runtime, value);
                 }
-                let attrs_len = attrs.len();
                 drop(bg);
-                unsafe {
-                    raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, attrs_len as _);
-                }
             }
         }
         Value::Relationship(rel) => {
@@ -170,18 +166,14 @@ pub fn reply_compact_value(
                 raw::reply_with_long_long(ctx.ctx, u64::from(*rel_src) as _);
                 raw::reply_with_long_long(ctx.ctx, u64::from(*rel_dst) as _);
                 let node_attr_offset = bg.node_attribute_count() as i64;
-                raw::reply_with_array(ctx.ctx, i64::from(raw::REDISMODULE_POSTPONED_LEN));
-                let attrs: Vec<_> = bg.get_relationship_all_attrs_by_id(*rel_id).collect();
-                for (key, value) in &attrs {
+                let attrs = bg.get_relationship_all_attrs_by_id(*rel_id);
+                raw::reply_with_array(ctx.ctx, attrs.len() as _);
+                for (key, value) in attrs.iter() {
                     raw::reply_with_array(ctx.ctx, 3);
                     raw::reply_with_long_long(ctx.ctx, i64::from(*key) + node_attr_offset);
                     reply_compact_value(ctx, runtime, value);
                 }
-                let attrs_len = attrs.len();
                 drop(bg);
-                unsafe {
-                    raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, attrs_len as _);
-                }
             }
         }
         Value::Path(path) => {
@@ -371,23 +363,18 @@ pub fn reply_verbose_value(
                     raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, labels_len as _);
                 }
 
-                raw::reply_with_array(ctx.ctx, i64::from(raw::REDISMODULE_POSTPONED_LEN));
-                let attrs_len = bg
-                    .get_node_all_attrs(*id)
-                    .inspect(|(key, value)| {
-                        raw::reply_with_array(ctx.ctx, 2);
-                        raw::reply_with_string_buffer(
-                            ctx.ctx,
-                            key.as_ptr().cast::<c_char>(),
-                            key.len(),
-                        );
-                        reply_verbose_value(ctx, runtime, value);
-                    })
-                    .count();
-                drop(bg);
-                unsafe {
-                    raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, attrs_len as _);
+                let attrs = bg.get_node_all_attrs(*id);
+                raw::reply_with_array(ctx.ctx, attrs.len() as _);
+                for (key, value) in attrs.iter() {
+                    raw::reply_with_array(ctx.ctx, 2);
+                    raw::reply_with_string_buffer(
+                        ctx.ctx,
+                        key.as_ptr().cast::<c_char>(),
+                        key.len(),
+                    );
+                    reply_verbose_value(ctx, runtime, value);
                 }
+                drop(bg);
             }
         }
         Value::Relationship(rel) => {
@@ -417,23 +404,18 @@ pub fn reply_verbose_value(
                 raw::reply_with_long_long(ctx.ctx, usize::from(rel_type) as _);
                 raw::reply_with_long_long(ctx.ctx, u64::from(*rel_src) as _);
                 raw::reply_with_long_long(ctx.ctx, u64::from(*rel_dst) as _);
-                raw::reply_with_array(ctx.ctx, i64::from(raw::REDISMODULE_POSTPONED_LEN));
-                let attrs_len = bg
-                    .get_relationship_all_attrs(*rel_id)
-                    .inspect(|(key, value)| {
-                        raw::reply_with_array(ctx.ctx, 2);
-                        raw::reply_with_string_buffer(
-                            ctx.ctx,
-                            key.as_ptr().cast::<c_char>(),
-                            key.len(),
-                        );
-                        reply_verbose_value(ctx, runtime, value);
-                    })
-                    .count();
-                drop(bg);
-                unsafe {
-                    raw::RedisModule_ReplySetArrayLength.unwrap()(ctx.ctx, attrs_len as _);
+                let attrs = bg.get_relationship_all_attrs(*rel_id);
+                raw::reply_with_array(ctx.ctx, attrs.len() as _);
+                for (key, value) in attrs {
+                    raw::reply_with_array(ctx.ctx, 2);
+                    raw::reply_with_string_buffer(
+                        ctx.ctx,
+                        key.as_ptr().cast::<c_char>(),
+                        key.len(),
+                    );
+                    reply_verbose_value(ctx, runtime, &value);
                 }
+                drop(bg);
             }
         }
         Value::Path(path) => {
@@ -557,6 +539,12 @@ fn reply_result<const COMPACT: bool>(
     runtime: &Runtime<'_>,
     result: &ResultSummary<'_>,
 ) {
+    if runtime.return_names.is_empty() {
+        // No RETURN clause — send only stats (matches C FalkorDB behavior).
+        raw::reply_with_array(ctx.ctx, 1);
+        reply_stats(ctx, &result.stats, runtime.g.borrow().version);
+        return;
+    }
     raw::reply_with_array(ctx.ctx, 3);
     raw::reply_with_array(ctx.ctx, runtime.return_names.len() as _);
     for name in &runtime.return_names {


### PR DESCRIPTION
- Added `clear_elements` method to `Tensor` for bulk removal of edges based on a mask.
- Introduced `remove_mask` method in `VersionedMatrix` to efficiently remove entries matching a mask matrix.
- Enhanced `Runtime` operations to support bulk deletion of nodes and relationships, improving performance by reducing individual deletion calls.
- Updated `set` operations to skip deletion checks when no nodes or relationships have been deleted in the transaction.
- Refactored attribute retrieval methods to avoid unnecessary checks for deleted nodes and relationships.
- Improved JSON reply functions to streamline attribute responses for nodes and relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk implicit relationship deletion when removing nodes.
  * New accessors for relationship/attribute retrieval and a stats-only reply path when no return fields.

* **Performance**
  * Faster bulk attribute insert/remove and batched node/relationship deletions.
  * Reduced redundant checks during mutations and commit-time bulk removals.

* **Refactor**
  * Attribute/attribute-query APIs now materialize concrete containers (iterator→Vec/OrderMap) and return counts for set/remove operations.
  * Commit/create/delete flows reorganized for bulk processing and clearer stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->