### PR TITLE
perf(planner): fuse anonymous chained traversals into batched mxm

### DIFF
--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -448,6 +448,96 @@ impl MxM for Matrix {
     }
 }
 
+impl Matrix {
+    /// Delta-aware matrix-multiply: `self = self * vm` operating directly on
+    /// the versioned matrix's base/dp/dm components, mirroring C FalkorDB's
+    /// `Delta_mxm`.
+    ///
+    /// Computes `(self * (m + dp))<!(self * dm)>` without first materializing
+    /// the merged matrix. In the common read-only case (`dp.nvals() == 0 &&
+    /// dm.nvals() == 0`) this is a single `GrB_mxm` against `vm.m()`, avoiding
+    /// the eWiseAdd that `to_matrix()` would otherwise pay.
+    pub fn delta_lmxm(
+        &mut self,
+        vm: &super::versioned_matrix::VersionedMatrix,
+    ) {
+        let dp = vm.dp();
+        let dm = vm.dm();
+        let dp_nvals = dp.nvals();
+        let dm_nvals = dm.nvals();
+
+        if dp_nvals == 0 && dm_nvals == 0 {
+            // Hot path: clean snapshot, just self * vm.m()
+            self.lmxm(vm.m());
+            return;
+        }
+
+        let nrows = self.nrows();
+        let ncols = vm.ncols();
+
+        let mut mask: Option<Matrix> = None;
+        if dm_nvals > 0 {
+            let mut mk = Matrix::new(nrows, ncols);
+            unsafe {
+                let info = GrB_mxm(
+                    *mk.m,
+                    null_mut(),
+                    null_mut(),
+                    GxB_ANY_PAIR_BOOL,
+                    *self.m,
+                    *dm.m,
+                    null_mut(),
+                );
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            if mk.nvals() > 0 {
+                mask = Some(mk);
+            }
+        }
+
+        let mut accum: Option<Matrix> = None;
+        if dp_nvals > 0 {
+            let mut ac = Matrix::new(nrows, ncols);
+            unsafe {
+                let info = GrB_mxm(
+                    *ac.m,
+                    null_mut(),
+                    null_mut(),
+                    GxB_ANY_PAIR_BOOL,
+                    *self.m,
+                    *dp.m,
+                    null_mut(),
+                );
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            if ac.nvals() > 0 {
+                accum = Some(ac);
+            }
+        }
+
+        unsafe {
+            let (mask_ptr, desc) = match &mask {
+                Some(m) => (*m.m, GrB_DESC_RSC),
+                None => (null_mut(), null_mut()),
+            };
+            let info = GrB_mxm(
+                *self.m,
+                mask_ptr,
+                null_mut(),
+                GxB_ANY_PAIR_BOOL,
+                *self.m,
+                *vm.m().m,
+                desc,
+            );
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        }
+
+        if let Some(ac) = accum {
+            self.element_wise_add(None, None, Some(&ac), None);
+        }
+    }
+}
+
 /// A wrapper around a GraphBLAS boolean matrix.
 #[derive(Clone)]
 pub struct Matrix {
@@ -634,12 +724,14 @@ impl Matrix {
     }
 
     pub fn wait(&self) {
-        let lock = self.lock.lock();
-        unsafe {
-            let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
-            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        if self.pending() {
+            let lock = self.lock.lock();
+            unsafe {
+                let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            drop(lock);
         }
-        drop(lock);
     }
 
     #[must_use]

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -59,10 +59,7 @@ use std::{
     mem::{ManuallyDrop, MaybeUninit},
     os::raw::c_void,
     ptr::null_mut,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::Arc,
 };
 
 use parking_lot::Mutex;
@@ -86,15 +83,16 @@ use super::{
     GrB_Matrix_build_BOOL, GrB_Matrix_build_UINT64, GrB_Matrix_clear, GrB_Matrix_dup,
     GrB_Matrix_eWiseAdd_Semiring, GrB_Matrix_eWiseMult_Semiring, GrB_Matrix_extractElement_BOOL,
     GrB_Matrix_extractElement_UINT64, GrB_Matrix_extractTuples_BOOL, GrB_Matrix_free,
-    GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals, GrB_Matrix_removeElement,
-    GrB_Matrix_resize, GrB_Matrix_setElement_BOOL, GrB_Matrix_setElement_UINT64, GrB_Matrix_wait,
-    GrB_Mode, GrB_UINT64, GrB_WaitMode, GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL,
-    GxB_ANY_PAIR_BOOL, GxB_ANY_UINT64, GxB_Container_free, GxB_Container_new,
-    GxB_Global_Option_set_INT32, GxB_Iterator, GxB_Iterator_free, GxB_Iterator_new,
-    GxB_Matrix_fprint, GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field,
-    GxB_Print_Level, GxB_init, GxB_load_Matrix_from_Container, GxB_rowIterator_attach,
-    GxB_rowIterator_getColIndex, GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol,
-    GxB_rowIterator_nextRow, GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
+    GrB_Matrix_get_INT32, GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals,
+    GrB_Matrix_removeElement, GrB_Matrix_resize, GrB_Matrix_setElement_BOOL,
+    GrB_Matrix_setElement_UINT64, GrB_Matrix_wait, GrB_Mode, GrB_UINT64, GrB_WaitMode,
+    GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL, GxB_ANY_UINT64,
+    GxB_Container_free, GxB_Container_new, GxB_Global_Option_set_INT32, GxB_Iterator,
+    GxB_Iterator_free, GxB_Iterator_new, GxB_Matrix_fprint, GxB_Matrix_memoryUsage,
+    GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field, GxB_Print_Level, GxB_init,
+    GxB_load_Matrix_from_Container, GxB_rowIterator_attach, GxB_rowIterator_getColIndex,
+    GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol, GxB_rowIterator_nextRow,
+    GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
 };
 
 /// Initializes the GraphBLAS library in non-blocking mode.
@@ -274,7 +272,6 @@ impl MaskedElementWiseAdd for Matrix {
         b: Option<&Self>,
         descriptor: Option<Descriptor>,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_eWiseAdd_Semiring(
                 *self.m,
@@ -382,7 +379,6 @@ impl MaskedElementWiseMultiply for Matrix {
         b: Option<&Self>,
         descriptor: Option<Descriptor>,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_eWiseMult_Semiring(
                 *self.m,
@@ -419,7 +415,6 @@ impl MxM for Matrix {
         &mut self,
         b: &Self,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_mxm(
                 *self.m,
@@ -438,7 +433,6 @@ impl MxM for Matrix {
         &mut self,
         b: &Self,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_mxm(
                 *self.m,
@@ -484,7 +478,6 @@ impl Matrix {
         let mut mask: Option<Matrix> = None;
         if dm_nvals > 0 {
             let mut mk = Matrix::new(nrows, ncols);
-            mk.mark_pending();
             unsafe {
                 let info = GrB_mxm(
                     *mk.m,
@@ -505,7 +498,6 @@ impl Matrix {
         let mut accum: Option<Matrix> = None;
         if dp_nvals > 0 {
             let mut ac = Matrix::new(nrows, ncols);
-            ac.mark_pending();
             unsafe {
                 let info = GrB_mxm(
                     *ac.m,
@@ -523,7 +515,6 @@ impl Matrix {
             }
         }
 
-        self.mark_pending();
         unsafe {
             let (mask_ptr, desc) = match &mask {
                 Some(m) => (*m.m, GrB_DESC_RSC),
@@ -553,11 +544,6 @@ pub struct Matrix {
     /// The underlying GraphBLAS matrix.
     m: Arc<GrB_Matrix>,
     lock: Arc<Mutex<()>>,
-    /// Rust-side flag tracking whether GraphBLAS may have pending work on the
-    /// handle. Set by every mutating op; cleared by `wait()` after materialize.
-    /// Allows `wait()` to skip the GraphBLAS `pending` query (which is unsafe
-    /// to call concurrently with writers) and the lock when nothing's pending.
-    pending: Arc<AtomicBool>,
 }
 
 unsafe impl Send for Matrix {}
@@ -639,7 +625,6 @@ impl Decode<19> for Matrix {
             Ok(Self {
                 m: Arc::new(m),
                 lock: Arc::new(Mutex::new(())),
-                pending: Arc::new(AtomicBool::new(true)),
             })
         }
     }
@@ -722,28 +707,29 @@ impl Matrix {
 
     #[must_use]
     pub fn pending(&self) -> bool {
-        self.pending.load(Ordering::Acquire)
-    }
-
-    /// Mark the matrix as having pending GraphBLAS work. Called by every
-    /// mutating operation. The flag lives on the Rust side so `wait()` can
-    /// short-circuit without invoking GraphBLAS (which is unsafe to query
-    /// concurrently with writers).
-    fn mark_pending(&self) {
-        self.pending.store(true, Ordering::Release);
+        unsafe {
+            let mut pending = MaybeUninit::uninit();
+            let info = GrB_Matrix_get_INT32(
+                *self.m,
+                pending.as_mut_ptr(),
+                GxB_Option_Field::GxB_WILL_WAIT as _,
+            );
+            assert_eq!(
+                info,
+                GrB_Info::GrB_SUCCESS,
+                "GrB_Matrix_get_INT32 failed: {info:?}"
+            );
+            pending.assume_init() == 1
+        }
     }
 
     pub fn wait(&self) {
-        if !self.pending.load(Ordering::Acquire) {
-            return;
-        }
         let lock = self.lock.lock();
-        if self.pending.load(Ordering::Acquire) {
+        if self.pending() {
             unsafe {
                 let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
                 debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
             }
-            self.pending.store(false, Ordering::Release);
         }
         drop(lock);
     }
@@ -759,7 +745,6 @@ impl Matrix {
     }
 
     pub fn clear(&mut self) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_clear(*self.m);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -770,7 +755,6 @@ impl Matrix {
         &mut self,
         b: &Self,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_transpose(*self.m, *b.m, null_mut(), *self.m, GrB_DESC_RCT0);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -782,7 +766,6 @@ impl Matrix {
         mask: &Matrix,
         a: &Matrix,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_transpose(*self.m, *mask.m, null_mut(), *a.m, GrB_DESC_RCT0);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -814,7 +797,6 @@ impl Size for Matrix {
         nrows: u64,
         ncols: u64,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_resize(*self.m, nrows, ncols);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -854,7 +836,6 @@ impl New for Matrix {
             Self {
                 m: Arc::new(m.assume_init()),
                 lock: Arc::new(Mutex::new(())),
-                pending: Arc::new(AtomicBool::new(false)),
             }
         }
     }
@@ -878,7 +859,6 @@ impl Dup<Self> for Matrix {
                 m.assume_init()
             }),
             lock: Arc::new(Mutex::new(())),
-            pending: Arc::new(AtomicBool::new(self.pending.load(Ordering::Relaxed))),
         }
     }
 }
@@ -901,7 +881,6 @@ impl Matrix {
             Self {
                 m: Arc::new(m.assume_init()),
                 lock: Arc::new(Mutex::new(())),
-                pending: Arc::new(AtomicBool::new(false)),
             }
         }
     }
@@ -913,7 +892,6 @@ impl Matrix {
         j: u64,
         value: u64,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_setElement_UINT64(*self.m, value, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -947,7 +925,6 @@ impl Remove for Matrix {
         i: u64,
         j: u64,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_removeElement(*self.m, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -990,7 +967,6 @@ impl Set for Matrix {
         j: u64,
         value: bool,
     ) {
-        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_setElement_BOOL(*self.m, value, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -1010,7 +986,6 @@ impl Matrix {
         if rows.is_empty() {
             return;
         }
-        self.mark_pending();
         let nvals = rows.len() as u64;
         let vals = vec![true; rows.len()];
         unsafe {
@@ -1038,7 +1013,6 @@ impl Matrix {
         if rows.is_empty() {
             return;
         }
-        self.mark_pending();
         let nvals = rows.len() as u64;
         unsafe {
             let info = GrB_Matrix_build_UINT64(
@@ -1089,7 +1063,6 @@ where
     /// A new matrix that is the transpose of the original.
     fn transpose(&self) -> Self {
         let transpose = Self::new(self.ncols(), self.nrows());
-        transpose.mark_pending();
         unsafe {
             let info = GrB_transpose(*transpose.m, null_mut(), null_mut(), *self.m, null_mut());
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -59,7 +59,10 @@ use std::{
     mem::{ManuallyDrop, MaybeUninit},
     os::raw::c_void,
     ptr::null_mut,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use parking_lot::Mutex;
@@ -83,16 +86,15 @@ use super::{
     GrB_Matrix_build_BOOL, GrB_Matrix_build_UINT64, GrB_Matrix_clear, GrB_Matrix_dup,
     GrB_Matrix_eWiseAdd_Semiring, GrB_Matrix_eWiseMult_Semiring, GrB_Matrix_extractElement_BOOL,
     GrB_Matrix_extractElement_UINT64, GrB_Matrix_extractTuples_BOOL, GrB_Matrix_free,
-    GrB_Matrix_get_INT32, GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals,
-    GrB_Matrix_removeElement, GrB_Matrix_resize, GrB_Matrix_setElement_BOOL,
-    GrB_Matrix_setElement_UINT64, GrB_Matrix_wait, GrB_Mode, GrB_UINT64, GrB_WaitMode,
-    GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL, GxB_ANY_UINT64,
-    GxB_Container_free, GxB_Container_new, GxB_Global_Option_set_INT32, GxB_Iterator,
-    GxB_Iterator_free, GxB_Iterator_new, GxB_Matrix_fprint, GxB_Matrix_memoryUsage,
-    GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field, GxB_Print_Level, GxB_init,
-    GxB_load_Matrix_from_Container, GxB_rowIterator_attach, GxB_rowIterator_getColIndex,
-    GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol, GxB_rowIterator_nextRow,
-    GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
+    GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals, GrB_Matrix_removeElement,
+    GrB_Matrix_resize, GrB_Matrix_setElement_BOOL, GrB_Matrix_setElement_UINT64, GrB_Matrix_wait,
+    GrB_Mode, GrB_UINT64, GrB_WaitMode, GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL,
+    GxB_ANY_PAIR_BOOL, GxB_ANY_UINT64, GxB_Container_free, GxB_Container_new,
+    GxB_Global_Option_set_INT32, GxB_Iterator, GxB_Iterator_free, GxB_Iterator_new,
+    GxB_Matrix_fprint, GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field,
+    GxB_Print_Level, GxB_init, GxB_load_Matrix_from_Container, GxB_rowIterator_attach,
+    GxB_rowIterator_getColIndex, GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol,
+    GxB_rowIterator_nextRow, GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
 };
 
 /// Initializes the GraphBLAS library in non-blocking mode.
@@ -272,6 +274,7 @@ impl MaskedElementWiseAdd for Matrix {
         b: Option<&Self>,
         descriptor: Option<Descriptor>,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_eWiseAdd_Semiring(
                 *self.m,
@@ -379,6 +382,7 @@ impl MaskedElementWiseMultiply for Matrix {
         b: Option<&Self>,
         descriptor: Option<Descriptor>,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_eWiseMult_Semiring(
                 *self.m,
@@ -415,6 +419,7 @@ impl MxM for Matrix {
         &mut self,
         b: &Self,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_mxm(
                 *self.m,
@@ -433,6 +438,7 @@ impl MxM for Matrix {
         &mut self,
         b: &Self,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_mxm(
                 *self.m,
@@ -478,6 +484,7 @@ impl Matrix {
         let mut mask: Option<Matrix> = None;
         if dm_nvals > 0 {
             let mut mk = Matrix::new(nrows, ncols);
+            mk.mark_pending();
             unsafe {
                 let info = GrB_mxm(
                     *mk.m,
@@ -498,6 +505,7 @@ impl Matrix {
         let mut accum: Option<Matrix> = None;
         if dp_nvals > 0 {
             let mut ac = Matrix::new(nrows, ncols);
+            ac.mark_pending();
             unsafe {
                 let info = GrB_mxm(
                     *ac.m,
@@ -515,6 +523,7 @@ impl Matrix {
             }
         }
 
+        self.mark_pending();
         unsafe {
             let (mask_ptr, desc) = match &mask {
                 Some(m) => (*m.m, GrB_DESC_RSC),
@@ -544,6 +553,11 @@ pub struct Matrix {
     /// The underlying GraphBLAS matrix.
     m: Arc<GrB_Matrix>,
     lock: Arc<Mutex<()>>,
+    /// Rust-side flag tracking whether GraphBLAS may have pending work on the
+    /// handle. Set by every mutating op; cleared by `wait()` after materialize.
+    /// Allows `wait()` to skip the GraphBLAS `pending` query (which is unsafe
+    /// to call concurrently with writers) and the lock when nothing's pending.
+    pending: Arc<AtomicBool>,
 }
 
 unsafe impl Send for Matrix {}
@@ -625,6 +639,7 @@ impl Decode<19> for Matrix {
             Ok(Self {
                 m: Arc::new(m),
                 lock: Arc::new(Mutex::new(())),
+                pending: Arc::new(AtomicBool::new(true)),
             })
         }
     }
@@ -707,29 +722,28 @@ impl Matrix {
 
     #[must_use]
     pub fn pending(&self) -> bool {
-        unsafe {
-            let mut pending = MaybeUninit::uninit();
-            let info = GrB_Matrix_get_INT32(
-                *self.m,
-                pending.as_mut_ptr(),
-                GxB_Option_Field::GxB_WILL_WAIT as _,
-            );
-            assert_eq!(
-                info,
-                GrB_Info::GrB_SUCCESS,
-                "GrB_Matrix_get_INT32 failed: {info:?}"
-            );
-            pending.assume_init() == 1
-        }
+        self.pending.load(Ordering::Acquire)
+    }
+
+    /// Mark the matrix as having pending GraphBLAS work. Called by every
+    /// mutating operation. The flag lives on the Rust side so `wait()` can
+    /// short-circuit without invoking GraphBLAS (which is unsafe to query
+    /// concurrently with writers).
+    fn mark_pending(&self) {
+        self.pending.store(true, Ordering::Release);
     }
 
     pub fn wait(&self) {
+        if !self.pending.load(Ordering::Acquire) {
+            return;
+        }
         let lock = self.lock.lock();
-        if self.pending() {
+        if self.pending.load(Ordering::Acquire) {
             unsafe {
                 let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
                 debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
             }
+            self.pending.store(false, Ordering::Release);
         }
         drop(lock);
     }
@@ -745,6 +759,7 @@ impl Matrix {
     }
 
     pub fn clear(&mut self) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_clear(*self.m);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -755,6 +770,7 @@ impl Matrix {
         &mut self,
         b: &Self,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_transpose(*self.m, *b.m, null_mut(), *self.m, GrB_DESC_RCT0);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -766,6 +782,7 @@ impl Matrix {
         mask: &Matrix,
         a: &Matrix,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_transpose(*self.m, *mask.m, null_mut(), *a.m, GrB_DESC_RCT0);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -797,6 +814,7 @@ impl Size for Matrix {
         nrows: u64,
         ncols: u64,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_resize(*self.m, nrows, ncols);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -836,6 +854,7 @@ impl New for Matrix {
             Self {
                 m: Arc::new(m.assume_init()),
                 lock: Arc::new(Mutex::new(())),
+                pending: Arc::new(AtomicBool::new(false)),
             }
         }
     }
@@ -859,6 +878,7 @@ impl Dup<Self> for Matrix {
                 m.assume_init()
             }),
             lock: Arc::new(Mutex::new(())),
+            pending: Arc::new(AtomicBool::new(self.pending.load(Ordering::Relaxed))),
         }
     }
 }
@@ -881,6 +901,7 @@ impl Matrix {
             Self {
                 m: Arc::new(m.assume_init()),
                 lock: Arc::new(Mutex::new(())),
+                pending: Arc::new(AtomicBool::new(false)),
             }
         }
     }
@@ -892,6 +913,7 @@ impl Matrix {
         j: u64,
         value: u64,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_setElement_UINT64(*self.m, value, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -925,6 +947,7 @@ impl Remove for Matrix {
         i: u64,
         j: u64,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_removeElement(*self.m, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -967,6 +990,7 @@ impl Set for Matrix {
         j: u64,
         value: bool,
     ) {
+        self.mark_pending();
         unsafe {
             let info = GrB_Matrix_setElement_BOOL(*self.m, value, i, j);
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
@@ -986,6 +1010,7 @@ impl Matrix {
         if rows.is_empty() {
             return;
         }
+        self.mark_pending();
         let nvals = rows.len() as u64;
         let vals = vec![true; rows.len()];
         unsafe {
@@ -1013,6 +1038,7 @@ impl Matrix {
         if rows.is_empty() {
             return;
         }
+        self.mark_pending();
         let nvals = rows.len() as u64;
         unsafe {
             let info = GrB_Matrix_build_UINT64(
@@ -1063,6 +1089,7 @@ where
     /// A new matrix that is the transpose of the original.
     fn transpose(&self) -> Self {
         let transpose = Self::new(self.ncols(), self.nrows());
+        transpose.mark_pending();
         unsafe {
             let info = GrB_transpose(*transpose.m, null_mut(), null_mut(), *self.m, null_mut());
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -725,11 +725,9 @@ impl Matrix {
 
     pub fn wait(&self) {
         let lock = self.lock.lock();
-        if self.pending() {
-            unsafe {
-                let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
-                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
-            }
+        unsafe {
+            let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
         }
         drop(lock);
     }

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -724,14 +724,14 @@ impl Matrix {
     }
 
     pub fn wait(&self) {
+        let lock = self.lock.lock();
         if self.pending() {
-            let lock = self.lock.lock();
             unsafe {
                 let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
                 debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
             }
-            drop(lock);
         }
+        drop(lock);
     }
 
     #[must_use]

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -69,6 +69,7 @@ use crate::graph::cow::Cow;
 ///
 /// Wraps a base matrix with separate matrices for tracking additions
 /// and deletions, enabling concurrent reads during writes.
+#[derive(Clone)]
 pub struct VersionedMatrix {
     /// Base committed matrix
     m: Cow<Matrix>,
@@ -121,6 +122,18 @@ impl New for VersionedMatrix {
 }
 
 impl VersionedMatrix {
+    pub fn m(&self) -> &Matrix {
+        &self.m
+    }
+
+    pub fn dp(&self) -> &Matrix {
+        &self.dp
+    }
+
+    pub fn dm(&self) -> &Matrix {
+        &self.dm
+    }
+
     /// Wrap an owned `Matrix` as a `VersionedMatrix` with empty delta-plus /
     /// delta-minus.  Used when callers materialize a merged matrix and then
     /// want to expose it through the versioned-matrix iter API without the

--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -178,6 +178,11 @@ pub enum IR {
         /// direction in the graph. The runtime transposes the relationship
         /// scan accordingly.
         transposed: bool,
+        /// Additional hops fused by `fuse_anonymous_traverse`, in traversal
+        /// order. Empty for a single-hop CondTraverse. Each chain hop is an
+        /// anonymous-edge, anonymous-intermediate-node traversal — only the
+        /// final hop's `to` alias is bound at runtime.
+        chain: Vec<Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>>,
     },
     /// Variable-length traversal (BFS) from known nodes
     CondVarLenTraverse {
@@ -516,13 +521,24 @@ impl Display for IR {
             Self::CondTraverse {
                 relationship: rel,
                 transposed,
+                chain,
                 ..
             } => {
-                write!(
-                    f,
-                    "Conditional Traverse | {}",
-                    fmt_rel_with_labels_dir(rel, *transposed)
-                )
+                if chain.is_empty() {
+                    write!(
+                        f,
+                        "Conditional Traverse | {}",
+                        fmt_rel_with_labels_dir(rel, *transposed)
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Conditional Traverse | {} (+ {} fused hop{})",
+                        fmt_rel_with_labels_dir(rel, *transposed),
+                        chain.len(),
+                        if chain.len() == 1 { "" } else { "s" }
+                    )
+                }
             }
             Self::CondVarLenTraverse {
                 relationship: rel, ..
@@ -1449,7 +1465,8 @@ impl Planner {
                     relationship: relationship.clone(),
                     emit_relationship: emit_rel(relationship),
                     sibling_edges: sibling_edges.clone(),
-                    transposed: false
+                    transposed: false,
+                    chain: Vec::new(),
                 });
                 if let Some(filter_expr) = edge_attr_filter {
                     ct = tree!(IR::Filter(Arc::new(filter_expr)), ct);
@@ -1593,7 +1610,8 @@ impl Planner {
                             relationship: relationship.clone(),
                             emit_relationship: emit_rel(relationship),
                             sibling_edges: sibling_edges.clone(),
-                            transposed: false
+                            transposed: false,
+                            chain: Vec::new(),
                         },
                         res
                     );

--- a/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
+++ b/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
@@ -1,0 +1,271 @@
+//! Fuses chains of anonymous-edge `CondTraverse` operators sharing
+//! anonymous, unreferenced intermediate nodes into a single `CondTraverse`
+//! whose runtime executes the chained traversal as a single F·A1·A2·…·An
+//! matrix product, mirroring C FalkorDB's `_should_divide_expression`
+//! decision (`src/arithmetic/algebraic_expression/algebraic_expression_construction.c`).
+//!
+//! ## Plan shape (before)
+//!
+//! ```text
+//! CondTraverse{ rel = (b)-->(c), transposed=false, chain=[] }
+//!   CondTraverse{ rel = (a)-->(b), transposed=false, chain=[] }
+//!     <child>
+//! ```
+//!
+//! ## Plan shape (after)
+//!
+//! ```text
+//! CondTraverse{ rel = (a)-->(b),  // entry hop
+//!               transposed = false,
+//!               chain = [ (b)-->(c) ] }
+//!   <child>
+//! ```
+//!
+//! The intermediate variable `b` must be anonymous (`_anon*` prefix), have no
+//! labels (the v1 runtime does not apply mid-chain label filters), have no
+//! inline attribute predicates, and not be referenced by any ancestor of the
+//! outer CT. Both edges must be anonymous, non-bidirectional, non-variable-
+//! length, and have no inline attribute predicates. Both ops must have empty
+//! `sibling_edges` and `transposed = false`. When any condition fails the
+//! pair is left alone and the fast/slow paths run as before.
+
+use orx_tree::{Bfs, DynTree, NodeRef};
+
+use super::super::IR;
+use super::reduce_expand_into;
+
+fn is_anon(name_opt: Option<&std::sync::Arc<String>>) -> bool {
+    name_opt.is_some_and(|n| n.starts_with("_anon"))
+}
+
+/// True when the QueryRelationship's inline-attrs tree is the empty `{}` map.
+fn rel_attrs_empty(
+    rel: &crate::parser::ast::QueryRelationship<
+        std::sync::Arc<String>,
+        std::sync::Arc<String>,
+        crate::parser::ast::Variable,
+    >
+) -> bool {
+    use crate::parser::ast::ExprIR;
+    let root = rel.attrs.root();
+    matches!(root.data(), ExprIR::Map) && root.children().next().is_none()
+}
+
+fn node_attrs_empty(
+    node: &crate::parser::ast::QueryNode<std::sync::Arc<String>, crate::parser::ast::Variable>
+) -> bool {
+    use crate::parser::ast::ExprIR;
+    let root = node.attrs.root();
+    matches!(root.data(), ExprIR::Map) && root.children().next().is_none()
+}
+
+/// True when no ancestor of `idx` (excluding the parent CondTraverse if any)
+/// references the variable `(var_id, scope_id)`. We reuse the per-IR-node
+/// reference check from `reduce_expand_into`'s helper.
+fn intermediate_unreferenced(
+    plan: &DynTree<IR>,
+    idx: orx_tree::NodeIdx<orx_tree::Dyn<IR>>,
+    var_id: u32,
+    scope_id: u32,
+) -> bool {
+    let mut cur = idx;
+    while let Some(parent) = plan.node(cur).parent() {
+        if reduce_expand_into::ir_references_variable(parent.data(), var_id, scope_id) {
+            return false;
+        }
+        cur = parent.idx();
+    }
+    true
+}
+
+/// Returns true when `parent_ct` (outer) and `child_ct` (its only CT child)
+/// can be fused into a single CondTraverse.
+fn can_fuse(
+    parent_ct: &IR,
+    child_ct: &IR,
+    plan: &DynTree<IR>,
+    parent_idx: orx_tree::NodeIdx<orx_tree::Dyn<IR>>,
+) -> bool {
+    let (
+        IR::CondTraverse {
+            relationship: p_rel,
+            emit_relationship: p_emit,
+            sibling_edges: p_sib,
+            transposed: p_trans,
+            chain: _p_chain,
+        },
+        IR::CondTraverse {
+            relationship: c_rel,
+            emit_relationship: c_emit,
+            sibling_edges: c_sib,
+            transposed: c_trans,
+            chain: c_chain,
+        },
+    ) = (parent_ct, child_ct)
+    else {
+        return false;
+    };
+
+    // Direction simplification: only fuse when both hops are storage-direction.
+    if *p_trans || *c_trans {
+        return false;
+    }
+    // Anonymous edges only (criteria for skipping edge binding mid-chain and
+    // for matching C's `_should_populate_edge` gate).
+    if !is_anon(p_rel.alias.name.as_ref()) || !is_anon(c_rel.alias.name.as_ref()) {
+        return false;
+    }
+    // emit_relationship must be off on both — non-anonymous edges aren't
+    // collapsible (would lose per-edge bindings). reduce_expand_into has
+    // already turned off emit for unreferenced anonymous edges.
+    if *p_emit || *c_emit {
+        return false;
+    }
+    // Sibling edge uniqueness needs per-edge inspection — skip.
+    if !p_sib.is_empty() || !c_sib.is_empty() {
+        return false;
+    }
+    // No bidirectional or variable-length hops.
+    if p_rel.bidirectional || c_rel.bidirectional {
+        return false;
+    }
+    if p_rel.min_hops.is_some() || c_rel.min_hops.is_some() {
+        return false;
+    }
+    // No inline attribute predicates on edges or endpoints.
+    if !rel_attrs_empty(p_rel) || !rel_attrs_empty(c_rel) {
+        return false;
+    }
+    // Intermediate node = parent.from = child.to. Must be the same alias.
+    if p_rel.from.alias.id != c_rel.to.alias.id
+        || p_rel.from.alias.scope_id != c_rel.to.alias.scope_id
+    {
+        return false;
+    }
+    // Intermediate node anonymous, no labels, no inline attrs.
+    let intermediate = &p_rel.from;
+    if !is_anon(intermediate.alias.name.as_ref()) {
+        return false;
+    }
+    if !intermediate.labels.is_empty() {
+        return false;
+    }
+    if !node_attrs_empty(intermediate) {
+        return false;
+    }
+    // Endpoint inline attrs on entry hop's `from` and final `to` are
+    // handled by surrounding Filter nodes (planner emits them above the CT),
+    // so we only need to check the relationships and intermediate here.
+    // The child's `from` and parent's `to` are external to the fused chain.
+    // Already-fused chain entries on the child stay storage-direction by
+    // construction (the pass only ever inserts non-transposed hops).
+    let _ = c_chain;
+
+    // Intermediate must not be referenced by any ancestor of the parent CT,
+    // since after fusion it disappears from the binding set. (Filters that
+    // reference the intermediate sit between parent and grandparent — those
+    // ancestors are skipped by intermediate_unreferenced's BFS walk, so we
+    // explicitly check the parent's siblings/ancestors via the same helper.)
+    if !intermediate_unreferenced(
+        plan,
+        parent_idx,
+        intermediate.alias.id,
+        intermediate.alias.scope_id,
+    ) {
+        return false;
+    }
+    true
+}
+
+pub(super) fn fuse_anonymous_traverse(plan: &mut DynTree<IR>) {
+    loop {
+        // Find one fusable pair (parent CT, child CT). Restart after each
+        // mutation to avoid stale node indices.
+        let mut fuse_target: Option<orx_tree::NodeIdx<orx_tree::Dyn<IR>>> = None;
+        for idx in plan.root().indices::<Bfs>() {
+            let parent_node = plan.node(idx);
+            if !matches!(parent_node.data(), IR::CondTraverse { .. }) {
+                continue;
+            }
+            if parent_node.num_children() != 1 {
+                continue;
+            }
+            let child_node = parent_node.child(0);
+            if !matches!(child_node.data(), IR::CondTraverse { .. }) {
+                continue;
+            }
+            if can_fuse(parent_node.data(), child_node.data(), plan, idx) {
+                fuse_target = Some(idx);
+                break;
+            }
+        }
+
+        let Some(parent_idx) = fuse_target else { break };
+
+        // Extract data we need before mutating.
+        let parent_node = plan.node(parent_idx);
+        let child_node = parent_node.child(0);
+        let child_idx = child_node.idx();
+
+        let (parent_rel, parent_emit, parent_sib, parent_chain) = if let IR::CondTraverse {
+            relationship,
+            emit_relationship,
+            sibling_edges,
+            chain,
+            ..
+        } = parent_node.data()
+        {
+            (
+                relationship.clone(),
+                *emit_relationship,
+                sibling_edges.clone(),
+                chain.clone(),
+            )
+        } else {
+            unreachable!();
+        };
+        let (child_rel, child_chain) = if let IR::CondTraverse {
+            relationship,
+            chain,
+            ..
+        } = child_node.data()
+        {
+            (relationship.clone(), chain.clone())
+        } else {
+            unreachable!();
+        };
+
+        // Build the merged chain: child's existing chain (entry-side hops),
+        // then the parent's relationship, then parent's existing chain.
+        let mut merged_chain = child_chain;
+        merged_chain.push(parent_rel);
+        merged_chain.extend(parent_chain.into_iter());
+
+        // Detach grandchildren (child CT's subtree) so we can reattach them
+        // under the merged op.
+        let grandchild_indices: Vec<_> = plan.node(child_idx).children().map(|c| c.idx()).collect();
+        let grandchild_trees: Vec<DynTree<IR>> = grandchild_indices
+            .into_iter()
+            .map(|g_idx| plan.node_mut(g_idx).clone_as_tree())
+            .collect();
+
+        // Replace parent's data with the merged CondTraverse, then prune
+        // and reattach grandchildren.
+        *plan.node_mut(parent_idx).data_mut() = IR::CondTraverse {
+            relationship: child_rel,
+            emit_relationship: parent_emit,
+            sibling_edges: parent_sib,
+            transposed: false,
+            chain: merged_chain,
+        };
+        // Prune all current children of parent (only the child CT).
+        while plan.node(parent_idx).num_children() > 0 {
+            let c_idx = plan.node(parent_idx).child(0).idx();
+            plan.node_mut(c_idx).prune();
+        }
+        // Attach the original grandchildren under the merged op.
+        for g_tree in grandchild_trees {
+            plan.node_mut(parent_idx).push_child_tree(g_tree);
+        }
+    }
+}

--- a/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
+++ b/graph/src/planner/optimizer/fuse_anonymous_traverse.rs
@@ -249,8 +249,10 @@ pub(super) fn fuse_anonymous_traverse(plan: &mut DynTree<IR>) {
             .map(|g_idx| plan.node_mut(g_idx).clone_as_tree())
             .collect();
 
-        // Replace parent's data with the merged CondTraverse, then prune
-        // and reattach grandchildren.
+        // Replace parent's data with the merged CondTraverse, then attach
+        // grandchildren and prune the original child CT last — pruning may
+        // invalidate other NodeIdx values under orx-tree's default memory
+        // policy, so it must be the final mutation that uses parent_idx.
         *plan.node_mut(parent_idx).data_mut() = IR::CondTraverse {
             relationship: child_rel,
             emit_relationship: parent_emit,
@@ -258,14 +260,12 @@ pub(super) fn fuse_anonymous_traverse(plan: &mut DynTree<IR>) {
             transposed: false,
             chain: merged_chain,
         };
-        // Prune all current children of parent (only the child CT).
-        while plan.node(parent_idx).num_children() > 0 {
-            let c_idx = plan.node(parent_idx).child(0).idx();
-            plan.node_mut(c_idx).prune();
-        }
-        // Attach the original grandchildren under the merged op.
+        // Attach the original grandchildren under the merged op (now parent
+        // has [child_CT, g1, g2, ...]).
         for g_tree in grandchild_trees {
             plan.node_mut(parent_idx).push_child_tree(g_tree);
         }
+        // Prune the original child CT, leaving [g1, g2, ...].
+        plan.node_mut(child_idx).prune();
     }
 }

--- a/graph/src/planner/optimizer/mod.rs
+++ b/graph/src/planner/optimizer/mod.rs
@@ -47,6 +47,7 @@
 
 mod absorb_edge_filters_into_vlt;
 mod eliminate_true_filters;
+mod fuse_anonymous_traverse;
 mod push_filters_down;
 mod reduce_count;
 mod reduce_expand_into;
@@ -70,6 +71,7 @@ use super::IR;
 
 use absorb_edge_filters_into_vlt::absorb_edge_filters_into_vlt;
 use eliminate_true_filters::eliminate_true_filters;
+use fuse_anonymous_traverse::fuse_anonymous_traverse;
 use push_filters_down::push_filters_down;
 use reduce_count::reduce_count;
 use reduce_expand_into::reduce_expand_into;
@@ -125,6 +127,7 @@ pub fn optimize(
     eliminate_true_filters(&mut optimized_plan, params);
     select_scan_node(&mut optimized_plan, graph);
     push_filters_down(&mut optimized_plan);
+    fuse_anonymous_traverse(&mut optimized_plan);
     replace_cartesian_with_hash_join(&mut optimized_plan);
     absorb_edge_filters_into_vlt(&mut optimized_plan);
     utilize_index(&mut optimized_plan, graph);

--- a/graph/src/planner/optimizer/reduce_expand_into.rs
+++ b/graph/src/planner/optimizer/reduce_expand_into.rs
@@ -19,7 +19,7 @@ use super::super::IR;
 
 /// Check if any expression in an IR node references a variable with the
 /// given (id, scope_id) pair.
-fn ir_references_variable(
+pub(super) fn ir_references_variable(
     ir: &IR,
     var_id: u32,
     scope_id: u32,

--- a/graph/src/planner/optimizer/select_scan_node.rs
+++ b/graph/src/planner/optimizer/select_scan_node.rs
@@ -419,6 +419,7 @@ pub(super) fn select_scan_node(
                     emit_relationship: emit,
                     sibling_edges: edges,
                     transposed: true,
+                    chain: Vec::new(),
                 };
 
                 if is_leaf || child_is_planner_scan {
@@ -523,7 +524,8 @@ pub(super) fn select_scan_node(
                         relationship: rel,
                         emit_relationship: emit,
                         sibling_edges: edges,
-                        transposed
+                        transposed,
+                        chain: Vec::new(),
                     },
                     subtree
                 );
@@ -591,6 +593,7 @@ pub(super) fn select_scan_node(
                         emit_relationship: emit,
                         sibling_edges: edges,
                         transposed: trans,
+                        chain: Vec::new(),
                     };
 
                     op.push_child_tree(scan_subtree);

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -61,6 +61,11 @@ struct CtState {
     /// first `expand_batch`. Cached for op lifetime; safe because writes
     /// are serialized w.r.t. read queries.
     batched_matrix: Option<Matrix>,
+    /// Per-hop matrices for fused chain (same lifetime/safety rules as
+    /// `batched_matrix`). `chain_matrices[i]` corresponds to `chain[i]`.
+    chain_matrices: Vec<Matrix>,
+    /// Per-hop label IDs for `chain[i].to` (post-multiply dst filter).
+    chain_dst_label_ids: Vec<Vec<LabelId>>,
 }
 
 pub struct CondTraverseOp<'a> {
@@ -83,6 +88,11 @@ pub struct CondTraverseOp<'a> {
     /// edge direction in the graph. The scan labels and node assignments are
     /// transposed accordingly.
     transposed: bool,
+    /// Additional fused hops (anonymous-edge, anonymous-intermediate-node)
+    /// to chain after this CT in the F·A path. Empty for single-hop. Each
+    /// hop's `from` is the previous hop's `to` (anonymous & unreferenced);
+    /// only the final hop's `to` alias is bound on the output env.
+    chain: &'a [Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>],
     pub(crate) idx: NodeIdx<Dyn<IR>>,
     /// Maximum number of records this operator should produce. Once reached,
     /// subsequent `next()` calls return `None`. Set by limit propagation.
@@ -153,6 +163,7 @@ impl<'a> CondTraverseOp<'a> {
         emit_relationship: bool,
         sibling_edges: &'a [u32],
         transposed: bool,
+        chain: &'a [Arc<QueryRelationship<Arc<String>, Arc<String>, Variable>>],
         idx: NodeIdx<Dyn<IR>>,
         record_cap: Option<usize>,
     ) -> Self {
@@ -197,13 +208,22 @@ impl<'a> CondTraverseOp<'a> {
                 (None, None)
             };
 
+        // For fused chains the batched path is the ONLY correct path —
+        // expand_row only handles single-hop. The planner inserts a Filter
+        // for any non-empty inline attrs, so attribute predicates are
+        // enforced by surrounding Filter nodes regardless of which path runs.
+        // Single-hop ops keep the existing strict check (expand_row applies
+        // attrs redundantly, but the Filter is still the source of truth).
+        let chain_is_empty = chain.is_empty();
         let batched_eligible = !emit_relationship
             && !rp.bidirectional
             && bidir_dedup.is_none()
             && sibling_edges.is_empty()
-            && attrs_is_static_empty(&rp.attrs)
-            && attrs_is_static_empty(&rp.from.attrs)
-            && attrs_is_static_empty(&rp.to.attrs);
+            && (!chain_is_empty
+                || (attrs_is_static_empty(&rp.attrs)
+                    && attrs_is_static_empty(&rp.from.attrs)
+                    && attrs_is_static_empty(&rp.to.attrs)))
+            && chain.iter().all(|hop| !hop.bidirectional);
 
         Self {
             runtime,
@@ -215,6 +235,7 @@ impl<'a> CondTraverseOp<'a> {
             emit_relationship,
             sibling_edges,
             transposed,
+            chain,
             idx,
             record_cap,
             produced: 0,
@@ -302,6 +323,8 @@ impl<'a> CondTraverseOp<'a> {
             edge_iters,
             no_match,
             batched_matrix: None,
+            chain_matrices: Vec::new(),
+            chain_dst_label_ids: Vec::new(),
         }
     }
 
@@ -350,6 +373,33 @@ impl<'a> CondTraverseOp<'a> {
                 }
             };
             state.batched_matrix = Some(m);
+
+            // Build per-hop matrices and label-id vectors for the fused chain.
+            // If any hop's relationship type is unknown, mark no_match — that
+            // hop can produce no rows, so the overall fused traversal can't
+            // either.
+            for hop in self.chain {
+                let hm = if hop.types.is_empty() {
+                    g.adjacency_matrix().to_matrix()
+                } else {
+                    match g.build_relationship_matrix_unrestricted(&hop.types) {
+                        Some(m) => m,
+                        None => {
+                            state.no_match = true;
+                            return Ok(true);
+                        }
+                    }
+                };
+                state.chain_matrices.push(hm);
+                let dst_labels = match g.resolve_label_ids(&hop.to.labels) {
+                    Some(ids) => ids,
+                    None => {
+                        state.no_match = true;
+                        return Ok(true);
+                    }
+                };
+                state.chain_dst_label_ids.push(dst_labels);
+            }
         }
         let m_merged = state.batched_matrix.as_ref().unwrap();
         let ncols = m_merged.ncols();
@@ -403,23 +453,35 @@ impl<'a> CondTraverseOp<'a> {
         let mut f = Matrix::new(nrows, ncols);
         f.build_bool(&row_idx_buf, &col_idx_buf);
         f.lmxm(m_merged);
+        for hop_m in &state.chain_matrices {
+            f.lmxm(hop_m);
+        }
 
         let (row_is, col_is) = f.extract_tuples_bool();
+        // For fused chains all hops are storage-direction (the fusion pass
+        // refuses to fuse when transposed differs), so `transposed` applies
+        // only to the first hop and the final destination alias comes from
+        // the last hop in `self.chain`.
         let from_alias = if transposed {
             &rp.to.alias
         } else {
             &rp.from.alias
         };
-        let to_alias = if transposed {
-            &rp.from.alias
+        let (to_alias, dst_label_ids) = if let Some(last_hop) = self.chain.last() {
+            (
+                &last_hop.to.alias,
+                state.chain_dst_label_ids.last().unwrap().as_slice(),
+            )
+        } else if transposed {
+            (&rp.from.alias, state.fwd_dst_label_ids.as_slice())
         } else {
-            &rp.to.alias
+            (&rp.to.alias, state.fwd_dst_label_ids.as_slice())
         };
+        let chain_is_empty = self.chain.is_empty();
         for (row_i, dest_raw) in row_is.into_iter().zip(col_is) {
             let dest_id = NodeId::from(dest_raw);
-            // Post-filter dst label (= F * A * R_dst in C's algebra).
-            if !state
-                .fwd_dst_label_ids
+            // Post-filter final-hop dst label (= F * A * R_dst in C's algebra).
+            if !dst_label_ids
                 .iter()
                 .all(|&lid| g.node_has_label_id(dest_id, lid))
             {
@@ -434,42 +496,51 @@ impl<'a> CondTraverseOp<'a> {
             {
                 continue;
             }
-            // Look up one representative edge id (mirrors expand_row's
-            // anonymous-edge fast path). Required because downstream
-            // PathBuilder reads the edge alias even when emit_relationship
-            // is false. Storage matrix orientation: src=F's seed
-            // (matrix-src), dst=F*A result (matrix-dst), regardless of
-            // self.transposed (which only affects alias→storage mapping,
-            // not the underlying matrix orientation since
-            // build_relationship_matrix_unrestricted is non-transposed).
-            let src_id = match env.get(from_alias) {
-                Some(Value::Node(id)) => *id,
-                _ => continue,
-            };
-            let mat_src = u64::from(src_id);
-            let mat_dst = u64::from(dest_id);
-            let key = compound_key(mat_src, mat_dst);
-            let mut found_id: Option<RelationshipId> = None;
-            for cell in &state.edge_iters {
-                let mut it = cell.borrow_mut();
-                it.seek(key, key);
-                if let Some((_, raw_id)) = it.next() {
-                    found_id = Some(RelationshipId::from(raw_id));
-                    break;
+            if chain_is_empty {
+                // Look up one representative edge id (mirrors expand_row's
+                // anonymous-edge fast path). Required because downstream
+                // PathBuilder reads the edge alias even when emit_relationship
+                // is false. Storage matrix orientation: src=F's seed
+                // (matrix-src), dst=F*A result (matrix-dst), regardless of
+                // self.transposed (which only affects alias→storage mapping,
+                // not the underlying matrix orientation since
+                // build_relationship_matrix_unrestricted is non-transposed).
+                let src_id = match env.get(from_alias) {
+                    Some(Value::Node(id)) => *id,
+                    _ => continue,
+                };
+                let mat_src = u64::from(src_id);
+                let mat_dst = u64::from(dest_id);
+                let key = compound_key(mat_src, mat_dst);
+                let mut found_id: Option<RelationshipId> = None;
+                for cell in &state.edge_iters {
+                    let mut it = cell.borrow_mut();
+                    it.seek(key, key);
+                    if let Some((_, raw_id)) = it.next() {
+                        found_id = Some(RelationshipId::from(raw_id));
+                        break;
+                    }
                 }
+                let Some(edge_id) = found_id else { continue };
+                let mut row = env.clone_pooled(runtime.env_pool);
+                row.insert(to_alias, Value::Node(dest_id));
+                row.insert(
+                    &rp.alias,
+                    Value::Relationship(Box::new((
+                        edge_id,
+                        NodeId::from(mat_src),
+                        NodeId::from(mat_dst),
+                    ))),
+                );
+                out.push(row);
+            } else {
+                // Fused chain: edges across hops are anonymous & unreferenced
+                // (enforced by the fusion pass), so no edge id is bound and
+                // no intermediate node alias is exposed.
+                let mut row = env.clone_pooled(runtime.env_pool);
+                row.insert(to_alias, Value::Node(dest_id));
+                out.push(row);
             }
-            let Some(edge_id) = found_id else { continue };
-            let mut row = env.clone_pooled(runtime.env_pool);
-            row.insert(to_alias, Value::Node(dest_id));
-            row.insert(
-                &rp.alias,
-                Value::Relationship(Box::new((
-                    edge_id,
-                    NodeId::from(mat_src),
-                    NodeId::from(mat_dst),
-                ))),
-            );
-            out.push(row);
         }
 
         drop(g);

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -28,7 +28,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use crate::graph::graph::{LabelId, NodeId, RelationshipId};
-use crate::graph::graphblas::matrix::{Matrix, MxM, New, Size};
+use crate::graph::graphblas::matrix::{Matrix, New, Size};
 use crate::graph::graphblas::tensor::compound_key;
 use crate::graph::graphblas::versioned_matrix::{Iter as EdgeIter, VersionedMatrix};
 use crate::parser::ast::{ExprIR, QueryExpr, QueryRelationship, Variable};
@@ -60,10 +60,10 @@ struct CtState {
     /// Materialized base matrix for batched mxm path. Built lazily on
     /// first `expand_batch`. Cached for op lifetime; safe because writes
     /// are serialized w.r.t. read queries.
-    batched_matrix: Option<Matrix>,
+    batched_matrix: Option<VersionedMatrix>,
     /// Per-hop matrices for fused chain (same lifetime/safety rules as
     /// `batched_matrix`). `chain_matrices[i]` corresponds to `chain[i]`.
-    chain_matrices: Vec<Matrix>,
+    chain_matrices: Vec<VersionedMatrix>,
     /// Per-hop label IDs for `chain[i].to` (post-multiply dst filter).
     chain_dst_label_ids: Vec<Vec<LabelId>>,
 }
@@ -362,10 +362,18 @@ impl<'a> CondTraverseOp<'a> {
 
         if state.batched_matrix.is_none() {
             let m = if rp.types.is_empty() {
-                g.adjacency_matrix().to_matrix()
+                g.adjacency_matrix().clone()
+            } else if rp.types.len() == 1 {
+                match g.get_relationship_matrix(&rp.types[0]) {
+                    Some(t) => t.matrix().clone(),
+                    None => {
+                        state.no_match = true;
+                        return Ok(true);
+                    }
+                }
             } else {
                 match g.build_relationship_matrix_unrestricted(&rp.types) {
-                    Some(m) => m,
+                    Some(m) => VersionedMatrix::from_matrix(m),
                     None => {
                         state.no_match = true;
                         return Ok(true);
@@ -380,10 +388,18 @@ impl<'a> CondTraverseOp<'a> {
             // either.
             for hop in self.chain {
                 let hm = if hop.types.is_empty() {
-                    g.adjacency_matrix().to_matrix()
+                    g.adjacency_matrix().clone()
+                } else if hop.types.len() == 1 {
+                    match g.get_relationship_matrix(&hop.types[0]) {
+                        Some(t) => t.matrix().clone(),
+                        None => {
+                            state.no_match = true;
+                            return Ok(true);
+                        }
+                    }
                 } else {
                     match g.build_relationship_matrix_unrestricted(&hop.types) {
-                        Some(m) => m,
+                        Some(m) => VersionedMatrix::from_matrix(m),
                         None => {
                             state.no_match = true;
                             return Ok(true);
@@ -452,9 +468,9 @@ impl<'a> CondTraverseOp<'a> {
 
         let mut f = Matrix::new(nrows, ncols);
         f.build_bool(&row_idx_buf, &col_idx_buf);
-        f.lmxm(m_merged);
+        f.delta_lmxm(m_merged);
         for hop_m in &state.chain_matrices {
-            f.lmxm(hop_m);
+            f.delta_lmxm(hop_m);
         }
 
         let (row_is, col_is) = f.extract_tuples_bool();

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -728,6 +728,7 @@ impl<'a> Runtime<'a> {
                 emit_relationship,
                 sibling_edges,
                 transposed,
+                chain,
             } => {
                 // Account for both limit and skip so the traverse produces
                 // enough rows for a downstream SkipOp + LimitOp pipeline.
@@ -742,6 +743,7 @@ impl<'a> Runtime<'a> {
                     *emit_relationship,
                     sibling_edges,
                     *transposed,
+                    chain,
                     idx,
                     record_cap,
                 )))


### PR DESCRIPTION
## Summary

Adds an optimizer pass that collapses adjacent `CondTraverse` operators into a single fused chain when the intermediate node and edge are anonymous and unreferenced elsewhere. The fused chain executes as a sequence of `F·A` matrix multiplies in `CondTraverseOp`, mirroring the batched traversal pattern used by C FalkorDB's `op_conditional_traverse`.

- New IR field `chain` on `IR::CondTraverse` carrying additional hops
- New optimizer pass `fuse_anonymous_traverse`
- `CondTraverseOp::expand_batch` walks `chain` and applies one `lmxm` per hop, post-filtering by the final hop's destination labels

## Test plan

- [x] \`cargo build --release\`
- [x] \`cargo test -p graph --release --lib\` — 47/47 pass
- [ ] Flow suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional traversals now support fused anonymous multi-hop chains end-to-end (planner + runtime + operator).

* **Performance Improvements**
  * Faster batched traversal execution using delta-aware matrix multiplication and reduced pending-work waits.

* **Refactor**
  * Query planner and optimizer updated to detect and fuse eligible anonymous traversal patterns for more efficient plans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/433)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->