### PR TITLE
perf(matrix): delta-aware mxm for batched traversal

### DIFF
--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -448,6 +448,96 @@ impl MxM for Matrix {
     }
 }
 
+impl Matrix {
+    /// Delta-aware matrix-multiply: `self = self * vm` operating directly on
+    /// the versioned matrix's base/dp/dm components, mirroring C FalkorDB's
+    /// `Delta_mxm`.
+    ///
+    /// Computes `(self * (m + dp))<!(self * dm)>` without first materializing
+    /// the merged matrix. In the common read-only case (`dp.nvals() == 0 &&
+    /// dm.nvals() == 0`) this is a single `GrB_mxm` against `vm.m()`, avoiding
+    /// the eWiseAdd that `to_matrix()` would otherwise pay.
+    pub fn delta_lmxm(
+        &mut self,
+        vm: &super::versioned_matrix::VersionedMatrix,
+    ) {
+        let dp = vm.dp();
+        let dm = vm.dm();
+        let dp_nvals = dp.nvals();
+        let dm_nvals = dm.nvals();
+
+        if dp_nvals == 0 && dm_nvals == 0 {
+            // Hot path: clean snapshot, just self * vm.m()
+            self.lmxm(vm.m());
+            return;
+        }
+
+        let nrows = self.nrows();
+        let ncols = vm.ncols();
+
+        let mut mask: Option<Matrix> = None;
+        if dm_nvals > 0 {
+            let mut mk = Matrix::new(nrows, ncols);
+            unsafe {
+                let info = GrB_mxm(
+                    *mk.m,
+                    null_mut(),
+                    null_mut(),
+                    GxB_ANY_PAIR_BOOL,
+                    *self.m,
+                    *dm.m,
+                    null_mut(),
+                );
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            if mk.nvals() > 0 {
+                mask = Some(mk);
+            }
+        }
+
+        let mut accum: Option<Matrix> = None;
+        if dp_nvals > 0 {
+            let mut ac = Matrix::new(nrows, ncols);
+            unsafe {
+                let info = GrB_mxm(
+                    *ac.m,
+                    null_mut(),
+                    null_mut(),
+                    GxB_ANY_PAIR_BOOL,
+                    *self.m,
+                    *dp.m,
+                    null_mut(),
+                );
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            if ac.nvals() > 0 {
+                accum = Some(ac);
+            }
+        }
+
+        unsafe {
+            let (mask_ptr, desc) = match &mask {
+                Some(m) => (*m.m, GrB_DESC_RSC),
+                None => (null_mut(), null_mut()),
+            };
+            let info = GrB_mxm(
+                *self.m,
+                mask_ptr,
+                null_mut(),
+                GxB_ANY_PAIR_BOOL,
+                *self.m,
+                *vm.m().m,
+                desc,
+            );
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        }
+
+        if let Some(ac) = accum {
+            self.element_wise_add(None, None, Some(&ac), None);
+        }
+    }
+}
+
 /// A wrapper around a GraphBLAS boolean matrix.
 #[derive(Clone)]
 pub struct Matrix {
@@ -634,12 +724,14 @@ impl Matrix {
     }
 
     pub fn wait(&self) {
-        let lock = self.lock.lock();
-        unsafe {
-            let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
-            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        if self.pending() {
+            let lock = self.lock.lock();
+            unsafe {
+                let info = GrB_Matrix_wait(*self.m, GrB_WaitMode::GrB_MATERIALIZE as _);
+                debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            }
+            drop(lock);
         }
-        drop(lock);
     }
 
     #[must_use]

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -69,6 +69,7 @@ use crate::graph::cow::Cow;
 ///
 /// Wraps a base matrix with separate matrices for tracking additions
 /// and deletions, enabling concurrent reads during writes.
+#[derive(Clone)]
 pub struct VersionedMatrix {
     /// Base committed matrix
     m: Cow<Matrix>,
@@ -121,6 +122,18 @@ impl New for VersionedMatrix {
 }
 
 impl VersionedMatrix {
+    pub fn m(&self) -> &Matrix {
+        &self.m
+    }
+
+    pub fn dp(&self) -> &Matrix {
+        &self.dp
+    }
+
+    pub fn dm(&self) -> &Matrix {
+        &self.dm
+    }
+
     /// Wrap an owned `Matrix` as a `VersionedMatrix` with empty delta-plus /
     /// delta-minus.  Used when callers materialize a merged matrix and then
     /// want to expose it through the versioned-matrix iter API without the

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -28,7 +28,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use crate::graph::graph::{LabelId, NodeId, RelationshipId};
-use crate::graph::graphblas::matrix::{Matrix, MxM, New, Size};
+use crate::graph::graphblas::matrix::{Matrix, New, Size};
 use crate::graph::graphblas::tensor::compound_key;
 use crate::graph::graphblas::versioned_matrix::{Iter as EdgeIter, VersionedMatrix};
 use crate::parser::ast::{ExprIR, QueryExpr, QueryRelationship, Variable};
@@ -60,10 +60,10 @@ struct CtState {
     /// Materialized base matrix for batched mxm path. Built lazily on
     /// first `expand_batch`. Cached for op lifetime; safe because writes
     /// are serialized w.r.t. read queries.
-    batched_matrix: Option<Matrix>,
+    batched_matrix: Option<VersionedMatrix>,
     /// Per-hop matrices for fused chain (same lifetime/safety rules as
     /// `batched_matrix`). `chain_matrices[i]` corresponds to `chain[i]`.
-    chain_matrices: Vec<Matrix>,
+    chain_matrices: Vec<VersionedMatrix>,
     /// Per-hop label IDs for `chain[i].to` (post-multiply dst filter).
     chain_dst_label_ids: Vec<Vec<LabelId>>,
 }
@@ -362,10 +362,18 @@ impl<'a> CondTraverseOp<'a> {
 
         if state.batched_matrix.is_none() {
             let m = if rp.types.is_empty() {
-                g.adjacency_matrix().to_matrix()
+                g.adjacency_matrix().clone()
+            } else if rp.types.len() == 1 {
+                match g.get_relationship_matrix(&rp.types[0]) {
+                    Some(t) => t.matrix().clone(),
+                    None => {
+                        state.no_match = true;
+                        return Ok(true);
+                    }
+                }
             } else {
                 match g.build_relationship_matrix_unrestricted(&rp.types) {
-                    Some(m) => m,
+                    Some(m) => VersionedMatrix::from_matrix(m),
                     None => {
                         state.no_match = true;
                         return Ok(true);
@@ -380,10 +388,18 @@ impl<'a> CondTraverseOp<'a> {
             // either.
             for hop in self.chain {
                 let hm = if hop.types.is_empty() {
-                    g.adjacency_matrix().to_matrix()
+                    g.adjacency_matrix().clone()
+                } else if hop.types.len() == 1 {
+                    match g.get_relationship_matrix(&hop.types[0]) {
+                        Some(t) => t.matrix().clone(),
+                        None => {
+                            state.no_match = true;
+                            return Ok(true);
+                        }
+                    }
                 } else {
                     match g.build_relationship_matrix_unrestricted(&hop.types) {
-                        Some(m) => m,
+                        Some(m) => VersionedMatrix::from_matrix(m),
                         None => {
                             state.no_match = true;
                             return Ok(true);
@@ -452,9 +468,9 @@ impl<'a> CondTraverseOp<'a> {
 
         let mut f = Matrix::new(nrows, ncols);
         f.build_bool(&row_idx_buf, &col_idx_buf);
-        f.lmxm(m_merged);
+        f.delta_lmxm(m_merged);
         for hop_m in &state.chain_matrices {
-            f.lmxm(hop_m);
+            f.delta_lmxm(hop_m);
         }
 
         let (row_is, col_is) = f.extract_tuples_bool();


### PR DESCRIPTION
## Summary

- Adds \`Matrix::delta_lmxm\`, mirroring C FalkorDB's \`Delta_mxm\`: when the target \`VersionedMatrix\` has empty \`dp\`/\`dm\` (steady state), collapses to a single \`GrB_mxm\` against the base. Otherwise computes \`(self * dp)\` and a \`!dm\` mask in two extra ops and combines them.
- \`CondTraverseOp\` batched F·A path now keeps each hop as a cheap clone of the source \`VersionedMatrix\` (Cow share) and calls \`delta_lmxm\`, eliminating per-state-init dup overhead.

> Stacked on #433. Merge after the fusion PR.

## Test plan

- [x] \`cargo build --release\`
- [x] \`cargo test -p graph --release --lib\` — 47/47 pass