### PR TITLE
feat: persist edge indexes across RDB save/restore

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -2202,6 +2202,41 @@ impl Graph {
                 self.node_indexer.enable(&label);
             }
         }
+
+        // Edge indexes: symmetric to the node path, but walk the
+        // relationship tensor and emit `Document::new_edge(src, dst, eid)`
+        // so RediSearch keys stay the 24-byte `[src, dst, edge_id]`
+        // triple that `Index_RemoveEdge` expects on delete. Stream
+        // the tensor iterator directly so we don't materialize every
+        // `(src, dst, eid)` triple for large relationship types on
+        // RDB load.
+        let edge_fields_by_type = self.edge_indexer.get_all_pending_fields();
+        for (type_name, attrs) in edge_fields_by_type {
+            if let Some(tensor) = self.get_relationship_matrix(&type_name) {
+                let mut batch = Vec::new();
+                for (src, dst, eid) in tensor.iter(0, u64::MAX, false) {
+                    let mut doc = Document::new_edge(src, dst, eid);
+                    let mut has_fields = false;
+                    for (attr, fields) in &attrs {
+                        if let Some(value) = self.relationship_attrs.get_attr(eid, attr) {
+                            for field in fields {
+                                doc.set(field, &value);
+                            }
+                            has_fields = true;
+                        }
+                    }
+                    if has_fields {
+                        batch.push(doc);
+                    }
+                }
+                if !batch.is_empty() {
+                    let mut add_docs = HashMap::new();
+                    add_docs.insert(type_name.clone(), batch);
+                    self.edge_indexer.commit(&mut add_docs, &mut HashMap::new());
+                }
+                self.edge_indexer.enable(&type_name);
+            }
+        }
     }
 
     pub fn commit_attrs(&mut self) -> Result<(), String> {

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -275,93 +275,125 @@ impl Encode<19> for Schema {
             w.write_unsigned(i as u64);
             w.write_buffer(&null_terminated(label));
 
-            let label_indices: Vec<_> = self
+            // Only include NODE indexes here — edge indexes are
+            // encoded under the relationship-schema block below.
+            // Without the entity_type filter, an edge index on a
+            // type whose name collides with a node label would be
+            // written as if it belonged to the node schema.
+            let label_indices: Vec<&IndexInfo> = self
                 .indexes
                 .iter()
-                .filter(|info| info.label.as_str() == label.as_str())
+                .filter(|info| {
+                    info.label.as_str() == label.as_str() && info.entity_type != "RELATIONSHIP"
+                })
                 .collect();
-
-            let has_index = !label_indices.is_empty();
-            w.write_unsigned(u64::from(has_index));
-
-            if has_index {
-                let language = label_indices
-                    .first()
-                    .and_then(|info| info.language.as_ref())
-                    .map_or("english", |l| l.as_str());
-                w.write_buffer(&null_terminated(language));
-
-                let stopwords: Vec<_> = label_indices
-                    .first()
-                    .and_then(|info| info.stopwords.as_ref())
-                    .map(|sw| sw.iter().map(|s| s.as_str()).collect())
-                    .unwrap_or_default();
-                w.write_unsigned(stopwords.len() as u64);
-                for sw in &stopwords {
-                    w.write_buffer(&null_terminated(sw));
-                }
-
-                let all_fields: Vec<_> = label_indices
-                    .iter()
-                    .flat_map(|info| info.fields.values().flatten())
-                    .collect();
-                w.write_unsigned(all_fields.len() as u64);
-                for f in &all_fields {
-                    let name = f.name.to_str().unwrap_or("");
-                    w.write_buffer(&null_terminated(name));
-
-                    let field_type = match f.ty {
-                        IndexType::Fulltext => index_field_type::INDEX_FLD_FULLTEXT,
-                        IndexType::Range => {
-                            index_field_type::INDEX_FLD_NUMERIC
-                                | index_field_type::INDEX_FLD_STR
-                                | index_field_type::INDEX_FLD_GEO
-                        }
-                        IndexType::Vector => index_field_type::INDEX_FLD_VECTOR,
-                    };
-                    w.write_unsigned(field_type);
-
-                    let opts = f.options();
-                    w.write_double(opts.and_then(|o| o.weight).unwrap_or(1.0));
-                    w.write_unsigned(u64::from(opts.and_then(|o| o.nostem).unwrap_or(false)));
-                    let phonetic = opts.and_then(|o| o.phonetic).map_or(String::new(), |p| {
-                        if p {
-                            "dm:en".to_string()
-                        } else {
-                            String::new()
-                        }
-                    });
-                    w.write_buffer(&null_terminated(&phonetic));
-
-                    if field_type & index_field_type::INDEX_FLD_VECTOR != 0
-                        && let Some(vopts) = f.vector_options()
-                    {
-                        w.write_unsigned(u64::from(vopts.dimension));
-                        w.write_unsigned(vopts.m.unwrap_or(16) as u64);
-                        w.write_unsigned(vopts.ef_construction.unwrap_or(200) as u64);
-                        w.write_unsigned(vopts.ef_runtime.unwrap_or(10) as u64);
-                        // similarity function: 0 = cosine (default)
-                        let sim = match vopts.similarity_function.as_deref() {
-                            Some("L2") => 1u64,
-                            Some("IP") => 2u64,
-                            _ => 0u64,
-                        };
-                        w.write_unsigned(sim);
-                    }
-                }
-            }
+            encode_schema_index_block(w, &label_indices);
 
             // Constraints (not implemented yet)
             w.write_unsigned(0);
         }
 
         // --- Relation schemas ---
+        // Symmetric to the node block: write the edge-index blob for
+        // each relationship type so indexes survive RDB save/reload.
+        // Matches FalkorDB C's `_RdbSaveSchema`, which uses a single
+        // codepath for node and edge schemas.
         w.write_unsigned(self.relationship_types.len() as u64);
         for (i, type_name) in self.relationship_types.iter().enumerate() {
             w.write_unsigned(i as u64);
             w.write_buffer(&null_terminated(type_name));
-            w.write_unsigned(0); // no indices
-            w.write_unsigned(0); // no constraints
+
+            let type_indices: Vec<&IndexInfo> = self
+                .indexes
+                .iter()
+                .filter(|info| {
+                    info.label.as_str() == type_name.as_str() && info.entity_type == "RELATIONSHIP"
+                })
+                .collect();
+            encode_schema_index_block(w, &type_indices);
+
+            // Constraints (not implemented yet)
+            w.write_unsigned(0);
+        }
+    }
+}
+
+/// Write the `has_index + [language/stopwords/fields]` block that
+/// lives inside a schema entry. Shared by the node and relation
+/// encode paths so the two can't drift; the matching decoder is
+/// `decode_schema_entry`.
+fn encode_schema_index_block(
+    w: &mut dyn Writer,
+    infos: &[&IndexInfo],
+) {
+    let has_index = !infos.is_empty();
+    w.write_unsigned(u64::from(has_index));
+    if !has_index {
+        return;
+    }
+
+    let language = infos
+        .first()
+        .and_then(|info| info.language.as_ref())
+        .map_or("english", |l| l.as_str());
+    w.write_buffer(&null_terminated(language));
+
+    let stopwords: Vec<&str> = infos
+        .first()
+        .and_then(|info| info.stopwords.as_ref())
+        .map(|sw| sw.iter().map(|s| s.as_str()).collect())
+        .unwrap_or_default();
+    w.write_unsigned(stopwords.len() as u64);
+    for sw in &stopwords {
+        w.write_buffer(&null_terminated(sw));
+    }
+
+    let all_fields: Vec<_> = infos
+        .iter()
+        .flat_map(|info| info.fields.values().flatten())
+        .collect();
+    w.write_unsigned(all_fields.len() as u64);
+    for f in &all_fields {
+        let name = f.name.to_str().unwrap_or("");
+        w.write_buffer(&null_terminated(name));
+
+        let field_type = match f.ty {
+            IndexType::Fulltext => index_field_type::INDEX_FLD_FULLTEXT,
+            IndexType::Range => {
+                index_field_type::INDEX_FLD_NUMERIC
+                    | index_field_type::INDEX_FLD_STR
+                    | index_field_type::INDEX_FLD_GEO
+            }
+            IndexType::Vector => index_field_type::INDEX_FLD_VECTOR,
+        };
+        w.write_unsigned(field_type);
+
+        let opts = f.options();
+        w.write_double(opts.and_then(|o| o.weight).unwrap_or(1.0));
+        w.write_unsigned(u64::from(opts.and_then(|o| o.nostem).unwrap_or(false)));
+        let phonetic = opts.and_then(|o| o.phonetic).map_or(String::new(), |p| {
+            if p {
+                "dm:en".to_string()
+            } else {
+                String::new()
+            }
+        });
+        w.write_buffer(&null_terminated(&phonetic));
+
+        if field_type & index_field_type::INDEX_FLD_VECTOR != 0
+            && let Some(vopts) = f.vector_options()
+        {
+            w.write_unsigned(u64::from(vopts.dimension));
+            w.write_unsigned(vopts.m.unwrap_or(16) as u64);
+            w.write_unsigned(vopts.ef_construction.unwrap_or(200) as u64);
+            w.write_unsigned(vopts.ef_runtime.unwrap_or(10) as u64);
+            // similarity function: 0 = cosine (default)
+            let sim = match vopts.similarity_function.as_deref() {
+                Some("L2") => 1u64,
+                Some("IP") => 2u64,
+                _ => 0u64,
+            };
+            w.write_unsigned(sim);
         }
     }
 }
@@ -385,17 +417,28 @@ impl Decode<19> for Schema {
             let label = Arc::new(label);
             if let Some(mut info) = info {
                 info.label = label.clone();
+                info.entity_type = String::from("NODE");
                 indexes.push(info);
             }
             node_labels.push(label);
         }
 
         // --- Relation schemas ---
+        // Symmetric to the node block: preserve any `IndexInfo` the
+        // encoder wrote and stamp it as RELATIONSHIP so
+        // `rebuild_indexes` calls `create_index_sync` with the right
+        // entity type.
         let rel_schema_count = r.read_unsigned()?;
         let mut relationship_types = Vec::with_capacity(rel_schema_count as usize);
         for _ in 0..rel_schema_count {
-            let (schema_name, _) = decode_schema_entry(r)?;
-            relationship_types.push(Arc::new(schema_name));
+            let (type_name, info) = decode_schema_entry(r)?;
+            let type_name = Arc::new(type_name);
+            if let Some(mut info) = info {
+                info.label = type_name.clone();
+                info.entity_type = String::from("RELATIONSHIP");
+                indexes.push(info);
+            }
+            relationship_types.push(type_name);
         }
 
         Ok(Self {
@@ -444,7 +487,11 @@ fn decode_schema_entry(r: &mut dyn Reader) -> Result<(String, Option<IndexInfo>)
             } else {
                 Some(stopwords)
             },
-            entity_type: String::from("NODE"),
+            // Left empty here: this helper is shared by the node and
+            // relation-schema decode blocks and doesn't know which
+            // one called it. Each caller stamps the appropriate
+            // `entity_type` on the returned info.
+            entity_type: String::new(),
         })
     } else {
         None

--- a/tests/flow/test_edge_index_scans.py
+++ b/tests/flow/test_edge_index_scans.py
@@ -916,3 +916,41 @@ class testEdgeByIndexScanRegressionsFlow(FlowTestsBase):
             g.delete()
 
 
+# RDB round-trip regression for edge indexes. Needs DEBUG RELOAD so it
+# lives in its own class with `enableDebugCommand=True`. Matches
+# FalkorDB C's behavior: edge indexes are encoded and restored under
+# the relationship-schema block, symmetric with node indexes.
+class testEdgeIndexRdbRoundtripFlow(FlowTestsBase):
+    def __init__(self):
+        self.env, self.db = Env(enableDebugCommand=True)
+
+    def test26_rdb_roundtrip_edge_index(self):
+        g = self.db.select_graph("edge_index_rdb_roundtrip")
+        try:
+            g.query("CREATE ()-[:T {v: 1}]->()")
+            g.query("CREATE ()-[:T {v: 2}]->()")
+            g.query("CREATE ()-[:T {v: 3}]->()")
+            create_edge_range_index(g, "T", "v", sync=True)
+
+            probe = "MATCH ()-[r:T]->() WHERE r.v = 2 RETURN r.v"
+            plan_before = str(g.explain(probe))
+            self.env.assertContains("Edge By Index Scan", plan_before)
+            self.env.assertEqual(g.query(probe).result_set, [[2]])
+
+            self.env.dumpAndReload()
+
+            # After reload the edge index must still exist and the
+            # planner must still route the probe through it.
+            plan_after = str(g.explain(probe))
+            self.env.assertContains("Edge By Index Scan", plan_after)
+            self.env.assertEqual(g.query(probe).result_set, [[2]])
+
+            # The probe must also see edges inserted after reload —
+            # the index is live, not a frozen snapshot.
+            g.query("CREATE ()-[:T {v: 42}]->()")
+            q = "MATCH ()-[r:T]->() WHERE r.v = 42 RETURN r.v"
+            self.env.assertContains("Edge By Index Scan", str(g.explain(q)))
+            self.env.assertEqual(g.query(q).result_set, [[42]])
+        finally:
+            g.delete()
+


### PR DESCRIPTION
## Summary

Edge indexes didn't survive an RDB reload on the Rust side: the encoder hardcoded `0` for every relation schema's `has_index` flag, and the decoder threw away any `Option<IndexInfo>` it got from a relation block. After `DEBUG RELOAD` every edge index was gone. Node indexes survived because the encoder/decoder pair already handled them correctly — C's `_RdbSaveSchema` uses one codepath for both, and this PR restores that symmetry.

This is PR #2 of a 2-PR split of #393. **Base branch is `pr393-feature` (#396); retarget to `main` once that merges.**

## Changes

- `src/serializers/mod.rs`: extract `encode_schema_index_block` helper so node and relation encoders share one body. Filter `self.indexes` by `entity_type` in each block. Decoder preserves relation-block `Option<IndexInfo>` and stamps it `RELATIONSHIP`; `decode_schema_entry` no longer hardcodes `NODE` — each caller stamps its own.
- `graph/src/graph/graph.rs`: `populate_indexes_sync` gains a streaming edge pass so rebuilt indexes are actually populated on RDB load, not empty until the first edge mutation.
- `tests/flow/test_edge_index_scans.py`: `testEdgeIndexRdbRoundtripFlow::test26_rdb_roundtrip_edge_index` — creates an edge range index, calls `dumpAndReload`, asserts plan still has `Edge By Index Scan` and probe returns the right row. In its own class because it needs `enableDebugCommand=True`.

## Backward compatibility

Staying on version 19. Per-relation-schema layout changes from `{id, name, 0, 0}` to `{id, name, 0|1, [index_body?], 0}`:

- **Old RDB → new decoder**: `has_idx = 0`, skips the block, unchanged behavior.
- **New RDB → old decoder**: `decode_schema_entry` already handled variable-length index blocks (node path does); the old decoder parses the bytes correctly and discards `Option<IndexInfo>` — the pre-fix behavior of losing edge indexes on load, not a panic.

C interop: the field layout inside `decode_schema_entry` (language → stopwords → fields → …) already matches C's `_RdbLoadIndex_v18`, so C-produced RDBs with edge indexes decode correctly once the relation-block decoder stops discarding the returned info.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build`
- [x] `TEST=tests/flow/test_edge_index_scans ./flow.sh` — 28 pass (27 feature + 1 roundtrip)
- [x] `TEST=tests/flow/test_encode_decode ./flow.sh` — 13 pass (no regression on node-side RDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)