### PR TITLE
ci: multi-arch toolchain image to GHCR + GraphBLAS pin

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,0 +1,88 @@
+# Build the toolchain image (build/Dockerfile) for both linux/amd64 and linux/arm64
+# and push it to ghcr.io/falkordb/falkordb-build:latest as a multi-arch manifest.
+# This image is the BUILD_IMAGE that build/runtime/Dockerfile's chef stage uses to
+# compile libfalkordb.so — having it multi-arch is what unblocks arm64 in
+# .github/workflows/build-image.yml.
+#
+# Triggers:
+#   - workflow_dispatch: explicit refresh
+#   - push to main when build/Dockerfile or this workflow changes
+#
+# Note: this does NOT replace aviavni/falkordb-build (still used by the rest of
+# rust-pr.yml's containerized jobs). Migrating those is a separate concern.
+
+name: Build toolchain image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'build/Dockerfile'
+      - '.github/workflows/build-toolchain.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-toolchain-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64,     platform: linux/amd64, runner: ubuntu-latest }
+          - { arch: arm64v8, platform: linux/arm64, runner: ubuntu-24.04-arm }
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (${{ matrix.arch }})
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: ./build
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          tags: ghcr.io/falkordb/falkordb-build:latest-${{ matrix.arch }}
+          cache-from: type=registry,ref=ghcr.io/falkordb/falkordb-build:buildcache-${{ matrix.arch }}
+          cache-to:   type=registry,ref=ghcr.io/falkordb/falkordb-build:buildcache-${{ matrix.arch }},mode=max
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assemble multi-arch manifest
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t ghcr.io/falkordb/falkordb-build:latest \
+            ghcr.io/falkordb/falkordb-build:latest-x64 \
+            ghcr.io/falkordb/falkordb-build:latest-arm64v8

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,15 +1,10 @@
-# Build the toolchain image (build/Dockerfile) for both linux/amd64 and linux/arm64
-# and push it to ghcr.io/falkordb/falkordb-build:latest as a multi-arch manifest.
-# This image is the BUILD_IMAGE that build/runtime/Dockerfile's chef stage uses to
-# compile libfalkordb.so — having it multi-arch is what unblocks arm64 in
-# .github/workflows/build-image.yml.
+# Builds the toolchain image (build/Dockerfile) for linux/amd64 and linux/arm64
+# and publishes it as a multi-arch manifest at ghcr.io/falkordb/falkordb-build:latest.
 #
 # Triggers:
-#   - workflow_dispatch: explicit refresh
 #   - push to main when build/Dockerfile or this workflow changes
-#
-# Note: this does NOT replace aviavni/falkordb-build (still used by the rest of
-# rust-pr.yml's containerized jobs). Migrating those is a separate concern.
+#   - workflow_dispatch (UI / API) — runs only publish from refs/heads/main, so
+#     dispatching from a feature branch is a no-op (won't overwrite :latest).
 
 name: Build toolchain image
 
@@ -30,6 +25,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -65,6 +61,7 @@ jobs:
 
   manifest:
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,11 +15,6 @@ RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
-# GraphBLAS pinned to the latest tagged release (v10.3.1, May 2025). The
-# previous `dev2` branch tracking led to non-reproducible builds and broke
-# entirely when upstream landed a mid-flight arena rewrite — the build/Dockerfile
-# can't be rebuilt cleanly off dev2 HEAD today. v10.3.1 is what the C-port
-# vendors as well.
 RUN git clone --branch v10.3.1 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 
 RUN cd GraphBLAS && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,7 +15,7 @@ RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
-RUN git clone --branch v10.3.1 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+RUN git clone --branch v10.3.1 --single-branch --depth 1 https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 
 RUN cd GraphBLAS && \
     make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on' JOBS=2 CC=clang-22 CXX=clang++-22 && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,8 +15,12 @@ RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
-RUN git clone --branch dev2 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
-# RUN git clone --branch v10.3.1 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+# GraphBLAS pinned to the latest tagged release (v10.3.1, May 2025). The
+# previous `dev2` branch tracking led to non-reproducible builds and broke
+# entirely when upstream landed a mid-flight arena rewrite — the build/Dockerfile
+# can't be rebuilt cleanly off dev2 HEAD today. v10.3.1 is what the C-port
+# vendors as well.
+RUN git clone --branch v10.3.1 --single-branch https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 
 RUN cd GraphBLAS && \
     make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on' JOBS=2 CC=clang-22 CXX=clang++-22 && \


### PR DESCRIPTION
## Summary

Publishes the toolchain image (the one `build/Dockerfile` describes) as a multi-arch manifest at **`ghcr.io/falkordb/falkordb-build:latest`** and pins **GraphBLAS to `v10.3.1`** so the build is reproducible. Together these unblock arm64 in the runtime release pipeline ([#451](../pull/451)) and prevent future PRs that touch `build/Dockerfile` from accidentally rebuilding against an in-flight upstream dev branch.

## What's in the box

| File | Purpose |
|------|---------|
| `.github/workflows/build-toolchain.yml` (NEW) | Matrix builds the toolchain image on native x64 + arm64 runners, pushes per-arch tags `:latest-x64` / `:latest-arm64v8`, assembles multi-arch `:latest`. Triggers: `workflow_dispatch` + `push` to main when `build/Dockerfile` or this workflow changes. Registry cache at `:buildcache-<arch>`. |
| `build/Dockerfile` | `--branch dev2` → `--branch v10.3.1`. Comment explains why. |

## Why pin GraphBLAS

- `aviavni/falkordb-build:latest` was last built April 14, 2026, when dev2 was at unreleased `10.4.0`. The image **works**, but reproducing it requires the specific dev2 SHA from that day, which isn't recorded anywhere.
- Since then, dev2 has had a multi-week arena rewrite landing in pieces. Building `build/Dockerfile` today against dev2 HEAD produces six clang errors in `Source/arena/GB_set_arenas.c` — every PR that touches `build/Dockerfile` hits this (we verified on PR #451 a few cycles back).
- `v10.3.1` is the latest tagged release. The C-port vendors a derivative of it. It's the most stable pin available today.
- If the Rust port turns out to depend on a post-v10.3.1 API, we'll find out via a clean compile error and can re-evaluate — but the existing `Cargo.toml` doesn't suggest such a dependency.

## What this does NOT change

- `aviavni/falkordb-build:latest` (the existing Docker Hub toolchain image) is untouched. The rest of CI continues to use it via `container:` references in `rust-pr.yml`, `rust-push.yml`, `flow-tests-sanitizer.yml`.
- `build/runtime/Dockerfile`'s `BUILD_IMAGE` default is **not** switched to GHCR yet. That switch (plus restoring arm64 in `build-image.yml`'s matrix) lands as a follow-up after this PR merges and the GHCR image is built and linked.

## Pre-merge prerequisites (outside the repo)

- After merge, the path trigger fires `build-toolchain.yml` on the merge commit. **First push creates `ghcr.io/falkordb/falkordb-build` as a new GHCR package — it starts private and unlinked.** An org admin must:
  1. Flip the package to **public** (Settings → Packages → falkordb-build → Change visibility).
  2. **Link it to this repo** (`falkordb-rs-next-gen`) so downstream workflows authenticated via `GITHUB_TOKEN` can push/pull.
- No new secrets required — the workflow uses the auto-injected `GITHUB_TOKEN` for GHCR.

## Sequencing

```
This PR → merge
   ↓
push trigger fires build-toolchain.yml
   ↓
ghcr.io/falkordb/falkordb-build:latest exists (multi-arch)
   ↓
admin makes it public + links to repo
   ↓
follow-up PR on top of #451: switch BUILD_IMAGE + restore arm64 in build-image.yml matrix
```

## Test plan

- [x] `actionlint` against `build-toolchain.yml`: no errors
- [ ] After merge, `build-toolchain.yml` runs successfully on both arches (verified via Actions tab)
- [ ] `docker buildx imagetools inspect ghcr.io/falkordb/falkordb-build:latest` shows two manifests (linux/amd64 + linux/arm64)
- [ ] `docker pull --platform linux/arm64 ghcr.io/falkordb/falkordb-build:latest` succeeds after package is linked + made public
- [ ] Follow-up PR restoring arm64 in build-image.yml turns green on the arm64 cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure with multi-architecture Docker image support for AMD64 and ARM64 platforms
  * Updated GraphBLAS dependency to version 10.3.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->