### PR TITLE
fix(runtime): prevent integer-overflow panics that crashed the server

### DIFF
--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -767,9 +767,16 @@ impl<'a> ExprEval<'a> {
                         if (start > end && step > 0) || (start < end && step < 0) {
                             return Ok(ValueIter::Empty);
                         }
-                        let length = (end - start) / step + 1;
-                        #[allow(clippy::cast_lossless)]
-                        if length > u32::MAX as i64 {
+                        let span = if end >= start {
+                            (end as i128) - (start as i128)
+                        } else {
+                            (start as i128) - (end as i128)
+                        };
+                        let abs_step = (step as i128).unsigned_abs();
+                        let length = (span.unsigned_abs() / abs_step)
+                            .checked_add(1)
+                            .ok_or_else(|| String::from("Range too large"))?;
+                        if length > u32::MAX as u128 {
                             return Err(String::from("Range too large"));
                         }
 
@@ -783,7 +790,7 @@ impl<'a> ExprEval<'a> {
                         Ok(ValueIter::RangeDown {
                             current: start,
                             end,
-                            step: (-step) as usize,
+                            step: step.unsigned_abs() as usize,
                         })
                     }
                     _ => {

--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -418,7 +418,9 @@ impl<'a> ExprEval<'a> {
                     }
                 },
                 ExprIR::Negate => match self.eval(ir, node.child(0).idx(), env, agg_group_key)? {
-                    Value::Int(i) => res.push(Value::Int(-i)),
+                    Value::Int(i) => res.push(Value::Int(i.checked_neg().ok_or_else(|| {
+                        String::from("ArgumentError: integer overflow in unary minus")
+                    })?)),
                     Value::Float(f) => res.push(Value::Float(-f)),
                     Value::Null => res.push(Value::Null),
                     v => {
@@ -1373,7 +1375,9 @@ pub fn evaluate_param(expr: &DynNode<ExprIR<Arc<String>>>) -> Result<Value, Stri
         ExprIR::Negate => {
             let v = evaluate_param(&expr.child(0))?;
             match v {
-                Value::Int(i) => Ok(Value::Int(-i)),
+                Value::Int(i) => Ok(Value::Int(i.checked_neg().ok_or_else(|| {
+                    String::from("ArgumentError: integer overflow in unary minus")
+                })?)),
                 Value::Float(f) => Ok(Value::Float(-f)),
                 _ => Ok(Value::Null),
             }

--- a/graph/src/runtime/functions/math.rs
+++ b/graph/src/runtime/functions/math.rs
@@ -301,7 +301,7 @@ pub fn register(funcs: &mut Functions) {
                     Ok(Value::List(Arc::new(
                         (end..=start)
                             .rev()
-                            .step_by((-(step as i128)) as usize)
+                            .step_by(step.unsigned_abs() as usize)
                             .map(Value::Int)
                             .collect(),
                     )))

--- a/graph/src/runtime/functions/math.rs
+++ b/graph/src/runtime/functions/math.rs
@@ -45,7 +45,10 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Int, Type::Float, Type::Null]),
         fn abs(_, args) {
             match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Int(n.abs())),
+                Some(Value::Int(n)) => n
+                    .checked_abs()
+                    .map(Value::Int)
+                    .ok_or_else(|| String::from("ArgumentError: integer overflow in abs()")),
                 Some(Value::Float(f)) => Ok(Value::Float(f.abs())),
                 Some(Value::Null) => Ok(Value::Null),
 
@@ -271,9 +274,20 @@ pub fn register(funcs: &mut Functions) {
                         return Ok(Value::List(Arc::new(thin_vec![])));
                     }
 
-                    let length = (end - start) / step + 1;
-                    #[allow(clippy::cast_lossless)]
-                    if length > u32::MAX as i64 {
+                    // Compute (|end - start| / |step|) + 1 with overflow checks.
+                    // We use unsigned absolute differences so that
+                    // `range(i64::MIN, i64::MAX)` doesn't overflow the
+                    // intermediate subtraction.
+                    let span = if end >= start {
+                        (end as i128) - (start as i128)
+                    } else {
+                        (start as i128) - (end as i128)
+                    };
+                    let abs_step = (step as i128).unsigned_abs();
+                    let length = (span.unsigned_abs() / abs_step)
+                        .checked_add(1)
+                        .ok_or_else(|| String::from("Range too large"))?;
+                    if length > u32::MAX as u128 {
                         return Err(String::from("Range too large"));
                     }
                     if step > 0 {
@@ -287,7 +301,7 @@ pub fn register(funcs: &mut Functions) {
                     Ok(Value::List(Arc::new(
                         (end..=start)
                             .rev()
-                            .step_by((-step) as usize)
+                            .step_by((-(step as i128)) as usize)
                             .map(Value::Int)
                             .collect(),
                     )))

--- a/graph/src/runtime/functions/temporal.rs
+++ b/graph/src/runtime/functions/temporal.rs
@@ -381,9 +381,17 @@ pub fn construct_duration_secs(
     minutes: i64,
     seconds: i64,
 ) -> Result<i64, String> {
-    let total_month_offset = years * 12 + months;
-    let base_year = 1970i32 + (total_month_offset as i32).div_euclid(12);
-    let base_month = ((total_month_offset as i32).rem_euclid(12) + 1) as u32;
+    let total_month_offset = years
+        .checked_mul(12)
+        .and_then(|y| y.checked_add(months))
+        .ok_or_else(|| format!("Duration overflow: years={years}, months={months}"))?;
+    let total_month_offset_i32: i32 = total_month_offset
+        .try_into()
+        .map_err(|_| format!("Duration out of range: years={years}, months={months}"))?;
+    let base_year = 1970i32
+        .checked_add(total_month_offset_i32.div_euclid(12))
+        .ok_or_else(|| format!("Duration out of range: years={years}, months={months}"))?;
+    let base_month = (total_month_offset_i32.rem_euclid(12) + 1) as u32;
 
     let anchor = NaiveDate::from_ymd_opt(base_year, base_month, 1)
         .ok_or_else(|| format!("Invalid duration: years={years}, months={months}"))?
@@ -391,8 +399,21 @@ pub fn construct_duration_secs(
         .ok_or("Invalid anchor time")?;
 
     let anchor_ts = anchor.and_utc().timestamp();
-    let extra = (weeks * 7 + days) * 86400 + hours * 3600 + minutes * 60 + seconds;
-    Ok(anchor_ts + extra)
+    let extra = weeks
+        .checked_mul(7)
+        .and_then(|w| w.checked_add(days))
+        .and_then(|wd| wd.checked_mul(86400))
+        .and_then(|s| hours.checked_mul(3600).and_then(|h| s.checked_add(h)))
+        .and_then(|s| minutes.checked_mul(60).and_then(|m| s.checked_add(m)))
+        .and_then(|s| s.checked_add(seconds))
+        .ok_or_else(|| {
+            format!(
+                "Duration overflow: weeks={weeks}, days={days}, hours={hours}, minutes={minutes}, seconds={seconds}"
+            )
+        })?;
+    anchor_ts
+        .checked_add(extra)
+        .ok_or_else(|| "Duration overflow when combining components".to_string())
 }
 
 /// Decompose a duration (seconds from epoch) into (years, months, remaining_seconds).

--- a/tests/test_overflow_crashes.py
+++ b/tests/test_overflow_crashes.py
@@ -37,33 +37,33 @@ def _ensure_alive():
 
 
 def test_abs_i64_min_does_not_crash():
-    with pytest.raises(ResponseError, match="(?i)overflow"):
+    with pytest.raises(ResponseError, match=r"(?i)overflow"):
         common.g.query("RETURN abs(-9223372036854775808)")
     _ensure_alive()
 
 
 def test_unary_minus_i64_min_does_not_crash():
-    with pytest.raises(ResponseError, match="(?i)overflow"):
+    with pytest.raises(ResponseError, match=r"(?i)overflow"):
         common.g.query("WITH -9223372036854775808 AS x RETURN -x")
     _ensure_alive()
 
 
 def test_unary_minus_i64_min_param_does_not_crash():
     # Same bug, exercised through the parameter-evaluation path.
-    with pytest.raises(ResponseError, match="(?i)overflow"):
+    with pytest.raises(ResponseError, match=r"(?i)overflow"):
         common.g.query("CYPHER x=-9223372036854775808 RETURN -$x")
     _ensure_alive()
 
 
 def test_range_to_i64_max_does_not_crash():
-    with pytest.raises(ResponseError, match="(?i)range too large"):
+    with pytest.raises(ResponseError, match=r"(?i)range too large"):
         common.g.query("RETURN range(0, 9223372036854775807)")
     _ensure_alive()
 
 
 def test_range_full_int_span_does_not_crash():
     # Spans the entire i64 domain; old code overflowed `end - start`.
-    with pytest.raises(ResponseError, match="(?i)range too large"):
+    with pytest.raises(ResponseError, match=r"(?i)range too large"):
         common.g.query(
             "RETURN range(-9223372036854775808, 9223372036854775807)"
         )

--- a/tests/test_overflow_crashes.py
+++ b/tests/test_overflow_crashes.py
@@ -85,3 +85,56 @@ def test_range_normal_values_still_work():
     assert res.result_set == [[[1, 2, 3, 4, 5]]]
     res = common.g.query("RETURN range(10, 2, -2)")
     assert res.result_set == [[[10, 8, 6, 4, 2]]]
+
+
+# --- Iterator-path tests (UNWIND uses eval_iter_expr, a separate code path) ---
+
+def test_unwind_range_to_i64_max_does_not_crash():
+    with pytest.raises(ResponseError, match=r"(?i)range too large"):
+        common.g.query("UNWIND range(0, 9223372036854775807) AS x RETURN x")
+    _ensure_alive()
+
+
+def test_unwind_range_full_int_span_does_not_crash():
+    with pytest.raises(ResponseError, match=r"(?i)range too large"):
+        common.g.query(
+            "UNWIND range(-9223372036854775808, 9223372036854775807) AS x RETURN x"
+        )
+    _ensure_alive()
+
+
+def test_unwind_range_normal_values_still_work():
+    res = common.g.query("UNWIND range(1, 5) AS x RETURN collect(x)")
+    assert res.result_set == [[[1, 2, 3, 4, 5]]]
+    res = common.g.query("UNWIND range(10, 2, -2) AS x RETURN collect(x)")
+    assert res.result_set == [[[10, 8, 6, 4, 2]]]
+
+
+# --- Duration overflow tests --------------------------------------------------
+# `construct_duration_secs` previously used unchecked i64 arithmetic on the
+# user-supplied duration components, panicking (and crashing the server) on
+# values such as i64::MAX or i64::MIN.
+
+@pytest.mark.parametrize("query", [
+    "RETURN duration({years: 9223372036854775807})",
+    "RETURN duration({years: -9223372036854775808})",
+    "RETURN duration({days: 9223372036854775807})",
+    "RETURN duration({days: -9223372036854775808})",
+    "RETURN duration({weeks: 9223372036854775807})",
+    "RETURN duration({hours: 9223372036854775807})",
+    "RETURN duration({minutes: 9223372036854775807})",
+    "RETURN date('2024-01-01') + duration({days: 9223372036854775807})",
+    "RETURN duration({days: 1}) + duration({days: 9223372036854775807})",
+])
+def test_duration_overflow_does_not_crash(query):
+    with pytest.raises(ResponseError, match=r"(?i)overflow|out of range"):
+        common.g.query(query)
+    _ensure_alive()
+
+
+def test_duration_normal_values_still_work():
+    res = common.g.query(
+        "RETURN duration({days: 1, hours: 2, minutes: 3, seconds: 4})"
+    )
+    # Duration is rendered as its string form; just ensure we got one row.
+    assert len(res.result_set) == 1

--- a/tests/test_overflow_crashes.py
+++ b/tests/test_overflow_crashes.py
@@ -1,0 +1,87 @@
+"""Regression tests for integer-overflow runtime crashes.
+
+Each of the following queries used to crash the server (SIGSEGV / Rust panic
+abort) before being fixed:
+
+  * abs(i64::MIN)             -> n.abs() overflow panic
+  * unary minus on i64::MIN   -> -i overflow panic
+  * range(0, i64::MAX)        -> length overflow / huge allocation
+
+The fixes replace the offending arithmetic with `checked_neg` / `checked_abs`
+and saturating/checked length math in `range`. These tests assert that the
+server (a) does NOT crash and (b) returns a clear error to the client.
+"""
+
+from redis import ResponseError
+import pytest
+
+import common
+
+
+def setup_module(module):
+    common.start_redis()
+
+
+def teardown_module(module):
+    common.shutdown_redis()
+
+
+def setup_function(function):
+    if common.g.name in common.client.list_graphs():
+        common.g.delete()
+
+
+def _ensure_alive():
+    # If the server crashed, this raises ConnectionError instead of returning.
+    assert common.client.connection.ping()
+
+
+def test_abs_i64_min_does_not_crash():
+    with pytest.raises(ResponseError, match="(?i)overflow"):
+        common.g.query("RETURN abs(-9223372036854775808)")
+    _ensure_alive()
+
+
+def test_unary_minus_i64_min_does_not_crash():
+    with pytest.raises(ResponseError, match="(?i)overflow"):
+        common.g.query("WITH -9223372036854775808 AS x RETURN -x")
+    _ensure_alive()
+
+
+def test_unary_minus_i64_min_param_does_not_crash():
+    # Same bug, exercised through the parameter-evaluation path.
+    with pytest.raises(ResponseError, match="(?i)overflow"):
+        common.g.query("CYPHER x=-9223372036854775808 RETURN -$x")
+    _ensure_alive()
+
+
+def test_range_to_i64_max_does_not_crash():
+    with pytest.raises(ResponseError, match="(?i)range too large"):
+        common.g.query("RETURN range(0, 9223372036854775807)")
+    _ensure_alive()
+
+
+def test_range_full_int_span_does_not_crash():
+    # Spans the entire i64 domain; old code overflowed `end - start`.
+    with pytest.raises(ResponseError, match="(?i)range too large"):
+        common.g.query(
+            "RETURN range(-9223372036854775808, 9223372036854775807)"
+        )
+    _ensure_alive()
+
+
+def test_abs_normal_values_still_work():
+    res = common.g.query("RETURN abs(-3), abs(3), abs(-1.5), abs(NULL)")
+    assert res.result_set == [[3, 3, 1.5, None]]
+
+
+def test_unary_minus_normal_values_still_work():
+    res = common.g.query("RETURN -5, -(-7), -1.25, -NULL")
+    assert res.result_set == [[-5, 7, -1.25, None]]
+
+
+def test_range_normal_values_still_work():
+    res = common.g.query("RETURN range(1, 5)")
+    assert res.result_set == [[[1, 2, 3, 4, 5]]]
+    res = common.g.query("RETURN range(10, 2, -2)")
+    assert res.result_set == [[[10, 8, 6, 4, 2]]]


### PR DESCRIPTION
## Summary
Three Cypher queries could crash the server (SIGSEGV on debug builds; silent overflow + multi-EB allocation / abort on release builds):

```cypher
RETURN abs(-9223372036854775808)
WITH -9223372036854775808 AS x RETURN -x
RETURN range(0, 9223372036854775807)
```

All three were caused by unchecked `i64` arithmetic in the runtime.

## Changes
- `graph/src/runtime/functions/math.rs::abs` — use `checked_abs` and return an `ArgumentError` on `i64::MIN` instead of `n.abs()` (which panics).
- `graph/src/runtime/eval.rs::Negate` (both the main evaluator and the parameter evaluator) — use `checked_neg` so that negating `i64::MIN` returns a clean error instead of panicking.
- `graph/src/runtime/functions/math.rs::range` — compute the result length in `i128` with `unsigned_abs` + `checked_add` so the `length > u32::MAX` guard always fires before any allocation. Previously the `(end - start) / step + 1` expression overflowed and the wrapped negative value bypassed the guard, leading to OOM/abort.
- `tests/test_overflow_crashes.py` — regression tests for each scenario (asserting a clean `ResponseError` and that the server is still alive afterwards) plus sanity tests that normal inputs still work.

## Testing
- `cargo build` ✅
- `cargo test -p graph` ✅ (47 passed)
- `cargo clippy --all-targets` ✅ (no new warnings)
- `pytest tests/test_overflow_crashes.py -vv` ✅ (8 passed)

Before the fix, each of the three queries killed `redis-server` (`Connection refused` immediately after issuing the query). After the fix, each returns a clear error message:
```
ArgumentError: integer overflow in abs()
ArgumentError: integer overflow in unary minus
Range too large
```

## Memory / Performance Impact
Negligible. Two extra `checked_*` calls on already-cheap operations and an `i128` length computation in `range` (a single arithmetic step before allocation).

## Related Issues
None — discovered during a runtime crash audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integer overflow operations now return proper error messages instead of crashing the server.
  * Unary negation, absolute value, and range functions now handle edge cases safely with overflow detection.
  * Improved stability when performing mathematical operations near integer boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/436)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->