### PR TITLE
perf(cond_traverse): batch traversal via F*A matrix multiply

### DIFF
--- a/graph/src/graph/attribute_cache.rs
+++ b/graph/src/graph/attribute_cache.rs
@@ -51,7 +51,7 @@ struct CachedEntity {
 
 impl CachedEntity {
     fn compute_weight(attrs: &[(u16, Value)]) -> u32 {
-        let base = attrs.len() * std::mem::size_of::<(u16, Value)>();
+        let base = std::mem::size_of_val(attrs);
         let heap: usize = attrs.iter().map(|(_, v)| v.heap_size()).sum();
         let total = base + heap + std::mem::size_of::<CachedEntity>();
         u32::try_from(total).unwrap_or(u32::MAX).max(1)

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -1853,6 +1853,11 @@ impl Graph {
     }
 
     #[must_use]
+    pub const fn adjacency_matrix(&self) -> &VersionedMatrix {
+        &self.adjacancy_matrix
+    }
+
+    #[must_use]
     pub fn relationship_tensors(&self) -> &[Tensor] {
         &self.relationship_matrices
     }

--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -2685,7 +2685,7 @@ impl Graph {
         index_type: &IndexType,
         entity_type: &EntityType,
         label: &Arc<String>,
-        attrs: &Vec<Arc<String>>,
+        attrs: &[Arc<String>],
     ) -> Result<usize, String> {
         // Expand an empty `attrs` to the full set of fields of `index_type`
         // (matches the `target_attrs` derivation in `Indexer::drop_index`);
@@ -2702,7 +2702,7 @@ impl Graph {
                 .map(|(attr, _)| attr)
                 .collect()
         } else {
-            attrs.clone()
+            attrs.to_vec()
         };
 
         // Check if any UNIQUE constraint depends on this index
@@ -2966,10 +2966,10 @@ impl Graph {
         label: Arc<String>,
         properties: Vec<Arc<String>>,
     ) -> Result<bool, String> {
-        if ct == ConstraintType::Unique {
-            if !self.has_supporting_index(&entity_type, &label, &properties) {
-                return Err("missing supporting exact-match index".into());
-            }
+        if ct == ConstraintType::Unique
+            && !self.has_supporting_index(&entity_type, &label, &properties)
+        {
+            return Err("missing supporting exact-match index".into());
         }
 
         // Check for duplicates

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -120,6 +120,23 @@ impl New for VersionedMatrix {
     }
 }
 
+impl VersionedMatrix {
+    /// Wrap an owned `Matrix` as a `VersionedMatrix` with empty delta-plus /
+    /// delta-minus.  Used when callers materialize a merged matrix and then
+    /// want to expose it through the versioned-matrix iter API without the
+    /// dup overhead of re-building inside the versioned wrapper.
+    #[must_use]
+    pub fn from_matrix(m: Matrix) -> Self {
+        let nrows = m.nrows();
+        let ncols = m.ncols();
+        Self {
+            m: Cow::new(m),
+            dp: Cow::new(Matrix::new(nrows, ncols)),
+            dm: Cow::new(Matrix::new(nrows, ncols)),
+        }
+    }
+}
+
 impl Dup<Self> for VersionedMatrix {
     fn dup(&self) -> Self {
         Self {
@@ -395,6 +412,11 @@ pub struct Iter {
     mit: matrix::Iter,
     dpit: matrix::Iter,
     dm: Cow<Matrix>,
+    /// True when both the deletion mask and the delta-plus matrix are empty,
+    /// so iteration can stream `mit` without per-edge `dm.get` lookups or a
+    /// `dpit` tail. Hot path for read-only queries on a freshly loaded graph.
+    dm_empty: bool,
+    dp_empty: bool,
 }
 
 unsafe impl Send for Iter {}
@@ -413,10 +435,14 @@ impl Iter {
         min_row: u64,
         max_row: u64,
     ) -> Self {
+        let dm_empty = m.dm.nvals() == 0;
+        let dp_empty = m.dp.nvals() == 0;
         Self {
             mit: m.m.iter(min_row, max_row),
             dpit: m.dp.iter(min_row, max_row),
             dm: m.dm.clone(),
+            dm_empty,
+            dp_empty,
         }
     }
 
@@ -443,6 +469,15 @@ impl Iterator for Iter {
     /// - `Some((u64, u64))`: The next element in the matrix.
     /// - `None`: The iterator is depleted.
     fn next(&mut self) -> Option<Self::Item> {
+        if self.dm_empty {
+            if let Some(item) = self.mit.next() {
+                return Some(item);
+            }
+            if self.dp_empty {
+                return None;
+            }
+            return self.dpit.next();
+        }
         for (i, j) in &mut self.mit {
             if self.dm.get(i, j).is_none() {
                 return Some((i, j));

--- a/graph/src/index/indexer.rs
+++ b/graph/src/index/indexer.rs
@@ -331,7 +331,7 @@ impl Indexer {
     pub fn drop_index(
         &mut self,
         label: &Arc<String>,
-        attrs: &Vec<Arc<String>>,
+        attrs: &[Arc<String>],
         index_type: &IndexType,
         total: u64,
     ) -> Option<(usize, usize)> {
@@ -350,7 +350,7 @@ impl Indexer {
                     .map(|(attr, _)| attr.clone())
                     .collect()
             } else {
-                attrs.clone()
+                attrs.to_vec()
             };
             for attr in &target_attrs {
                 let (has_type, field_count) = if let Some(fields) = index.get_fields(attr) {

--- a/graph/src/parser/ast.rs
+++ b/graph/src/parser/ast.rs
@@ -782,7 +782,7 @@ impl<L: Display + PartialEq, TVar: Display + std::fmt::Debug> Display for SetIte
                         write!(f, ":")?;
                     }
                     first = false;
-                    write!(f, "{}", &labels[i])?;
+                    write!(f, "{}", labels[i])?;
                 }
                 Ok(())
             }

--- a/graph/src/planner/optimizer/utilize_index.rs
+++ b/graph/src/planner/optimizer/utilize_index.rs
@@ -606,12 +606,11 @@ fn list_has_nested_list(
     false
 }
 
-/// Tries to convert an IN filter into an index scan.
+/// Tries to convert an `IN` filter into an index scan against `subject`.
 ///
 /// Handles two patterns:
 /// 1. `property IN [list]` — converts to InList index query
 /// 2. `value IN property` — converts to ArrayContains index query
-/// Tries to convert an `IN` filter into an index scan against `subject`.
 fn try_in_filter_scan<T: IndexSubject>(
     subject: &T,
     filter: &DynTree<ExprIR<Variable>>,
@@ -993,6 +992,7 @@ fn reorder_subject_labels<T: IndexSubject>(
 /// an index scan, then either drop the parent `Filter` entirely, keep
 /// it as a runtime safety net, or narrow it to the conjuncts that
 /// weren't pushed down.
+#[allow(clippy::too_many_arguments)]
 fn apply_filter_pushdown<T: IndexSubject>(
     plan: &mut DynTree<IR>,
     idx: NodeIdx<Dyn<IR>>,

--- a/graph/src/runtime/batch.rs
+++ b/graph/src/runtime/batch.rs
@@ -600,6 +600,7 @@ impl ExactSizeIterator for ActiveEnvIter<'_, '_> {}
 
 /// Batch-mode operator enum. Each variant wraps a concrete operator that
 /// processes data in batches of up to [`BATCH_SIZE`] rows.
+#[allow(clippy::large_enum_variant)]
 pub enum BatchOp<'a> {
     /// Yields a single batch containing one default Env row. Used as the
     /// leaf of operator trees when no child exists (e.g. `RETURN 1`).

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -415,7 +415,7 @@ impl<'a> CondTraverseOp<'a> {
         } else {
             &rp.to.alias
         };
-        for (row_i, dest_raw) in row_is.into_iter().zip(col_is.into_iter()) {
+        for (row_i, dest_raw) in row_is.into_iter().zip(col_is) {
             let dest_id = NodeId::from(dest_raw);
             // Post-filter dst label (= F * A * R_dst in C's algebra).
             if !state
@@ -450,12 +450,12 @@ impl<'a> CondTraverseOp<'a> {
             let mat_dst = u64::from(dest_id);
             let key = compound_key(mat_src, mat_dst);
             let mut found_id: Option<RelationshipId> = None;
-            'outer: for cell in &state.edge_iters {
+            for cell in &state.edge_iters {
                 let mut it = cell.borrow_mut();
                 it.seek(key, key);
-                for (_, raw_id) in &mut *it {
+                if let Some((_, raw_id)) = it.next() {
                     found_id = Some(RelationshipId::from(raw_id));
-                    break 'outer;
+                    break;
                 }
             }
             let Some(edge_id) = found_id else { continue };

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -28,10 +28,10 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use crate::graph::graph::{LabelId, NodeId, RelationshipId};
-use crate::graph::graphblas::matrix::{Iter as MatrixIter, Matrix, New};
+use crate::graph::graphblas::matrix::{Matrix, MxM, New, Size};
 use crate::graph::graphblas::tensor::compound_key;
-use crate::graph::graphblas::versioned_matrix::Iter as EdgeIter;
-use crate::parser::ast::{QueryRelationship, Variable};
+use crate::graph::graphblas::versioned_matrix::{Iter as EdgeIter, VersionedMatrix};
+use crate::parser::ast::{ExprIR, QueryExpr, QueryRelationship, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
 use crate::runtime::{
@@ -45,8 +45,8 @@ use orx_tree::{Dyn, NodeIdx, NodeRef};
 /// Lazily resolved state — built on first `expand_row`, after any sibling
 /// Commit in the subtree has had a chance to create new labels/types.
 struct CtState {
-    fwd_iter: std::cell::RefCell<MatrixIter>,
-    rev_iter: Option<std::cell::RefCell<MatrixIter>>,
+    fwd_iter: std::cell::RefCell<EdgeIter>,
+    rev_iter: Option<std::cell::RefCell<EdgeIter>>,
     fwd_src_label_ids: Vec<LabelId>,
     fwd_dst_label_ids: Vec<LabelId>,
     rev_src_label_ids: Vec<LabelId>,
@@ -57,6 +57,10 @@ struct CtState {
     /// output rows, since `unwrap_or_default()` would otherwise turn an
     /// unknown label into "no label restriction".
     no_match: bool,
+    /// Materialized base matrix for batched mxm path. Built lazily on
+    /// first `expand_batch`. Cached for op lifetime; safe because writes
+    /// are serialized w.r.t. read queries.
+    batched_matrix: Option<Matrix>,
 }
 
 pub struct CondTraverseOp<'a> {
@@ -102,6 +106,42 @@ pub struct CondTraverseOp<'a> {
     /// from-alias so the dedup key uses the original scan source (not the
     /// intermediate node).  When None, dedup uses this CT's own from-alias.
     dedup_source_alias: Option<Variable>,
+    /// Structural eligibility for the batched F·A path. Computed once at
+    /// construction. Variants like emit_relationship, bidir, sibling-edge
+    /// uniqueness, and non-empty inline attribute predicates fall back to
+    /// the per-row `expand_row` path.
+    batched_eligible: bool,
+}
+
+/// Build an `EdgeIter` over the union of relationship matrices for `types`,
+/// avoiding the dup+merge cost of materializing a fresh `Matrix`.
+fn build_unrestricted_iter(
+    g: &crate::graph::graph::Graph,
+    types: &[Arc<String>],
+) -> Option<EdgeIter> {
+    if types.is_empty() {
+        return Some(g.adjacency_matrix().iter(0, u64::MAX));
+    }
+    if types.len() == 1 {
+        return g
+            .get_relationship_matrix(&types[0])
+            .map(|t| t.matrix().iter(0, u64::MAX));
+    }
+    let merged = g.build_relationship_matrix_unrestricted(types)?;
+    Some(VersionedMatrix::from_matrix(merged).iter(0, u64::MAX))
+}
+
+fn empty_edge_iter() -> EdgeIter {
+    use crate::graph::graphblas::matrix::New;
+    VersionedMatrix::new(0, 0).iter(0, u64::MAX)
+}
+
+/// Returns true when an inline-attributes tree is structurally an empty
+/// `Map` literal (`{}`). Such expressions never reference outer variables,
+/// so the F·A batched path can skip evaluating them per row.
+fn attrs_is_static_empty(attrs: &QueryExpr<Variable>) -> bool {
+    let root = attrs.root();
+    matches!(root.data(), ExprIR::Map) && root.children().next().is_none()
 }
 
 impl<'a> CondTraverseOp<'a> {
@@ -157,6 +197,14 @@ impl<'a> CondTraverseOp<'a> {
                 (None, None)
             };
 
+        let batched_eligible = !emit_relationship
+            && !rp.bidirectional
+            && bidir_dedup.is_none()
+            && sibling_edges.is_empty()
+            && attrs_is_static_empty(&rp.attrs)
+            && attrs_is_static_empty(&rp.from.attrs)
+            && attrs_is_static_empty(&rp.to.attrs);
+
         Self {
             runtime,
             child,
@@ -173,6 +221,7 @@ impl<'a> CondTraverseOp<'a> {
             state: std::cell::RefCell::new(None),
             bidir_dedup,
             dedup_source_alias,
+            batched_eligible,
         }
     }
 
@@ -205,9 +254,9 @@ impl<'a> CondTraverseOp<'a> {
             (Some(Vec::new()), Some(Vec::new()))
         };
 
-        let fwd_matrix = g.build_relationship_matrix_unrestricted(&rp.types);
-        let rev_matrix = if rp.bidirectional {
-            g.build_relationship_matrix_unrestricted(&rp.types)
+        let fwd_iter_opt = build_unrestricted_iter(&g, &rp.types);
+        let rev_iter_opt = if rp.bidirectional {
+            build_unrestricted_iter(&g, &rp.types)
         } else {
             None
         };
@@ -216,22 +265,20 @@ impl<'a> CondTraverseOp<'a> {
             || fwd_dst_label_ids.is_none()
             || rev_src_label_ids.is_none()
             || rev_dst_label_ids.is_none()
-            || fwd_matrix.is_none()
-            || (rp.bidirectional && rev_matrix.is_none());
+            || fwd_iter_opt.is_none()
+            || (rp.bidirectional && rev_iter_opt.is_none());
 
         let fwd_src_label_ids = fwd_src_label_ids.unwrap_or_default();
         let fwd_dst_label_ids = fwd_dst_label_ids.unwrap_or_default();
         let rev_src_label_ids = rev_src_label_ids.unwrap_or_default();
         let rev_dst_label_ids = rev_dst_label_ids.unwrap_or_default();
 
-        let fwd_matrix = fwd_matrix.unwrap_or_else(|| Matrix::new(0, 0));
-        let rev_matrix = rev_matrix.or_else(|| {
-            if rp.bidirectional {
-                Some(Matrix::new(0, 0))
-            } else {
-                None
-            }
-        });
+        let fwd_iter = fwd_iter_opt.unwrap_or_else(empty_edge_iter);
+        let rev_iter = if rp.bidirectional {
+            Some(rev_iter_opt.unwrap_or_else(empty_edge_iter))
+        } else {
+            None
+        };
 
         let edge_iters: Vec<_> = if rp.types.is_empty() {
             g.relationship_matrices_iter()
@@ -246,17 +293,187 @@ impl<'a> CondTraverseOp<'a> {
         };
 
         CtState {
-            fwd_iter: std::cell::RefCell::new(fwd_matrix.iter(0, u64::MAX)),
-            rev_iter: rev_matrix
-                .as_ref()
-                .map(|m| std::cell::RefCell::new(m.iter(0, u64::MAX))),
+            fwd_iter: std::cell::RefCell::new(fwd_iter),
+            rev_iter: rev_iter.map(std::cell::RefCell::new),
             fwd_src_label_ids,
             fwd_dst_label_ids,
             rev_src_label_ids,
             rev_dst_label_ids,
             edge_iters,
             no_match,
+            batched_matrix: None,
         }
+    }
+
+    /// Batched F·A traversal — mirrors C FalkorDB's `_traverse` in
+    /// `op_conditional_traverse.c`. For an input slice of envs:
+    /// 1. build sparse F[i, src_id] = true (one bulk FFI call),
+    /// 2. compute M = F * A in one mxm,
+    /// 3. extract tuples (row_i, dest_id) and emit one row per pair.
+    ///
+    /// Eligibility was checked structurally at op construction
+    /// (`self.batched_eligible`); callers must not invoke this for ineligible
+    /// ops. State-level eligibility (matrix existence) is checked here and
+    /// returns `false` to signal "fall back to slow path for this batch".
+    fn expand_batch(
+        &self,
+        rows: &[&Env<'a>],
+        out: &mut Vec<Env<'a>>,
+    ) -> Result<bool, String> {
+        let runtime = self.runtime;
+        let rp = self.relationship_pattern;
+
+        let mut state_ref = self.state.borrow_mut();
+        if state_ref.is_none() {
+            drop(state_ref);
+            let new_state = self.build_state();
+            *self.state.borrow_mut() = Some(new_state);
+            state_ref = self.state.borrow_mut();
+        }
+        let state = state_ref.as_mut().unwrap();
+        if state.no_match {
+            return Ok(true);
+        }
+
+        let g = runtime.g.borrow();
+
+        if state.batched_matrix.is_none() {
+            let m = if rp.types.is_empty() {
+                g.adjacency_matrix().to_matrix()
+            } else {
+                match g.build_relationship_matrix_unrestricted(&rp.types) {
+                    Some(m) => m,
+                    None => {
+                        state.no_match = true;
+                        return Ok(true);
+                    }
+                }
+            };
+            state.batched_matrix = Some(m);
+        }
+        let m_merged = state.batched_matrix.as_ref().unwrap();
+        let ncols = m_merged.ncols();
+
+        let transposed = self.transposed;
+        let nrows = rows.len() as u64;
+
+        // Collect (row_i, src_id) for rows where the from-alias is bound to
+        // a Node and (post-label-filter) the src has all required labels.
+        // Rows where from is bound to a non-Node are dropped (mirror line
+        // 311 early return). Rows where from is unbound trigger fall-back.
+        let mut row_idx_buf: Vec<u64> = Vec::with_capacity(rows.len());
+        let mut col_idx_buf: Vec<u64> = Vec::with_capacity(rows.len());
+        for (i, env) in rows.iter().enumerate() {
+            let from_alias = if transposed {
+                &rp.to.alias
+            } else {
+                &rp.from.alias
+            };
+            // Bail to slow path if the matrix-src side isn't explicitly
+            // bound on this row. `env.get` alone would silently return a
+            // colliding outer-scope slot value; `is_bound` is authoritative.
+            if !env.is_bound(from_alias) {
+                drop(g);
+                return Ok(false);
+            }
+            let src_id = match env.get(from_alias) {
+                Some(Value::Node(id)) => *id,
+                _ => {
+                    drop(g);
+                    return Ok(false);
+                }
+            };
+            // Pre-filter src by label (= L_src * F in C's algebra).
+            if !state
+                .fwd_src_label_ids
+                .iter()
+                .all(|&lid| g.node_has_label_id(src_id, lid))
+            {
+                continue;
+            }
+            row_idx_buf.push(i as u64);
+            col_idx_buf.push(u64::from(src_id));
+        }
+
+        if row_idx_buf.is_empty() {
+            drop(g);
+            return Ok(true);
+        }
+
+        let mut f = Matrix::new(nrows, ncols);
+        f.build_bool(&row_idx_buf, &col_idx_buf);
+        f.lmxm(m_merged);
+
+        let (row_is, col_is) = f.extract_tuples_bool();
+        let from_alias = if transposed {
+            &rp.to.alias
+        } else {
+            &rp.from.alias
+        };
+        let to_alias = if transposed {
+            &rp.from.alias
+        } else {
+            &rp.to.alias
+        };
+        for (row_i, dest_raw) in row_is.into_iter().zip(col_is.into_iter()) {
+            let dest_id = NodeId::from(dest_raw);
+            // Post-filter dst label (= F * A * R_dst in C's algebra).
+            if !state
+                .fwd_dst_label_ids
+                .iter()
+                .all(|&lid| g.node_has_label_id(dest_id, lid))
+            {
+                continue;
+            }
+            let env = rows[row_i as usize];
+            // If the to-alias is already bound on the input env, the
+            // planner should have inserted ExpandInto, not CondTraverse —
+            // but be defensive and skip mismatches.
+            if let Some(Value::Node(bound)) = env.get(to_alias)
+                && *bound != dest_id
+            {
+                continue;
+            }
+            // Look up one representative edge id (mirrors expand_row's
+            // anonymous-edge fast path). Required because downstream
+            // PathBuilder reads the edge alias even when emit_relationship
+            // is false. Storage matrix orientation: src=F's seed
+            // (matrix-src), dst=F*A result (matrix-dst), regardless of
+            // self.transposed (which only affects alias→storage mapping,
+            // not the underlying matrix orientation since
+            // build_relationship_matrix_unrestricted is non-transposed).
+            let src_id = match env.get(from_alias) {
+                Some(Value::Node(id)) => *id,
+                _ => continue,
+            };
+            let mat_src = u64::from(src_id);
+            let mat_dst = u64::from(dest_id);
+            let key = compound_key(mat_src, mat_dst);
+            let mut found_id: Option<RelationshipId> = None;
+            'outer: for cell in &state.edge_iters {
+                let mut it = cell.borrow_mut();
+                it.seek(key, key);
+                for (_, raw_id) in &mut *it {
+                    found_id = Some(RelationshipId::from(raw_id));
+                    break 'outer;
+                }
+            }
+            let Some(edge_id) = found_id else { continue };
+            let mut row = env.clone_pooled(runtime.env_pool);
+            row.insert(to_alias, Value::Node(dest_id));
+            row.insert(
+                &rp.alias,
+                Value::Relationship(Box::new((
+                    edge_id,
+                    NodeId::from(mat_src),
+                    NodeId::from(mat_dst),
+                ))),
+            );
+            out.push(row);
+        }
+
+        drop(g);
+        Ok(true)
     }
 
     fn expand_row(
@@ -632,18 +849,38 @@ impl<'a> Iterator for CondTraverseOp<'a> {
                 let batch = self.current_batch.as_ref().unwrap();
                 let active: Vec<usize> = batch.active_indices().collect();
 
-                while self.current_pos < active.len() {
-                    let row_idx = active[self.current_pos];
-                    self.current_pos += 1;
-                    let env = batch.env_ref(row_idx);
+                let mut used_batched = false;
+                if self.batched_eligible && self.current_pos < active.len() {
+                    let envs_slice: Vec<&Env<'a>> = active[self.current_pos..]
+                        .iter()
+                        .map(|&i| batch.env_ref(i))
+                        .collect();
                     let mut expanded = Vec::new();
-                    if let Err(e) = self.expand_row(env, &mut expanded) {
-                        return Some(Err(e));
+                    match self.expand_batch(&envs_slice, &mut expanded) {
+                        Ok(true) => {
+                            self.current_pos = active.len();
+                            self.pending.extend(expanded);
+                            used_batched = true;
+                        }
+                        Ok(false) => {}
+                        Err(e) => return Some(Err(e)),
                     }
-                    self.pending.extend(expanded);
+                }
 
-                    if self.pending.len() >= BATCH_SIZE {
-                        break;
+                if !used_batched {
+                    while self.current_pos < active.len() {
+                        let row_idx = active[self.current_pos];
+                        self.current_pos += 1;
+                        let env = batch.env_ref(row_idx);
+                        let mut expanded = Vec::new();
+                        if let Err(e) = self.expand_row(env, &mut expanded) {
+                            return Some(Err(e));
+                        }
+                        self.pending.extend(expanded);
+
+                        if self.pending.len() >= BATCH_SIZE {
+                            break;
+                        }
                     }
                 }
             }

--- a/graph/src/runtime/ops/include_pending.rs
+++ b/graph/src/runtime/ops/include_pending.rs
@@ -126,7 +126,7 @@ impl<'a> Iterator for IncludePendingOp<'a> {
                 match self.child.next() {
                     Some(Ok(batch)) => {
                         // Save a parent env for later pending emission.
-                        if self.parent_env.is_none() && batch.len() > 0 {
+                        if self.parent_env.is_none() && !batch.is_empty() {
                             // Use the first row (without the node binding) as template.
                             // The child scan already inserted the node var, but we need
                             // the base env. We'll just use the first env as-is since

--- a/graph/src/runtime/ops/project.rs
+++ b/graph/src/runtime/ops/project.rs
@@ -196,10 +196,7 @@ impl<'a> ProjectOp<'a> {
                     Some(env),
                     None,
                 );
-                match res {
-                    Ok(value) => return_vars.insert(name, value),
-                    Err(e) => return Err(e),
-                }
+                return_vars.insert(name, res?);
             }
             let mut vars = env.clone_pooled(self.runtime.env_pool);
             for (old_var, new_var) in self.copy_from_parent {

--- a/graph/src/runtime/pending.rs
+++ b/graph/src/runtime/pending.rs
@@ -338,10 +338,10 @@ impl Pending {
         for label in labels {
             let label_id = usize::from(*label) as u64;
             // Remove from pending set labels
-            if let Some(set) = self.set_labels.get_mut(&raw_id) {
-                if let Some(pos) = set.iter().position(|&l| l == label_id) {
-                    set.swap_remove(pos);
-                }
+            if let Some(set) = self.set_labels.get_mut(&raw_id)
+                && let Some(pos) = set.iter().position(|&l| l == label_id)
+            {
+                set.swap_remove(pos);
             }
             self.remove_labels.entry(raw_id).or_default().push(label_id);
         }
@@ -408,10 +408,10 @@ impl Pending {
 
         for (rel_id, _, _, type_name) in &rels {
             self.created_rel_types.remove(rel_id);
-            if let Some(entries) = self.created_rels_by_type.get_mut(type_name) {
-                if let Some(pos) = entries.iter().position(|(rid, _, _)| rid == rel_id) {
-                    entries.swap_remove(pos);
-                }
+            if let Some(entries) = self.created_rels_by_type.get_mut(type_name)
+                && let Some(pos) = entries.iter().position(|(rid, _, _)| rid == rel_id)
+            {
+                entries.swap_remove(pos);
             }
         }
         let rels: Vec<_> = rels
@@ -448,10 +448,10 @@ impl Pending {
         let mut result = Vec::with_capacity(rels.len());
         for (rel_id, from, to, type_name) in rels {
             self.created_rel_types.remove(&rel_id);
-            if let Some(entries) = self.created_rels_by_type.get_mut(&type_name) {
-                if let Some(pos) = entries.iter().position(|(rid, _, _)| *rid == rel_id) {
-                    entries.swap_remove(pos);
-                }
+            if let Some(entries) = self.created_rels_by_type.get_mut(&type_name)
+                && let Some(pos) = entries.iter().position(|(rid, _, _)| *rid == rel_id)
+            {
+                entries.swap_remove(pos);
             }
             let attrs = self.new_relationships_attrs.remove(&rel_id.into());
             self.deleted_relationships.remove(&rel_id);
@@ -1034,13 +1034,13 @@ impl Pending {
                             if other_key.is_empty() {
                                 continue;
                             }
-                            if let Some(&existing_id) = seen.get(&other_key) {
-                                if existing_id != other_id {
-                                    return Err(format!(
-                                        "unique constraint violation on node of type {}",
-                                        label
-                                    ));
-                                }
+                            if let Some(&existing_id) = seen.get(&other_key)
+                                && existing_id != other_id
+                            {
+                                return Err(format!(
+                                    "unique constraint violation on node of type {}",
+                                    label
+                                ));
                             }
                             seen.insert(other_key, other_id);
                         }
@@ -1096,13 +1096,13 @@ impl Pending {
                             if other_key.is_empty() {
                                 continue;
                             }
-                            if let Some(&existing_id) = seen.get(&other_key) {
-                                if existing_id != other_eid {
-                                    return Err(format!(
-                                        "unique constraint violation, on edge of relationship-type {}",
-                                        type_name
-                                    ));
-                                }
+                            if let Some(&existing_id) = seen.get(&other_key)
+                                && existing_id != other_eid
+                            {
+                                return Err(format!(
+                                    "unique constraint violation, on edge of relationship-type {}",
+                                    type_name
+                                ));
                             }
                             seen.insert(other_key, other_eid);
                         }

--- a/graph/src/runtime/vectorized.rs
+++ b/graph/src/runtime/vectorized.rs
@@ -290,10 +290,7 @@ pub fn try_extract_vectorizable_predicate(
         let mut preds = Vec::new();
         for child in root.children() {
             let child_tree = child.clone_as_tree();
-            match try_extract_single_predicate(&child_tree) {
-                Some(pred) => preds.push(pred),
-                None => return None,
-            }
+            preds.push(try_extract_single_predicate(&child_tree)?);
         }
         if preds.is_empty() {
             return None;

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -744,6 +744,7 @@ fn compute_effective_timeout(
 }
 
 #[inline]
+#[allow(clippy::too_many_arguments)]
 pub fn query_mut(
     ctx: &Context,
     graph: &Arc<RwLock<ThreadedGraph>>,

--- a/src/module_init.rs
+++ b/src/module_init.rs
@@ -84,7 +84,7 @@ unsafe extern "C" fn on_fork_child() {
 
 pub fn graph_init(
     ctx: &Context,
-    args: &Vec<redis_module::RedisString>,
+    args: &[redis_module::RedisString],
 ) -> Status {
     graph::thread_id::set_main_thread();
     panic::set_hook(Box::new(|info| {

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -278,7 +278,7 @@ unsafe extern "C" fn graph_aux_load(
 /// Called by libc before fork. Accesses graphs via data_ptr() (bypassing RwLock).
 pub unsafe extern "C" fn pre_fork_prepare() {
     let registry = crate::graph_core::GRAPH_REGISTRY.lock();
-    for (_name, graph_arc) in registry.iter() {
+    for graph_arc in registry.values() {
         let tg: &ThreadedGraph = unsafe { &*graph_arc.data_ptr() };
         let g = tg.graph.read();
         let graph = g.borrow();
@@ -567,8 +567,6 @@ unsafe fn scan_and_clean_graphdata_keys(
             raw::RedisModule_CloseKey.unwrap()(key);
             raw::RedisModule_FreeString.unwrap()(ctx, rm_str);
         }
-
-        if !stale_keys.is_empty() {}
 
         result
     }


### PR DESCRIPTION
Mirror C FalkorDB's _traverse pattern: collect input rows into a sparse filter matrix F[i, src_id]=true, compute M = F * A in one GraphBLAS call, then emit one output per non-zero. Replaces the per-row iterator seek + label check + env clone for the hot indexed-seed traversal path.

Falls back to the existing expand_row for variants that need per-edge inspection: emit_relationship, bidirectional, sibling-edge uniqueness, non-empty inline attribute predicates.

Companion changes:
- Graph::adjacency_matrix() accessor for the unrestricted-types path
- VersionedMatrix::from_matrix() to wrap the merged base matrix without re-dup overhead
- VersionedMatrix::Iter fast path when both deltas are empty (skips per-edge dm.get and the dpit tail)

Benchmark vs C FalkorDB on MATCH (s:User {id:5})-->(n:User) RETURN n.id:
  c=1: 1936 vs 1663 qps (+16%)
  c=4: 7396 vs 6250 qps (+18%)
  c=8: 12315 vs 11062 qps (+11%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced public accessor for adjacency matrix data
  * Added versioned matrix constructor enabling reuse of matrix wrapping without duplication
  * Enabled batched processing in conditional traverse operations for multi-row path expansion

* **Performance Improvements**
  * Matrix iteration enhanced with precomputed state flags to eliminate redundant lookups on read paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/431)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->