### PR TITLE
perf(graph): apply per-type dp/dm directly when merging rel matrices

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -87,8 +87,8 @@ use crate::{
         constraint::{Constraint, ConstraintStatus, ConstraintType},
         graphblas::{
             matrix::{
-                Dup, Get, MaskedElementWiseAdd, MaskedElementWiseMultiply, Matrix, MxM, New,
-                Remove, Set, Size, Transpose,
+                Descriptor, Dup, Get, MaskedElementWiseAdd, MaskedElementWiseMultiply, Matrix, MxM,
+                New, Remove, Set, Size, Transpose,
             },
             serialization::{Encode, EncodeState, PayloadEntry, Writer},
             tensor::Tensor,
@@ -2118,11 +2118,12 @@ impl Graph {
         );
         for relationship_matrix in iter {
             m.element_wise_add(
+                Some(relationship_matrix.matrix().dm()),
                 None,
-                None,
-                Some(&relationship_matrix.matrix().to_matrix()),
-                None,
+                Some(relationship_matrix.matrix().m()),
+                Some(Descriptor::C),
             );
+            m.element_wise_add(None, None, Some(relationship_matrix.matrix().dp()), None);
         }
         Some(m)
     }

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -121,6 +121,18 @@ impl New for VersionedMatrix {
 }
 
 impl VersionedMatrix {
+    pub fn m(&self) -> &Matrix {
+        &self.m
+    }
+
+    pub fn dp(&self) -> &Matrix {
+        &self.dp
+    }
+
+    pub fn dm(&self) -> &Matrix {
+        &self.dm
+    }
+
     /// Wrap an owned `Matrix` as a `VersionedMatrix` with empty delta-plus /
     /// delta-minus.  Used when callers materialize a merged matrix and then
     /// want to expose it through the versioned-matrix iter API without the


### PR DESCRIPTION
## Summary

\`Graph::build_relationship_matrix_unrestricted\` materializes a merged matrix across N relationship types. The previous code called \`to_matrix()\` on each subsequent type, which dup's the type's base matrix and eWiseAdds dp into the dup before the union — two allocations plus an intermediate eWiseAdd per extra type.

Mirror C FalkorDB's Delta_Matrix algebra and apply each type's deltas directly against the accumulator:

- \`m += rel.m\` masked by \`rel.dm\` (descriptor C = complement, so dm-marked deletions are excluded)
- \`m += rel.dp\`

Same effective semantics, no per-type intermediate matrix.

## Test plan

- [x] \`cargo build --release\`
- [x] \`cargo test -p graph --release --lib\` — 47/47 pass

## Notes

Touches only the multi-type union path (single type still uses the base \`get_relationship_matrix\` accessor unchanged). No behavioral change visible to callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized matrix operations for relationship-type calculations.
  * Internal infrastructure improvements to support enhanced graph operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/432)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->