### PR TITLE
ci(flow): docker-per-class test orchestration

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -6,9 +6,14 @@ on:
     # PRs from batch-backport.yml target the version branch directly, so they
     # need the same RC build + flow gate as main PRs. rc-pr-<N> tags are
     # globally unique by PR number so there's no collision across base branches.
+    #
+    # `feat/docker-release` is included temporarily so this PR
+    # (feat/docker-per-class-tests → feat/docker-release) can run its own CI.
+    # Drop the entry before merging back to main.
     branches:
       - "main"
       - "[0-9]+.[0-9]+"
+      - "feat/docker-release"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -184,6 +184,29 @@ jobs:
         run: |
           . /data/venv/bin/activate
           TCK_DONE=tck_done.txt pytest tests/tck/test_tck.py -s
+      # Capture the GHA service container's stdout/stderr so a failing run
+      # carries the redis lifecycle, module RedisModule_Log output, and any
+      # ASAN/LSan reports off the runner. The service container is named
+      # after its YAML key ("falkordb"); `docker logs` is run via the
+      # /var/run/docker.sock the runner shares with the job container.
+      - name: Capture service container logs on failure
+        if: failure()
+        run: |
+          mkdir -p tests/flow/logs
+          # Dump every container the runner can see — GHA service containers
+          # are named after their YAML key but a workflow-run prefix can show
+          # up too; iterating all containers is safer than matching by name.
+          for cid in $(docker ps -aq); do
+            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
+          done
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-service-logs
+          path: tests/flow/logs/
+          if-no-files-found: ignore
   flow-test-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -464,6 +487,24 @@ jobs:
           summary-always: true
           # Don't push to gh-pages branch in the PR
           auto-push: false
+      - name: Capture service container logs on failure
+        if: failure()
+        run: |
+          mkdir -p tests/flow/logs
+          # Dump every container the runner can see — GHA service containers
+          # are named after their YAML key but a workflow-run prefix can show
+          # up too; iterating all containers is safer than matching by name.
+          for cid in $(docker ps -aq); do
+            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
+          done
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: benchmark-service-logs
+          path: tests/flow/logs/
+          if-no-files-found: ignore
   falkordb-e2e-compatibility:
     runs-on: ubuntu-latest
     needs: [build-rc-image]
@@ -506,3 +547,18 @@ jobs:
         run: |
           pip install -r tests/requirements.txt
           pytest -v -m "not extra" tests/test_e2e.py tests/test_functions.py -vv
+      - name: Capture service container logs on failure
+        if: failure()
+        run: |
+          mkdir -p tests/flow/logs
+          for cid in $(docker ps -aq); do
+            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
+          done
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-compatibility-service-logs
+          path: tests/flow/logs/
+          if-no-files-found: ignore

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -40,20 +40,30 @@ jobs:
         id: check
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        # Diff against the merge-base with main, not the immediate PR base.
-        # On a regular main-targeting PR these are identical. On a stacked PR
-        # (whose base is itself a branch like feat/docker-per-class-tests) the
-        # immediate-base diff hides toolchain changes from the parent stack,
-        # which causes downstream jobs to fall back to :latest — but :latest
-        # doesn't exist on GHCR (it's only populated when the stack lands on
-        # main). Diffing from main detects any build/Dockerfile change
-        # anywhere in the stack and rebuilds pr-<N> for this PR.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        # Pick the right diff target for "did the toolchain change":
+        #   - PRs targeting main, or stacked feat/ branches that ultimately
+        #     land on main → diff against origin/main's merge-base. Catches
+        #     toolchain changes anywhere in the stack so the :pr-<N> tag is
+        #     rebuilt for this PR (downstream jobs would otherwise fall back
+        #     to :latest, which doesn't exist on GHCR until the stack lands).
+        #   - PRs targeting a version branch (e.g. 6.0, 7.1, set by
+        #     batch-backport.yml) → diff against that version branch's
+        #     merge-base. :latest already exists on GHCR (the version branch
+        #     was cut from a released main), so an immediate-base diff is
+        #     correct and avoids spuriously rebuilding when main and the
+        #     version branch diverge on the Dockerfile.
         run: |
           # actions/checkout above used fetch-depth: 0 so we have full history,
-          # but only the PR's branch is fetched by default — pull main as a ref
-          # too so merge-base can find the actual divergence point.
-          git fetch --no-tags origin main
-          MERGE_BASE=$(git merge-base origin/main "$HEAD_SHA")
+          # but only the PR's branch is fetched by default — pull the diff
+          # target as a ref too so merge-base can find the actual divergence.
+          if [[ "$BASE_REF" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            DIFF_TARGET="$BASE_REF"
+          else
+            DIFF_TARGET="main"
+          fi
+          git fetch --no-tags origin "$DIFF_TARGET"
+          MERGE_BASE=$(git merge-base "origin/$DIFF_TARGET" "$HEAD_SHA")
           if git diff --name-only "$MERGE_BASE" "$HEAD_SHA" | grep -q "build/Dockerfile"; then
             echo "changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -194,20 +194,12 @@ jobs:
         id: set-matrix
         run: |
           echo "test_files=$(jq -Rc '[., inputs] | map(select(length > 0))' flow_tests_done.txt)" >> $GITHUB_OUTPUT
-  # Flow tests against the RC image with a hybrid execution model:
-  #
-  # 1. Default: master + replica are declared as GHA services, both backed
-  #    by the same RC image. Tests that don't pass moduleArgs and don't use
-  #    useSlaves connect to `master`. Tests using useSlaves=True transparently
-  #    get the replica via Env().getSlaveConnection() — no separate orchestration.
-  #
-  # 2. Override: tests that pass load-time-immutable moduleArgs (CACHE_SIZE,
-  #    NODE_CREATION_BUFFER, IMPORT_FOLDER, …) need a fresh redis with those
-  #    args baked into --loadmodule. The Env() helper in tests/flow/common.py
-  #    detects this and spawns a private container via `docker run` from
-  #    inside the toolchain (docker CLI installed in build/Dockerfile; host
-  #    socket bind-mounted via container.options). That private container's
-  #    lifecycle is scoped to the one Env() call.
+  # Flow tests against the RC image — one fresh container per RLTest class.
+  # The Env() helper in tests/flow/common.py issues `docker run` for each call,
+  # talking to the host docker daemon via the bind-mounted socket. Per-class
+  # isolation eliminates the cross-test state leakage that broke a shared
+  # services-block model (TIMEOUT_MAX surviving FLUSHALL, MONITOR seeing
+  # previous-test traffic, etc.).
   test-flow:
     # Display the asan vs normal cells distinctly in the GitHub Actions UI.
     name: ${{ matrix.sanitizer && 'asan-flow' || 'flow' }} ${{ matrix.test_file }}
@@ -225,36 +217,9 @@ jobs:
     permissions:
       contents: read
       packages: read
-    services:
-      master:
-        image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          # Override the image's production defaults ("TIMEOUT 1000 ..."); tests
-          # expect RLTest's spawned-redis defaults (no TIMEOUT cap).
-          FALKORDB_ARGS: ""
-          # log_path on the sanitizer cell only — harmless when libasan isn't loaded.
-          ASAN_OPTIONS: "detect_leaks=1:detect_odr_violation=0:halt_on_error=0:abort_on_error=0:symbolize=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=1:log_path=/tmp/asan-logs/asan:log_exe_name=1"
-      replica:
-        image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          FALKORDB_ARGS: ""
-          # REDIS_ARGS is interpolated by run.sh into the redis-server command
-          # line; --replicaof points at the master service via its network alias.
-          REDIS_ARGS: "--replicaof master 6379"
-          ASAN_OPTIONS: "detect_leaks=1:detect_odr_violation=0:halt_on_error=0:abort_on_error=0:symbolize=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=1:log_path=/tmp/asan-logs/asan:log_exe_name=1"
     env:
-      # Connection target for the default (no-override) test path.
-      FALKORDB_HOST: master
-      FALKORDB_PORT: "6379"
-      FALKORDB_REPLICA_HOST: replica
-      FALKORDB_REPLICA_PORT: "6379"
-      # Image used when Env() spawns a private container for moduleArgs override.
+      # The RC image to spawn containers from. Env() in tests/flow/common.py
+      # picks it up and runs `docker run -e FALKORDB_ARGS=<moduleArgs> ...`.
       FALKORDB_TEST_IMAGE: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
       SANITIZER: ${{ matrix.sanitizer && 'address' || '' }}
     strategy:
@@ -265,15 +230,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # Log into GHCR so the private-spawn path (`docker run` from Env()) can
-      # pull the RC image when needed. The default-service path doesn't need
-      # this — GHA already pulled the image via the services credentials.
-      - name: Login to GHCR (for private container spawns)
+      # Log into GHCR so the in-container docker CLI can pull the RC image
+      # the first time Env() spawns. Subsequent spawns hit the daemon's
+      # local image cache.
+      - name: Login to GHCR (for in-container docker pull)
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-pull RC image
+        env:
+          IMAGE: ${{ env.FALKORDB_TEST_IMAGE }}
+        run: docker pull "$IMAGE"
 
       - name: Run Flow test - ${{ matrix.test_file }} (sanitizer=${{ matrix.sanitizer }})
         env:

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -203,13 +203,6 @@ jobs:
   test-flow:
     # Display the asan vs normal cells distinctly in the GitHub Actions UI.
     name: ${{ matrix.sanitizer && 'asan-flow' || 'flow' }} ${{ matrix.test_file }}
-    # ASAN cells are advisory until the GraphBLAS-JIT-under-ASAN issue
-    # (matrix.rs:287 debug_assert_eq!(info, GrB_SUCCESS) panicking on
-    # GxB_JIT_ERROR returned by GrB_Matrix_eWiseAdd_Semiring) is fixed in
-    # a separate falkordb-rs PR. Tracked separately so the docker-per-class
-    # test infra can land; once the runtime bug is fixed the line below
-    # should be removed so ASAN gating returns.
-    continue-on-error: ${{ matrix.sanitizer }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -203,6 +203,13 @@ jobs:
   test-flow:
     # Display the asan vs normal cells distinctly in the GitHub Actions UI.
     name: ${{ matrix.sanitizer && 'asan-flow' || 'flow' }} ${{ matrix.test_file }}
+    # ASAN cells are advisory until the GraphBLAS-JIT-under-ASAN issue
+    # (matrix.rs:287 debug_assert_eq!(info, GrB_SUCCESS) panicking on
+    # GxB_JIT_ERROR returned by GrB_Matrix_eWiseAdd_Semiring) is fixed in
+    # a separate falkordb-rs PR. Tracked separately so the docker-per-class
+    # test infra can land; once the runtime bug is fixed the line below
+    # should be removed so ASAN gating returns.
+    continue-on-error: ${{ matrix.sanitizer }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -262,15 +262,30 @@ jobs:
           # module's true zero-config defaults; tests that need specific
           # config bring it via GRAPH.CONFIG SET.
           FALKORDB_ARGS: ""
-          # Some classified-as-no-args tests still use DEBUG SLEEP / DEBUG
-          # JMAP through other code paths; enabling DEBUG on the shared
-          # service is cheap (CI-only) and avoids surprise breakage.
+          # enableDebugCommand=True is no longer a spawn trigger — files
+          # routed to services can use DEBUG RELOAD / DEBUG SLEEP because
+          # the shared service starts with --enable-debug-command yes.
           REDIS_ARGS: "--enable-debug-command yes"
+      # Second service container reachable as `replica:6379` on the docker
+      # network the runner manages. Tests with Env(useSlaves=True) reach
+      # it through common.py services-mode (env.replica_host/port +
+      # _attach_slave). --replicaof retries until master is up, so the
+      # services come up in any order.
+      replica:
+        image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          FALKORDB_ARGS: ""
+          REDIS_ARGS: "--replicaof falkordb 6379 --enable-debug-command yes"
     env:
       FALKORDB_TEST_IMAGE: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
       FALKORDB_USE_SERVICE: "1"
       FALKORDB_HOST: falkordb
       FALKORDB_PORT: "6379"
+      FALKORDB_REPLICA_HOST: replica
+      FALKORDB_REPLICA_PORT: "6379"
       SANITIZER: ${{ matrix.sanitizer && 'address' || '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -121,49 +121,6 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/falkordb/falkordb:buildcache-asan
           cache-to:   type=registry,ref=ghcr.io/falkordb/falkordb:buildcache-asan,mode=max
 
-  # Extract the falkordb.so from each RC image and upload as an artifact. Tests
-  # that pass load-time-immutable moduleArgs (CACHE_SIZE, THREAD_COUNT, ...)
-  # fall back to RLTest's `env=oss` spawn mode (see tests/flow/common.py); that
-  # spawn needs the .so locally. We extract here on a host runner because the
-  # test-flow job runs inside the toolchain container which has no docker CLI.
-  extract-so:
-    needs: [build-rc-image, build-rc-asan-image]
-    if: ${{ !cancelled() && needs.build-rc-image.result == 'success' && needs.build-rc-asan-image.result == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { image_repo: falkordb-server, image_suffix: '',      artifact_name: rc-so      }
-          - { image_repo: falkordb,        image_suffix: '-asan', artifact_name: rc-asan-so }
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract falkordb.so
-        env:
-          IMAGE: ghcr.io/falkordb/${{ matrix.image_repo }}:rc-pr-${{ github.event.pull_request.number }}${{ matrix.image_suffix }}
-        run: |
-          set -euo pipefail
-          docker pull "$IMAGE"
-          CID=$(docker create "$IMAGE")
-          docker cp "${CID}:/var/lib/falkordb/bin/falkordb.so" libfalkordb.so
-          docker rm "$CID" >/dev/null
-          ls -lh libfalkordb.so
-      - name: Upload .so artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: libfalkordb.so
-          retention-days: 1
-          if-no-files-found: error
-
   lint:
     runs-on: ubuntu-latest
     container: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
@@ -232,50 +189,68 @@ jobs:
         id: set-matrix
         run: |
           echo "test_files=$(jq -Rc '[., inputs] | map(select(length > 0))' flow_tests_done.txt)" >> $GITHUB_OUTPUT
-  # Flow tests against the RC image. The sanitizer matrix dimension lets one
-  # job drive both the standard run (services: falkordb-server:rc-pr-N) and
-  # the ASAN run (services: falkordb:rc-pr-N-asan, with SANITIZER=address +
-  # ASAN_OPTIONS forced via service env). The ASAN_OPTIONS env on the service
-  # is harmless for non-sanitizer cells — libasan isn't loaded there.
+  # Flow tests against the RC image with a hybrid execution model:
+  #
+  # 1. Default: master + replica are declared as GHA services, both backed
+  #    by the same RC image. Tests that don't pass moduleArgs and don't use
+  #    useSlaves connect to `master`. Tests using useSlaves=True transparently
+  #    get the replica via Env().getSlaveConnection() — no separate orchestration.
+  #
+  # 2. Override: tests that pass load-time-immutable moduleArgs (CACHE_SIZE,
+  #    NODE_CREATION_BUFFER, IMPORT_FOLDER, …) need a fresh redis with those
+  #    args baked into --loadmodule. The Env() helper in tests/flow/common.py
+  #    detects this and spawns a private container via `docker run` from
+  #    inside the toolchain (docker CLI installed in build/Dockerfile; host
+  #    socket bind-mounted via container.options). That private container's
+  #    lifecycle is scoped to the one Env() call.
   test-flow:
     # Display the asan vs normal cells distinctly in the GitHub Actions UI.
-    # Default matrix interpolation renders as "test-flow (test_foo, true)"
-    # which is hard to scan; this gives "asan-flow test_foo" / "flow test_foo".
     name: ${{ matrix.sanitizer && 'asan-flow' || 'flow' }} ${{ matrix.test_file }}
     runs-on: ubuntu-latest
-    container: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+    container:
+      image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
     needs:
       - check-files
       - docker
       - flow-test-matrix
       - build-rc-image
       - build-rc-asan-image
-      - extract-so
-    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-image.result == 'success' && needs.build-rc-asan-image.result == 'success' && needs.extract-so.result == 'success' }}
+    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-image.result == 'success' && needs.build-rc-asan-image.result == 'success' }}
     permissions:
       contents: read
       packages: read
     services:
-      falkordb:
+      master:
         image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        ports: ["6379:6379"]
-        # FALKORDB_ARGS="" overrides the Dockerfile-baked production defaults
-        # ("TIMEOUT 1000 MAX_QUEUED_QUERIES 25 RESULTSET_SIZE 10000"). Tests
-        # are written against RLTest's spawned-redis defaults (no TIMEOUT etc.);
-        # the production knobs cause spurious "Query timed out" / queue-full
-        # failures during testing.
-        # Sanitizer cells need log_path overridden to a path we can `docker cp`
-        # out of the service container. Non-sanitizer service ignores it.
+        env:
+          # Override the image's production defaults ("TIMEOUT 1000 ..."); tests
+          # expect RLTest's spawned-redis defaults (no TIMEOUT cap).
+          FALKORDB_ARGS: ""
+          # log_path on the sanitizer cell only — harmless when libasan isn't loaded.
+          ASAN_OPTIONS: "detect_leaks=1:detect_odr_violation=0:halt_on_error=0:abort_on_error=0:symbolize=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=1:log_path=/tmp/asan-logs/asan:log_exe_name=1"
+      replica:
+        image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           FALKORDB_ARGS: ""
+          # REDIS_ARGS is interpolated by run.sh into the redis-server command
+          # line; --replicaof points at the master service via its network alias.
+          REDIS_ARGS: "--replicaof master 6379"
           ASAN_OPTIONS: "detect_leaks=1:detect_odr_violation=0:halt_on_error=0:abort_on_error=0:symbolize=1:print_stacktrace=1:strict_string_checks=1:detect_stack_use_after_return=1:log_path=/tmp/asan-logs/asan:log_exe_name=1"
     env:
-      EXISTING_ENV: "1"
-      FALKORDB_HOST: falkordb
+      # Connection target for the default (no-override) test path.
+      FALKORDB_HOST: master
       FALKORDB_PORT: "6379"
+      FALKORDB_REPLICA_HOST: replica
+      FALKORDB_REPLICA_PORT: "6379"
+      # Image used when Env() spawns a private container for moduleArgs override.
+      FALKORDB_TEST_IMAGE: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
       SANITIZER: ${{ matrix.sanitizer && 'address' || '' }}
     strategy:
       fail-fast: false
@@ -284,33 +259,23 @@ jobs:
         sanitizer: [false, true]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # Tests that pass load-time-only moduleArgs (CACHE_SIZE, THREAD_COUNT,
-      # IMPORT_FOLDER, ...) can't reconfigure the running service container.
-      # For those, the Env() helper falls back to RLTest's `env=oss` mode,
-      # which spawns its own redis with --loadmodule + moduleArgs. The .so
-      # is downloaded here from the extract-so job (we can't `docker cp`
-      # from inside the toolchain container — no docker CLI).
-      - name: Download .so artifact (byte-identical to service-container .so)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+
+      # Log into GHCR so the private-spawn path (`docker run` from Env()) can
+      # pull the RC image when needed. The default-service path doesn't need
+      # this — GHA already pulled the image via the services credentials.
+      - name: Login to GHCR (for private container spawns)
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          name: ${{ matrix.sanitizer && 'rc-asan-so' || 'rc-so' }}
-          path: target/release/
-      - run: chmod +x target/release/libfalkordb.so
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Flow test - ${{ matrix.test_file }} (sanitizer=${{ matrix.sanitizer }})
         env:
           TEST_FILE: ${{ matrix.test_file }}
         run: |
           . /data/venv/bin/activate
           TEST="$TEST_FILE" FAIL_FAST=1 RELEASE=1 ./flow.sh
-      - name: Collect ASAN logs from service container
-        if: failure() && matrix.sanitizer
-        env:
-          FALKORDB_CID: ${{ job.services.falkordb.id }}
-        run: |
-          # ASAN_OPTIONS.log_path inside the service container writes to
-          # /tmp/asan-logs/asan.<pid>. Pull them out for the artifact step.
-          mkdir -p tests/flow/logs/asan
-          docker cp "${FALKORDB_CID}:/tmp/asan-logs/." tests/flow/logs/asan/ 2>/dev/null || true
       - name: Upload flow logs on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -168,7 +168,13 @@ jobs:
           CXX=clang++-22 cargo clippy --all-targets
   test:
     runs-on: ubuntu-latest
-    container: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+    container:
+      image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+      # Mount the runner's docker socket so the "Capture service container
+      # logs on failure" step below can run `docker ps`/`docker logs` against
+      # the GHA service container. Without this the log-capture step is a
+      # silent no-op (and could mask the upload-artifact step).
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
     needs:
       - check-files
       - docker
@@ -564,7 +570,11 @@ jobs:
           fi                                                                
   benchmark:
     runs-on: ubuntu-latest
-    container: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+    container:
+      image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+      # Mount docker.sock so the failure-path log-capture step can dump the
+      # benchmark service container's stdout (same pattern as `test` above).
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
     needs:
       - check-files
       - docker

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -210,21 +210,103 @@ jobs:
   flow-test-matrix:
     runs-on: ubuntu-latest
     outputs:
+      services_files: ${{ steps.set-matrix.outputs.services_files }}
+      spawn_files: ${{ steps.set-matrix.outputs.spawn_files }}
+      # Union of services_files + spawn_files for callers like coverage-flow
+      # that don't go through docker and just need every test file.
       test_files: ${{ steps.set-matrix.outputs.test_files }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate test matrix
         id: set-matrix
+        # tests/flow/test_matrix_split.py classifies each entry in
+        # flow_tests_done.txt: files whose Env() invocations never pass
+        # special flags (moduleArgs / useSlaves / enableDebugCommand /
+        # oss-cluster / shardsCount) go to services_files (cheap shared
+        # service); the rest go to spawn_files (private docker run per class).
         run: |
-          echo "test_files=$(jq -Rc '[., inputs] | map(select(length > 0))' flow_tests_done.txt)" >> $GITHUB_OUTPUT
-  # Flow tests against the RC image — one fresh container per RLTest class.
-  # The Env() helper in tests/flow/common.py issues `docker run` for each call,
-  # talking to the host docker daemon via the bind-mounted socket. Per-class
-  # isolation eliminates the cross-test state leakage that broke a shared
-  # services-block model (TIMEOUT_MAX surviving FLUSHALL, MONITOR seeing
-  # previous-test traffic, etc.).
-  test-flow:
-    # Display the asan vs normal cells distinctly in the GitHub Actions UI.
+          python3 tests/flow/test_matrix_split.py >> $GITHUB_OUTPUT
+  # Flow tests — services bucket. Files whose Env() invocations never pass
+  # special flags (moduleArgs / useSlaves / enableDebugCommand / oss-cluster /
+  # shardsCount) reuse a long-running GHA service container per matrix cell.
+  # common.py's services mode (FALKORDB_USE_SERVICE=1) connects directly to
+  # `falkordb:6379` and FLUSHALLs between Env() calls for class-level isolation.
+  # No `docker run` per class → no docker socket mount needed for the test
+  # itself; the on-failure capture step still uses the socket to dump service
+  # logs, so we mount it for that.
+  test-flow-services:
+    name: ${{ matrix.sanitizer && 'asan-flow-svc' || 'flow-svc' }} ${{ matrix.test_file }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/falkordb/falkordb-build:${{ needs.check-files.outputs.file_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+      options: --volume /var/run/docker.sock:/var/run/docker.sock
+    needs:
+      - check-files
+      - docker
+      - flow-test-matrix
+      - build-rc-image
+      - build-rc-asan-image
+    if: ${{ !cancelled() && (needs.docker.result == 'success' || needs.docker.result == 'skipped') && needs.flow-test-matrix.result == 'success' && needs.build-rc-image.result == 'success' && needs.build-rc-asan-image.result == 'success' }}
+    permissions:
+      contents: read
+      packages: read
+    services:
+      falkordb:
+        image: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          # Empty FALKORDB_ARGS overrides the image's compiled-in default
+          # (MAX_QUEUED_QUERIES 25 ...) so the service starts with the
+          # module's true zero-config defaults; tests that need specific
+          # config bring it via GRAPH.CONFIG SET.
+          FALKORDB_ARGS: ""
+          # Some classified-as-no-args tests still use DEBUG SLEEP / DEBUG
+          # JMAP through other code paths; enabling DEBUG on the shared
+          # service is cheap (CI-only) and avoids surprise breakage.
+          REDIS_ARGS: "--enable-debug-command yes"
+    env:
+      FALKORDB_TEST_IMAGE: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
+      FALKORDB_USE_SERVICE: "1"
+      FALKORDB_HOST: falkordb
+      FALKORDB_PORT: "6379"
+      SANITIZER: ${{ matrix.sanitizer && 'address' || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test_file: ${{ fromJson(needs.flow-test-matrix.outputs.services_files) }}
+        sanitizer: [false, true]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run Flow test - ${{ matrix.test_file }} (sanitizer=${{ matrix.sanitizer }})
+        env:
+          TEST_FILE: ${{ matrix.test_file }}
+        run: |
+          . /data/venv/bin/activate
+          TEST="$TEST_FILE" FAIL_FAST=1 RELEASE=1 ./flow.sh
+      - name: Capture service container logs on failure
+        if: failure()
+        run: |
+          mkdir -p tests/flow/logs
+          for cid in $(docker ps -aq); do
+            name=$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+            docker logs "$cid" > "tests/flow/logs/service-${name:-$cid}.log" 2>&1 || true
+          done
+      - name: Upload flow logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-flow-svc-logs-${{ strategy.job-index }}
+          path: |
+            tests/flow/logs/
+          if-no-files-found: ignore
+
+  # Flow tests — spawn bucket. Files whose Env() invocations pass at least
+  # one special flag (moduleArgs / useSlaves / enableDebugCommand / oss-cluster
+  # / shardsCount) need per-class load-time config or topology. common.py
+  # issues `docker run` for each Env() call via the bind-mounted socket.
+  test-flow-spawn:
     name: ${{ matrix.sanitizer && 'asan-flow' || 'flow' }} ${{ matrix.test_file }}
     runs-on: ubuntu-latest
     container:
@@ -241,14 +323,12 @@ jobs:
       contents: read
       packages: read
     env:
-      # The RC image to spawn containers from. Env() in tests/flow/common.py
-      # picks it up and runs `docker run -e FALKORDB_ARGS=<moduleArgs> ...`.
       FALKORDB_TEST_IMAGE: ${{ matrix.sanitizer && format('ghcr.io/falkordb/falkordb:rc-pr-{0}-asan', github.event.pull_request.number) || format('ghcr.io/falkordb/falkordb-server:rc-pr-{0}', github.event.pull_request.number) }}
       SANITIZER: ${{ matrix.sanitizer && 'address' || '' }}
     strategy:
       fail-fast: false
       matrix:
-        test_file: ${{ fromJson(needs.flow-test-matrix.outputs.test_files) }}
+        test_file: ${{ fromJson(needs.flow-test-matrix.outputs.spawn_files) }}
         sanitizer: [false, true]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -278,7 +358,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-flow-logs-${{ strategy.job-index }}
+          name: test-flow-spawn-logs-${{ strategy.job-index }}
           path: |
             tests/flow/logs/
           if-no-files-found: ignore

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -39,10 +39,22 @@ jobs:
       - name: Check if specific file changed
         id: check
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Diff against the merge-base with main, not the immediate PR base.
+        # On a regular main-targeting PR these are identical. On a stacked PR
+        # (whose base is itself a branch like feat/docker-per-class-tests) the
+        # immediate-base diff hides toolchain changes from the parent stack,
+        # which causes downstream jobs to fall back to :latest — but :latest
+        # doesn't exist on GHCR (it's only populated when the stack lands on
+        # main). Diffing from main detects any build/Dockerfile change
+        # anywhere in the stack and rebuilds pr-<N> for this PR.
         run: |
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q "build/Dockerfile"; then
+          # actions/checkout above used fetch-depth: 0 so we have full history,
+          # but only the PR's branch is fetched by default — pull main as a ref
+          # too so merge-base can find the actual divergence point.
+          git fetch --no-tags origin main
+          MERGE_BASE=$(git merge-base origin/main "$HEAD_SHA")
+          if git diff --name-only "$MERGE_BASE" "$HEAD_SHA" | grep -q "build/Dockerfile"; then
             echo "changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT
           else

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,15 +23,6 @@ RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
-# Pin GraphBLAS to the same tagged release graphblas.sh uses (v10.3.1).
-# Previously this image cloned `--branch dev2` (upstream-dev, advances daily),
-# so each toolchain-image rebuild produced a different libgraphblas.a even
-# though graphblas.sh in the repo pinned to v10.3.1 — local builds and
-# Docker builds were on diverging GraphBLAS sources. The drift surfaced as
-# index/edge-SET regressions in the RC image's runtime (count(edges) was
-# right but RETURN/SET on the same MATCH returned 0). Tagged source keeps
-# both build paths in lockstep and matches what main's aviavni/falkordb-build
-# image was originally built against.
 RUN git clone --branch v10.3.1 --single-branch --depth 1 https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 
 RUN cd GraphBLAS && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,16 @@ RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest
 
-RUN git clone --branch dev2 --single-branch --depth 1 https://github.com/DrTimothyAldenDavis/GraphBLAS.git
+# Pin GraphBLAS to the same tagged release graphblas.sh uses (v10.3.1).
+# Previously this image cloned `--branch dev2` (upstream-dev, advances daily),
+# so each toolchain-image rebuild produced a different libgraphblas.a even
+# though graphblas.sh in the repo pinned to v10.3.1 — local builds and
+# Docker builds were on diverging GraphBLAS sources. The drift surfaced as
+# index/edge-SET regressions in the RC image's runtime (count(edges) was
+# right but RETURN/SET on the same MATCH returned 0). Tagged source keeps
+# both build paths in lockstep and matches what main's aviavni/falkordb-build
+# image was originally built against.
+RUN git clone --branch v10.3.1 --single-branch --depth 1 https://github.com/DrTimothyAldenDavis/GraphBLAS.git
 
 RUN cd GraphBLAS && \
     make static CMAKE_OPTIONS='-DGRAPHBLAS_COMPACT=1 -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_C_FLAGS=-Wno-incompatible-pointer-types -DCMAKE_CXX_FLAGS=-Wno-incompatible-pointer-types' JOBS=2 CC=clang-22 CXX=clang++-22 && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,14 @@ RUN apt update -y && \
 
 RUN apt install -y git make cmake curl zlib1g zlib1g-dev libpolly-22-dev libomp-22-dev libc++-22-dev libc++abi-22-dev libzstd-dev python3-venv lcov
 
+# Docker CLI for per-test-class container orchestration in flow tests:
+# tests/flow/common.py spawns dedicated containers from the RC image so each
+# class gets its own fresh redis with the right load-time module args. The
+# CLI talks to the host docker daemon via /var/run/docker.sock (mounted via
+# the rust-pr.yml `container.options`). docker.io includes the daemon binary
+# we never run — only the client matters here.
+RUN apt install -y docker.io
+
 RUN python3 -m venv venv
 
 RUN venv/bin/pip install behave falkordb falkordb-bulk-loader hypothesis pytest pytest-benchmark RLTest

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -2,26 +2,18 @@ ARG BUILD_IMAGE=ghcr.io/falkordb/falkordb-build:latest
 ARG BROWSER_TAG=latest
 ARG TARGETPLATFORM=linux/amd64
 
-# cargo-chef splits dep compilation into a layer cached on Cargo.toml/Cargo.lock,
-# so source-only changes skip dep rebuild.
-FROM $BUILD_IMAGE AS chef
-RUN cargo install cargo-chef --locked
+# Experiment: drop cargo-chef while keeping CXX=clang++-22 from the
+# original Dockerfile config. CXX-drop alone (commit 28f05ce) did not
+# fix the index/edge-SET bugs the RC image triggers, so restore CXX
+# and isolate cargo-chef as the single variable: if this build passes
+# the previously-failing tests, the two-pass cook+build pattern was
+# the culprit. (cargo-chef cooks stub-lib.rs deps then rebuilds the
+# real crate; with our heavy build.rs FFI that may produce subtly
+# different objects than a single-pass build.)
+FROM $BUILD_IMAGE AS builder
 WORKDIR /src
-
-FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-COPY --from=planner /src/recipe.json recipe.json
-# Experiment: drop CXX=clang++-22 to match main's local-build .so (which uses
-# the toolchain image's default g++). Index-mutation and edge-SET bugs
-# reproduce against the RC image but pass on main's locally-built .so; the
-# only meaningful build difference is the linker driver. If this rebuild's
-# .so passes those tests, the link path was the culprit.
-RUN cargo chef cook --release --recipe-path recipe.json
-COPY . .
-RUN cargo build --release && \
+RUN CXX=clang++-22 cargo build --release && \
     mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so
 
 FROM redis:8.6.3 AS server

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -2,16 +2,21 @@ ARG BUILD_IMAGE=ghcr.io/falkordb/falkordb-build:latest
 ARG BROWSER_TAG=latest
 ARG TARGETPLATFORM=linux/amd64
 
-# Experiment: drop cargo-chef while keeping CXX=clang++-22 from the
-# original Dockerfile config. CXX-drop alone (commit 28f05ce) did not
-# fix the index/edge-SET bugs the RC image triggers, so restore CXX
-# and isolate cargo-chef as the single variable: if this build passes
-# the previously-failing tests, the two-pass cook+build pattern was
-# the culprit. (cargo-chef cooks stub-lib.rs deps then rebuilds the
-# real crate; with our heavy build.rs FFI that may produce subtly
-# different objects than a single-pass build.)
-FROM $BUILD_IMAGE AS builder
+# cargo-chef splits dep compilation into a layer cached on
+# Cargo.toml/Cargo.lock, so source-only changes skip dep rebuild.
+# Confirmed not the trigger for the index/edge-SET regressions:
+# dropping it (commit c51c730) didn't change the failing test set.
+FROM $BUILD_IMAGE AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /src
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /src/recipe.json recipe.json
+RUN CXX=clang++-22 cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN CXX=clang++-22 cargo build --release && \
     mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -14,9 +14,14 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /src/recipe.json recipe.json
-RUN CXX=clang++-22 cargo chef cook --release --recipe-path recipe.json
+# Experiment: drop CXX=clang++-22 to match main's local-build .so (which uses
+# the toolchain image's default g++). Index-mutation and edge-SET bugs
+# reproduce against the RC image but pass on main's locally-built .so; the
+# only meaningful build difference is the linker driver. If this rebuild's
+# .so passes those tests, the link path was the culprit.
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN CXX=clang++-22 cargo build --release && \
+RUN cargo build --release && \
     mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so
 
 FROM redis:8.6.3 AS server

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -2,10 +2,6 @@ ARG BUILD_IMAGE=ghcr.io/falkordb/falkordb-build:latest
 ARG BROWSER_TAG=latest
 ARG TARGETPLATFORM=linux/amd64
 
-# cargo-chef splits dep compilation into a layer cached on
-# Cargo.toml/Cargo.lock, so source-only changes skip dep rebuild.
-# Confirmed not the trigger for the index/edge-SET regressions:
-# dropping it (commit c51c730) didn't change the failing test set.
 FROM $BUILD_IMAGE AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /src

--- a/build/runtime/Dockerfile.asan
+++ b/build/runtime/Dockerfile.asan
@@ -91,10 +91,17 @@ RUN apt-get update && \
         ca-certificates bash openssl wget gnupg lsb-release libasan8 && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 22 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends libomp5 llvm-22 && \
+    apt-get install -y --no-install-recommends libomp5 llvm-22 gcc && \
     apt-get purge -y wget gnupg lsb-release && \
     apt-get autoremove -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /llvm.sh
+# GraphBLAS JIT compiles matrix operations dynamically at runtime via cc.
+# Without a C compiler in PATH, JIT returns GxB_JIT_ERROR and our
+# debug_assert_eq!(info, GrB_SUCCESS) in matrix.rs:287 panics the module —
+# crashing redis on every MATCH/DELETE query. aviavni/falkordb-build (used
+# by the old asan workflow on main) had gcc installed by default; the slim
+# debian:trixie-slim base does not. The `gcc` apt package provides
+# /usr/bin/cc and /usr/bin/gcc, enough for GraphBLAS JIT.
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/build/runtime/Dockerfile.asan
+++ b/build/runtime/Dockerfile.asan
@@ -34,19 +34,24 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /src/recipe.json recipe.json
-# Target-specific env vars use cc-rs's envified form (uppercase + underscores,
-# lookup logic in cc-rs's envify()) rather than the literal target triple
-# `CFLAGS_x86_64-unknown-linux-gnu`. POSIX `/bin/sh` (dash on debian) rejects
-# hyphens in variable assignments and would fail with "command not found".
-RUN CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=2" \
-    CFLAGS_X86_64_UNKNOWN_LINUX_GNU="-fsanitize=address -fno-omit-frame-pointer" \
-    CXXFLAGS_X86_64_UNKNOWN_LINUX_GNU="-fsanitize=address -fno-omit-frame-pointer" \
+# Target-specific env vars MUST use the canonical hyphenated form
+# `CFLAGS_x86_64-unknown-linux-gnu` (cc-rs's primary lookup key); the
+# uppercase+underscore variant is a secondary lookup in some cc-rs paths
+# but not reliably for all C dependencies in our tree. POSIX /bin/sh (dash)
+# can't assign env vars with hyphens, so we use `env` which accepts them.
+# Confirmed by comparing against the old in-job asan build on main, which
+# used the same hyphenated names directly via GHA's `env:` block.
+RUN env \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=2" \
+    CFLAGS_x86_64-unknown-linux-gnu="-fsanitize=address -fno-omit-frame-pointer" \
+    CXXFLAGS_x86_64-unknown-linux-gnu="-fsanitize=address -fno-omit-frame-pointer" \
     CXX=clang++-22 \
     cargo chef cook --target x86_64-unknown-linux-gnu --recipe-path recipe.json
 COPY . .
-RUN CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=2" \
-    CFLAGS_X86_64_UNKNOWN_LINUX_GNU="-fsanitize=address -fno-omit-frame-pointer" \
-    CXXFLAGS_X86_64_UNKNOWN_LINUX_GNU="-fsanitize=address -fno-omit-frame-pointer" \
+RUN env \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-Zsanitizer=address -Cdebuginfo=2" \
+    CFLAGS_x86_64-unknown-linux-gnu="-fsanitize=address -fno-omit-frame-pointer" \
+    CXXFLAGS_x86_64-unknown-linux-gnu="-fsanitize=address -fno-omit-frame-pointer" \
     CXX=clang++-22 \
     cargo build --target x86_64-unknown-linux-gnu && \
     mkdir -p /out && cp target/x86_64-unknown-linux-gnu/debug/libfalkordb.so /out/falkordb.so

--- a/build/runtime/Dockerfile.asan
+++ b/build/runtime/Dockerfile.asan
@@ -78,12 +78,21 @@ ENV FALKORDB_HOME=/var/lib/falkordb \
 RUN mkdir -p ${FALKORDB_DATA_PATH} && ln -s ${FALKORDB_DATA_PATH} /data
 
 # Pull LLVM 22 from apt.llvm.org for libasan-version-matched libomp + symbolizer.
-# - `libomp5` (not `libomp5-22`): apt.llvm.org publishes the LLVM 22 OpenMP
-#   runtime under the unversioned `libomp5` name. Verified with apt-cache
-#   policy: candidate version is 1:22.1.x~++…, served from the
-#   llvm-toolchain-trixie-22 repo, so we get the version-matched runtime.
-# - No `libomp-22-dev` (dev package, only needed by the builder stage which
-#   uses the toolchain image's headers, not by the runtime image).
+# Plus GraphBLAS JIT runtime dependencies: at first matrix-op call GraphBLAS
+# generates C source under ~/.SuiteSparse/GrBN.M.K/c/ and invokes `cc` to
+# compile it into a per-kernel .so. Without these the JIT call returns
+# GxB_JIT_ERROR and matrix.rs:287's debug_assert_eq! panics the module,
+# killing redis on every MATCH/DELETE query.
+#
+# - `libomp5`: LLVM OpenMP **runtime**. The unversioned name is what
+#   apt.llvm.org publishes for LLVM 22; candidate via apt-cache policy is
+#   1:22.1.x from llvm-toolchain-trixie-22.
+# - `libomp-22-dev`: LLVM OpenMP **headers** (`omp.h`). Required by the
+#   JIT-compiled kernels — without it, the JIT `cc` invocation fails.
+# - `gcc`: provides `/usr/bin/cc`. GraphBLAS JIT defaults to invoking `cc`
+#   regardless of what the static library was built with. (clang-22 alone
+#   isn't enough — JIT doesn't shell out to a versioned name.)
+# - `llvm-22`: pulls in `llvm-symbolizer-22` for ASAN stack-trace symbol resolution.
 # - trixie's llvm.sh no longer requires `software-properties-common`; the
 #   helper script writes the apt source list directly.
 RUN apt-get update && \
@@ -91,17 +100,11 @@ RUN apt-get update && \
         ca-certificates bash openssl wget gnupg lsb-release libasan8 && \
     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 22 && \
     apt-get update && \
-    apt-get install -y --no-install-recommends libomp5 llvm-22 gcc && \
+    apt-get install -y --no-install-recommends \
+        libomp5 libomp-22-dev llvm-22 gcc && \
     apt-get purge -y wget gnupg lsb-release && \
     apt-get autoremove -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /llvm.sh
-# GraphBLAS JIT compiles matrix operations dynamically at runtime via cc.
-# Without a C compiler in PATH, JIT returns GxB_JIT_ERROR and our
-# debug_assert_eq!(info, GrB_SUCCESS) in matrix.rs:287 panics the module —
-# crashing redis on every MATCH/DELETE query. aviavni/falkordb-build (used
-# by the old asan workflow on main) had gcc installed by default; the slim
-# debian:trixie-slim base does not. The `gcc` apt package provides
-# /usr/bin/cc and /usr/bin/gcc, enough for GraphBLAS JIT.
 
 WORKDIR ${FALKORDB_HOME}
 

--- a/flow.sh
+++ b/flow.sh
@@ -72,7 +72,13 @@ fi
 # To run all tests in a specific file, use:
 # TEST="tests/flow/test_function_calls" FAIL_FAST=1 ./flow.sh
 # To run against an already-running redis (e.g. a service container):
-# FALKORDB_TEST_IMAGE=ghcr.io/falkordb/falkordb-server:edge-rs ./flow.sh
+#   FALKORDB_TEST_IMAGE=ghcr.io/falkordb/falkordb-server:edge-rs \
+#   FALKORDB_USE_SERVICE=1 \
+#   FALKORDB_HOST=<host> FALKORDB_PORT=<port> \
+#   ./flow.sh
+# Setting FALKORDB_TEST_IMAGE alone selects spawn mode (Env() docker-runs a
+# sibling container per call); add FALKORDB_USE_SERVICE=1 to skip the spawn
+# and connect to the existing service at FALKORDB_HOST:FALKORDB_PORT.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REDIS_CONF="$SCRIPT_DIR/tests/flow/redis.conf"

--- a/flow.sh
+++ b/flow.sh
@@ -38,18 +38,24 @@ if [[ "$FAIL_FAST" == 1 ]]; then
 	PARALLELISM="--parallelism 1"
 fi
 
-# Existing-env mode: RLTest connects to a pre-running redis (typically a CI
-# services-block container) instead of spawning one with --loadmodule. Parallel
-# tests would share the same redis and collide, so force serial execution.
+# Two execution modes, selected by FALKORDB_TEST_IMAGE:
 #
-# --parallelism is set safely below to 1. We pass --module too so per-test
-# Env(env='oss') overrides (tests/flow/common.py uses this when a test's
-# moduleArgs include load-time-immutable config that the running redis can't
-# apply on the fly) have the module path to spawn redis with. In CI the .so
-# is extracted from the service container before flow.sh runs; locally the
-# developer flow still builds it via cargo.
-if [[ "$EXISTING_ENV" == 1 ]]; then
-    MODULE_ARGS=(--env existing-env --existing-env-addr "${FALKORDB_HOST:-localhost}:${FALKORDB_PORT:-6379}" --module "$TARGET_DIR/$TARGET")
+# - CI mode (FALKORDB_TEST_IMAGE set, e.g. ghcr.io/falkordb/falkordb-server:rc-pr-N):
+#   tests/flow/common.py Env() handles all redis lifecycle (connects to the
+#   shared `master` GHA service, or spawns a private container when the test
+#   passes load-time moduleArgs). RLTest gets --env existing-env so it doesn't
+#   try to spawn redis itself; the --existing-env-addr is bogus-but-required
+#   syntax — the helper bypasses it entirely.
+#
+# - Local dev (FALKORDB_TEST_IMAGE unset):
+#   Original behavior — RLTest spawns redis-server locally with --loadmodule.
+#   Cargo-build the .so, run ./flow.sh — works the same as before this PR.
+#
+# --parallelism 1 in CI because the shared `master` service is process-singleton;
+# parallel RLTest classes would collide on its state. Locally RLTest spawns one
+# redis per class, so concurrency is safe.
+if [[ "$FALKORDB_TEST_IMAGE" != "" ]]; then
+    MODULE_ARGS=(--env existing-env --existing-env-addr "${FALKORDB_HOST:-master}:${FALKORDB_PORT:-6379}")
     PARALLELISM="--parallelism 1"
 else
     MODULE_ARGS=(--module "$TARGET_DIR/$TARGET")
@@ -66,7 +72,7 @@ fi
 # To run all tests in a specific file, use:
 # TEST="tests/flow/test_function_calls" FAIL_FAST=1 ./flow.sh
 # To run against an already-running redis (e.g. a service container):
-# EXISTING_ENV=1 FALKORDB_HOST=falkordb FALKORDB_PORT=6379 ./flow.sh
+# FALKORDB_TEST_IMAGE=ghcr.io/falkordb/falkordb-server:edge-rs ./flow.sh
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REDIS_CONF="$SCRIPT_DIR/tests/flow/redis.conf"

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -364,27 +364,10 @@ impl VersionedMatrix {
     ///
     /// If dm is empty, uses the fast path (1 FFI call per entry).
     /// Otherwise falls back to the full `set` path (2+ FFI calls per entry).
-    ///
-    /// When both `dm` and `dp` are empty (the hot path for the first bulk
-    /// CREATE on a fresh graph) we collect the iterator and issue a single
-    /// `GrB_Matrix_build_BOOL` instead of looping setElement. Looping
-    /// setElement accumulates GraphBLAS internal pending tuples; at certain
-    /// sizes on linux glibc the internal flush leaves the matrix in
-    /// `GrB_INVALID_OBJECT` state — count() then reads 0 and the next write
-    /// crashes on `GrB_Matrix_dup(invalid)`. `Matrix::set` swallows the
-    /// error in release because the check is a `debug_assert_eq!`.
     pub fn set_all(
         &mut self,
         entries: impl Iterator<Item = (u64, u64)>,
     ) {
-        if self.dm.nvals() == 0 && self.dp.nvals() == 0 {
-            // Hot path: build into empty dp in one FFI call
-            let (rows, cols): (Vec<u64>, Vec<u64>) = entries.unzip();
-            if !rows.is_empty() {
-                self.dp.build_bool(&rows, &cols);
-            }
-            return;
-        }
         if self.dm.nvals() == 0 {
             for (i, j) in entries {
                 self.dp.set(i, j, true);

--- a/graph/src/graph/graphblas/versioned_matrix.rs
+++ b/graph/src/graph/graphblas/versioned_matrix.rs
@@ -364,10 +364,27 @@ impl VersionedMatrix {
     ///
     /// If dm is empty, uses the fast path (1 FFI call per entry).
     /// Otherwise falls back to the full `set` path (2+ FFI calls per entry).
+    ///
+    /// When both `dm` and `dp` are empty (the hot path for the first bulk
+    /// CREATE on a fresh graph) we collect the iterator and issue a single
+    /// `GrB_Matrix_build_BOOL` instead of looping setElement. Looping
+    /// setElement accumulates GraphBLAS internal pending tuples; at certain
+    /// sizes on linux glibc the internal flush leaves the matrix in
+    /// `GrB_INVALID_OBJECT` state — count() then reads 0 and the next write
+    /// crashes on `GrB_Matrix_dup(invalid)`. `Matrix::set` swallows the
+    /// error in release because the check is a `debug_assert_eq!`.
     pub fn set_all(
         &mut self,
         entries: impl Iterator<Item = (u64, u64)>,
     ) {
+        if self.dm.nvals() == 0 && self.dp.nvals() == 0 {
+            // Hot path: build into empty dp in one FFI call
+            let (rows, cols): (Vec<u64>, Vec<u64>) = entries.unzip();
+            if !rows.is_empty() {
+                self.dp.build_bool(&rows, &cols);
+            }
+            return;
+        }
         if self.dm.nvals() == 0 {
             for (i, j) in entries {
                 self.dp.set(i, j, true);

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -101,12 +101,18 @@ def _wait_for_redis(host, port, cid, attempts=50, interval=0.1):
     raise RuntimeError(f"redis at {host}:{port} did not become ready after {attempts * interval:.1f}s")
 
 
-def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None):
+def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
+                    enable_debug_command=False):
     """Start a falkordb container, return (host, port, container_id).
 
     `falkordb_args` becomes the module's load-time arg string (CACHE_SIZE 16 ...).
-    `redis_args` is forwarded as the redis-server CLI args (for --replicaof, etc.)."""
+    `redis_args` is forwarded as the redis-server CLI args (for --replicaof, etc.).
+    `enable_debug_command=True` adds `--enable-debug-command yes` to redis-server,
+    matching what tests that pass enableDebugCommand=True to Env() expect under
+    the old RLTest model (RLTest's --enable-debug-command CLI flag did the same)."""
     alias = alias or f"falkordb-{uuid.uuid4().hex[:8]}"
+    if enable_debug_command:
+        redis_args = f"--enable-debug-command yes {redis_args}".strip()
     cmd = [
         "docker", "run", "-d",
         "--network", _job_network(),
@@ -176,7 +182,8 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # raises before we can override anything. flow.sh's --existing-env-addr
     # is a placeholder that gets superseded here.
     master_alias, master_port, _ = _spawn_falkordb(
-        test_image, falkordb_args=moduleArgs or "")
+        test_image, falkordb_args=moduleArgs or "",
+        enable_debug_command=enableDebugCommand)
     host, port = master_alias, master_port
     Defaults.external_addr = f"{master_alias}:{master_port}"
     env_obj = Environment(decodeResponses=True, env='existing-env')
@@ -185,6 +192,7 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
             test_image,
             falkordb_args=moduleArgs or "",
             redis_args=f"--replicaof {master_alias} 6379",
+            enable_debug_command=enableDebugCommand,
         )
         _attach_slave(env_obj, replica_alias, 6379)
 

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -3,6 +3,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from functools import wraps
@@ -82,27 +83,53 @@ def _job_mounts():
 
 def _host_path_for(in_container_path):
     """Translate an in-container absolute path to the host path that backs it,
-    via the job container's mount table. If no mount covers the path, return
-    it unchanged (local dev: the spawn happens directly on the host, so the
-    path is already the host path)."""
+    via the job container's mount table. Returns (host_path, covered_by_mount).
+    When not covered, host_path is the input unchanged — callers must NOT
+    bind-mount in that case, because the host daemon would interpret it as a
+    fresh path and create an empty directory there."""
     for src, dest in _job_mounts():
         if in_container_path == dest or in_container_path.startswith(dest.rstrip("/") + "/"):
-            return src + in_container_path[len(dest):]
-    return in_container_path
+            return src + in_container_path[len(dest):], True
+    return in_container_path, False
 
 
-def _import_folder_arg(falkordb_args):
-    """Extract IMPORT_FOLDER's value from a module-args string. moduleArgs is
-    a space-separated `KEY VALUE KEY VALUE ...` sequence (matches the format
-    redis-server's --loadmodule consumes), so the value is the token directly
-    after IMPORT_FOLDER. Returns None if absent."""
+_PATH_ARG_KEYS = ("IMPORT_FOLDER", "TEMP_FOLDER")
+
+
+def _path_args_in(falkordb_args):
+    """Yield (key, value) for path-shaped module args present in the args
+    string. moduleArgs is a space-separated `KEY VALUE KEY VALUE ...`
+    sequence (matches what redis-server's --loadmodule consumes), so the
+    value is the token directly after the key."""
     if not falkordb_args:
-        return None
+        return
     toks = falkordb_args.split()
     for i, t in enumerate(toks):
-        if t == "IMPORT_FOLDER" and i + 1 < len(toks):
-            return toks[i + 1]
-    return None
+        if t in _PATH_ARG_KEYS and i + 1 < len(toks):
+            yield t, toks[i + 1]
+
+
+def mountable_mkdtemp(*args, **kwargs):
+    """tempfile.mkdtemp(), but under FALKORDB_TEST_IMAGE the dir is rooted in
+    a workspace-relative location that's covered by the job container's
+    bind-mount table. Spawned sibling containers then see the same directory
+    via _spawn_falkordb's bind-mount logic. Local dev gets plain mkdtemp."""
+    if os.getenv("FALKORDB_TEST_IMAGE") and "dir" not in kwargs:
+        kwargs["dir"] = _ci_tmpdir()
+    return tempfile.mkdtemp(*args, **kwargs)
+
+
+def mountable_mkstemp(*args, **kwargs):
+    """Workspace-rooted tempfile.mkstemp(). See mountable_mkdtemp() for why."""
+    if os.getenv("FALKORDB_TEST_IMAGE") and "dir" not in kwargs:
+        kwargs["dir"] = _ci_tmpdir()
+    return tempfile.mkstemp(*args, **kwargs)
+
+
+def _ci_tmpdir():
+    p = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".ci-tmp")
+    os.makedirs(p, exist_ok=True)
+    return p
 
 
 def _job_network():
@@ -177,17 +204,20 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
     alias = alias or f"falkordb-{uuid.uuid4().hex[:8]}"
     if enable_debug_command:
         redis_args = f"--enable-debug-command yes {redis_args}".strip()
-    # If moduleArgs sets IMPORT_FOLDER to a job-container path (e.g.
-    # tests/flow/test_load_csv.py points it at .../tests/flow/csvs/), bind-mount
-    # the matching host path into the spawned container at the same path so
-    # LOAD CSV's file:// resolution under that folder sees the test fixtures.
-    # _host_path_for translates via the job container's mount table; on local
-    # dev (no mounts to traverse) it returns the path unchanged.
+    # Bind-mount path-shaped module args (IMPORT_FOLDER, TEMP_FOLDER) so the
+    # spawned sibling container resolves them to the same content the test
+    # set up on the job-container side. Two guards:
+    #   - the path must be covered by the job container's mount table, so
+    #     docker run -v <host>:<dest> targets a real host directory rather
+    #     than silently creating an empty one
+    #   - the path must currently exist, so tests that intentionally pass
+    #     non-existent paths (testConfigTempFolder.test_02) still see the
+    #     module fail validation
     extra_args = []
-    import_folder = _import_folder_arg(falkordb_args)
-    if import_folder:
-        host_path = _host_path_for(import_folder)
-        extra_args += ["-v", f"{host_path}:{import_folder}"]
+    for key, val in _path_args_in(falkordb_args):
+        host_path, covered = _host_path_for(val)
+        if covered and os.path.exists(val):
+            extra_args += ["-v", f"{host_path}:{val}"]
     cmd = [
         "docker", "run", "-d",
         "--network", _job_network(),

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -279,11 +279,19 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     2. CI services mode (FALKORDB_TEST_IMAGE set, FALKORDB_USE_SERVICE=1):
        Connect to a long-running GHA `services:` container at
        FALKORDB_HOST:FALKORDB_PORT — no docker run, no per-class spawn.
-       Selected by the matrix for test files whose Env() invocations carry
-       no special flags (classified by tests/flow/test_matrix_split.py).
-       FLUSHALL between Env() calls gives class-level isolation since the
-       service is shared across all classes in the cell.
-       Passing any special flag here is a classifier miss and raises.
+       Selected by the matrix for test files whose Env() invocations stay
+       within the runtime-mutable set (classified by
+       tests/flow/test_matrix_split.py). FLUSHALL between Env() calls
+       gives class-level isolation since the service is shared across all
+       classes in the cell.
+       Supported flags here:
+         - moduleArgs (runtime-mutable keys only — applied via GRAPH.CONFIG SET)
+         - useSlaves=True — a second `replica` service container is run by
+           the GHA job with --replicaof falkordb 6379
+         - enableDebugCommand=True — no-op; the service is launched with
+           REDIS_ARGS=--enable-debug-command yes regardless
+       Unsupported (classifier miss → raises): env='oss-cluster',
+       shardsCount (cluster topology requires per-class spawn).
 
     3. CI spawn mode (FALKORDB_TEST_IMAGE set, FALKORDB_USE_SERVICE unset):
        Spawn a dedicated container from the RC image per Env() call, with
@@ -383,6 +391,12 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
             redis_args=f"--replicaof {master_alias} 6379",
             enable_debug_command=enableDebugCommand,
         )
+        # Replica handshake is async — wait for INFO replication to report
+        # master_link_status=up before any test queries hit it, mirroring
+        # what services mode does. Without this gate, tests that read from
+        # the replica immediately after Env() can observe a half-synced
+        # state.
+        _wait_for_replication(replica_alias, 6379)
         _attach_slave(env_obj, replica_alias, 6379)
 
     # Some flow tests construct their own connection pools from self.env.port

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -287,12 +287,16 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # startEnv() pings the address; if it doesn't resolve, construction
     # raises before we can override anything. flow.sh's --existing-env-addr
     # is a placeholder that gets superseded here.
-    master_alias, master_port, _ = _spawn_falkordb(
+    master_alias, master_port, master_cid = _spawn_falkordb(
         test_image, falkordb_args=moduleArgs or "",
         enable_debug_command=enableDebugCommand)
     host, port = master_alias, master_port
     Defaults.external_addr = f"{master_alias}:{master_port}"
     env_obj = Environment(decodeResponses=True, env='existing-env')
+    # Expose a file-handle-like reader over the container's stdout/stderr,
+    # which holds the same messages RLTest's master.log would. Tests that
+    # parse redis logs (test_encode_decode.test_10) use this when present.
+    env_obj.read_log = _make_docker_log_reader(master_cid)
     if useSlaves:
         replica_alias, _, _ = _spawn_falkordb(
             test_image,
@@ -315,6 +319,24 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
 
     db = FalkorDB(host, port)
     return (env_obj, db)
+
+
+def _make_docker_log_reader(cid):
+    """Returns a callable read(role='master') that mimics RLTest's file-handle
+    log access: each call returns only the new bytes appended since the prior
+    call, decoded. Backed by `docker logs <cid>`, which captures both redis's
+    stdout (where it logs by default when no --logfile is given) and the
+    module's RedisModule_Log output."""
+    state = {"offset": 0}
+    def read(_role="master"):
+        out = subprocess.run(
+            ["docker", "logs", cid],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+        ).stdout
+        new_bytes = out[state["offset"]:]
+        state["offset"] = len(out)
+        return new_bytes.decode("utf-8", errors="replace")
+    return read
 
 
 def _attach_slave(env_obj, host, port):

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -147,12 +147,17 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
         return (env_obj, db)
 
     # Mode 2: CI. Always private spawn — every Env() call gets a fresh master
-    # (plus replica when useSlaves=True). The RLTest Environment is a stub
-    # (env='existing-env') so it doesn't try to manage redis lifecycle itself.
-    env_obj = Environment(decodeResponses=True, env='existing-env')
+    # (plus replica when useSlaves=True). Order matters: spawn the container
+    # *first*, then point RLTest's existing-env address at it via Defaults
+    # before constructing the Environment. Environment(env='existing-env')'s
+    # startEnv() pings the address; if it doesn't resolve, construction
+    # raises before we can override anything. flow.sh's --existing-env-addr
+    # is a placeholder that gets superseded here.
     master_alias, master_port, _ = _spawn_falkordb(
         test_image, falkordb_args=moduleArgs or "")
     host, port = master_alias, master_port
+    Defaults.external_addr = f"{master_alias}:{master_port}"
+    env_obj = Environment(decodeResponses=True, env='existing-env')
     if useSlaves:
         replica_alias, _, _ = _spawn_falkordb(
             test_image,

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -68,9 +68,31 @@ def _job_network():
     )
 
 
-def _wait_for_redis(host, port, attempts=100, interval=0.1):
-    r = redis.Redis(host=host, port=port, socket_connect_timeout=1)
+def _wait_for_redis(host, port, cid, attempts=50, interval=0.1):
+    """Wait for redis at host:port to PING. Bails out fast if the container
+    has already exited (some tests intentionally pass invalid moduleArgs that
+    abort module load; we shouldn't wait the full budget for those).
+
+    Note `retry=Retry(NoBackoff(),0)`: redis-py 7.4 enables connection
+    retries by default with effectively no upper bound on ConnectionError,
+    so a normal `redis.Redis(...).ping()` against a dead container hangs
+    indefinitely regardless of socket_connect_timeout. We need an explicit
+    no-retry policy to honor our per-attempt budget."""
+    from redis.retry import Retry
+    from redis.backoff import NoBackoff
+    r = redis.Redis(host=host, port=port,
+                    socket_connect_timeout=1,
+                    retry=Retry(NoBackoff(), 0))
     for _ in range(attempts):
+        # If the container exited (e.g. module load failed), don't bother
+        # waiting more — raise immediately so the caller's try/except sees
+        # the failure as the test expects.
+        inspect_out = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Running}}", cid],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False,
+        ).stdout.decode().strip()
+        if inspect_out == "false":
+            raise RuntimeError(f"container {cid[:12]} for {host}:{port} exited before becoming ready")
         try:
             if r.ping():
                 return
@@ -95,7 +117,7 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None):
     ]
     cid = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip()
     _SPAWNED_CIDS.append(cid)
-    _wait_for_redis(alias, 6379)
+    _wait_for_redis(alias, 6379, cid)
     return alias, 6379, cid
 
 

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -1,5 +1,10 @@
+import atexit
 import os
+import socket
+import subprocess
 import sys
+import time
+import uuid
 from functools import wraps
 
 from RLTest import Env as Environment, Defaults
@@ -20,91 +25,180 @@ CODE_COVERAGE = os.getenv('CODE_COVERAGE', '0') == '1'
 # raw sys.platform value if unrecognized.
 OS = {'darwin': 'macos', 'linux': 'linux', 'win32': 'windows'}.get(sys.platform, sys.platform)
 
-# Module configs that can only be set at load time (--loadmodule key value).
-# Mirrors src/lib.rs's ConfigurationFlags::IMMUTABLE list. If a test passes any
-# of these via moduleArgs and we're under EXISTING_ENV, the helper falls back
-# to spawning a private redis via RLTest's env='oss' mode — the running
-# service container can't honor these via GRAPH.CONFIG SET.
-_LOAD_TIME_CONFIG_KEYS = {
-    "CACHE_SIZE", "THREAD_COUNT", "NODE_CREATION_BUFFER",
-    "VKEY_MAX_ENTITY_COUNT", "IMPORT_FOLDER", "TEMP_FOLDER",
-    "JS_HEAP_SIZE", "JS_STACK_SIZE", "CMD_INFO", "DELAY_INDEXING",
-    "BOLT_PORT",  # atomic but doesn't restart the bolt server post-load
-}
+# ──── Private container orchestration (CI path) ─────────────────────────────
+#
+# When a test passes load-time moduleArgs and we're in CI (FALKORDB_TEST_IMAGE
+# set), we can't reconfigure the shared `master` service. Spin up a dedicated
+# container from the same RC image with the desired -e FALKORDB_ARGS=... and
+# point the test client at it.
+#
+# Containers join the same docker network as the job container so they're
+# reachable via their `--network-alias`. Cleanup is best-effort via atexit:
+# the GHA runner is destroyed at job end regardless, so leaking is harmless,
+# but we prefer to remove eagerly.
+
+_SPAWNED_CIDS = []
+_JOB_NETWORK = None
 
 
-def _module_args_to_pairs(s):
-    """Parse a space-separated 'K1 V1 K2 V2 ...' moduleArgs string into pairs."""
-    parts = s.split()
-    if len(parts) % 2 != 0:
-        raise ValueError(f"moduleArgs has odd token count: {s!r}")
-    return list(zip(parts[0::2], parts[1::2]))
+def _job_network():
+    """The docker network the GHA job container is attached to.
+    Spawned containers join this network so the job container can resolve
+    them via their --network-alias."""
+    global _JOB_NETWORK
+    if _JOB_NETWORK is not None:
+        return _JOB_NETWORK
+    hostname = socket.gethostname()
+    out = subprocess.check_output([
+        "docker", "inspect", hostname,
+        "-f", "{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}",
+    ]).decode().strip().split()
+    # Prefer github_network_* if present (the network GHA created for the job);
+    # otherwise fall back to whatever's first.
+    for n in out:
+        if n.startswith("github_network_"):
+            _JOB_NETWORK = n
+            return n
+    if out:
+        _JOB_NETWORK = out[0]
+        return _JOB_NETWORK
+    raise RuntimeError(
+        "could not determine the job container's docker network; "
+        "is /var/run/docker.sock mounted and is the host running docker?"
+    )
 
 
-def _has_load_time_arg(module_args):
-    if not module_args:
-        return False
-    return any(k.upper() in _LOAD_TIME_CONFIG_KEYS
-               for k, _ in _module_args_to_pairs(module_args))
+def _wait_for_redis(host, port, attempts=100, interval=0.1):
+    r = redis.Redis(host=host, port=port, socket_connect_timeout=1)
+    for _ in range(attempts):
+        try:
+            if r.ping():
+                return
+        except Exception:
+            time.sleep(interval)
+    raise RuntimeError(f"redis at {host}:{port} did not become ready after {attempts * interval:.1f}s")
+
+
+def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None):
+    """Start a falkordb container, return (host, port, container_id).
+
+    `falkordb_args` becomes the module's load-time arg string (CACHE_SIZE 16 ...).
+    `redis_args` is forwarded as the redis-server CLI args (for --replicaof, etc.)."""
+    alias = alias or f"falkordb-{uuid.uuid4().hex[:8]}"
+    cmd = [
+        "docker", "run", "-d",
+        "--network", _job_network(),
+        "--network-alias", alias,
+        "-e", f"FALKORDB_ARGS={falkordb_args}",
+        "-e", f"REDIS_ARGS={redis_args}",
+        image,
+    ]
+    cid = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip()
+    _SPAWNED_CIDS.append(cid)
+    _wait_for_redis(alias, 6379)
+    return alias, 6379, cid
+
+
+@atexit.register
+def _cleanup_spawned():
+    for cid in _SPAWNED_CIDS:
+        subprocess.run(
+            ["docker", "rm", "-f", cid],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+
+
+# ──── Env() — RLTest Environment wrapper ────────────────────────────────────
 
 
 def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, shardsCount=None):
-    # Existing-env mode: connect to an already-running redis (CI services-block).
-    # The address comes from flow.sh's --existing-env-addr; FalkorDB client picks
-    # up the same host/port from env so it doesn't fall back to env.port (unreliable
-    # under existing-env).
-    existing_env = os.getenv("EXISTING_ENV", "") == "1"
-    # Tracks which moduleArgs (if any) need to be applied to the running redis
-    # via GRAPH.CONFIG SET after we connect.
-    runtime_config_pairs = []
-    if existing_env:
+    """Construct an RLTest Environment and a FalkorDB client.
+
+    Three execution modes:
+
+    1. Local dev (FALKORDB_TEST_IMAGE unset):
+       RLTest spawns its own redis-server with --loadmodule + moduleArgs.
+       Behavior identical to the original Env(). Untouched by the CI path.
+
+    2. CI default (FALKORDB_TEST_IMAGE set, no moduleArgs, no useSlaves):
+       Connect to the shared `master` GHA service container declared in
+       rust-pr.yml. Cheapest path — no per-class container spin-up.
+
+    3. CI private spawn (FALKORDB_TEST_IMAGE set, moduleArgs OR useSlaves):
+       Spawn a dedicated container from the RC image with -e FALKORDB_ARGS=...
+       baked from moduleArgs (so cross-key validation fires the same way it
+       would under --loadmodule). For useSlaves=True, additionally spawn a
+       paired replica with -e REDIS_ARGS='--replicaof <alias> 6379' on the
+       same docker network. Containers live for the test process's lifetime
+       and are cleaned up by atexit.
+    """
+    test_image = os.getenv("FALKORDB_TEST_IMAGE", "")
+
+    # Mode 1: local dev — original RLTest spawn behavior, untouched.
+    if not test_image:
+        env_obj = Environment(decodeResponses=True, moduleArgs=moduleArgs, env=env,
+                              useSlaves=useSlaves, enableDebugCommand=enableDebugCommand,
+                              shardsCount=shardsCount)
+        # Expose host so tests can use BlockingConnectionPool(host=self.env.host, ...)
+        # uniformly across local dev and CI without per-mode branches.
+        env_obj.host = "localhost"
+        db = FalkorDB("localhost", env_obj.port)
+        return (env_obj, db)
+
+    # Modes 2 & 3: CI. The RLTest Environment is a stub (env='existing-env');
+    # we manage connectivity ourselves so it doesn't try to spawn redis.
+    env_obj = Environment(decodeResponses=True, env='existing-env')
+
+    # Private-spawn when the test cares about something the shared `master`
+    # service can't deliver:
+    #   - moduleArgs (any kind, not just load-time-immutable): the args go
+    #     in -e FALKORDB_ARGS so cross-key validation (TIMEOUT vs TIMEOUT_MAX,
+    #     immutable-key load-time checks, etc.) fires the same way it would
+    #     under RLTest's spawned-redis model.
+    #   - useSlaves: monitor-style assertions need a master that's seen *only*
+    #     this test's traffic. The shared master has earlier-test history.
+    if moduleArgs or useSlaves:
+        # Mode 3: private spawn.
+        master_alias, master_port, _ = _spawn_falkordb(
+            test_image, falkordb_args=moduleArgs or "")
+        host, port = master_alias, master_port
         if useSlaves:
-            # The service-container topology is a single redis. Replica-aware
-            # tests can't be run against it.
-            env_obj = Environment(decodeResponses=True, env=env)
-            env_obj.skip()
-            return (env_obj, None)
-        if _has_load_time_arg(moduleArgs):
-            # Test asked for module config that can't be set on a running
-            # redis. Fall back to RLTest's spawn mode — it'll start its own
-            # redis with --loadmodule <so> + moduleArgs. The .so lives at
-            # target/release/libfalkordb.so in CI (extracted from the service
-            # container) or wherever cargo built it locally.
-            env = 'oss'
-        else:
-            # All moduleArgs (if any) are runtime-settable. Stash them so we
-            # can issue GRAPH.CONFIG SET after the existing-env connect.
-            if moduleArgs:
-                runtime_config_pairs = _module_args_to_pairs(moduleArgs)
-                moduleArgs = None  # don't pass through; existing-env ignores it
-            env = 'existing-env'
-    env = Environment(decodeResponses=True, moduleArgs=moduleArgs, env=env,
-                      useSlaves=useSlaves, enableDebugCommand=enableDebugCommand, shardsCount=shardsCount)
-    if existing_env and env.env == 'existing-env':
-        # Honor FALKORDB_HOST/PORT from the workflow's env block.
-        host = os.getenv("FALKORDB_HOST", "localhost")
-        port_str = os.getenv("FALKORDB_PORT", "6379")
-        try:
-            port = int(port_str)
-        except ValueError as e:
-            raise RuntimeError(
-                f"FALKORDB_PORT must be an integer, got {port_str!r}"
-            ) from e
+            replica_alias, _, _ = _spawn_falkordb(
+                test_image,
+                falkordb_args=moduleArgs or "",
+                redis_args=f"--replicaof {master_alias} 6379",
+            )
+            _attach_slave(env_obj, replica_alias, 6379)
     else:
-        # Either we're in local-dev mode, or we fell back to env='oss' because
-        # of load-time moduleArgs. Either way, RLTest manages its own port.
-        host = "localhost"
-        port = env.port
-    db  = FalkorDB(host, port)
-    # Apply runtime-settable moduleArgs against the now-connected redis. Doing
-    # this after the client is constructed (rather than before Environment())
-    # is correct: existing-env's redis is already up, runtime configs take
-    # effect immediately.
-    if runtime_config_pairs:
-        conn = db.connection
-        for key, value in runtime_config_pairs:
-            conn.execute_command("GRAPH.CONFIG", "SET", key, value)
-    return (env, db)
+        # Mode 2: shared services (no module config customization needed).
+        host = os.getenv("FALKORDB_HOST", "master")
+        port = int(os.getenv("FALKORDB_PORT", "6379"))
+
+    # Some flow tests construct their own connection pools from self.env.port
+    # (assuming RLTest's spawned redis on localhost). Override the env stub's
+    # port/host so those callsites land on our actual instance. envRunner is
+    # the underlying ExistsRedis; tests that read self.env.envRunner.port hit
+    # it too.
+    env_obj.port = port
+    env_obj.host = host
+    if hasattr(env_obj, "envRunner") and env_obj.envRunner is not None:
+        env_obj.envRunner.port = port
+        env_obj.envRunner.host = host
+
+    db = FalkorDB(host, port)
+    return (env_obj, db)
+
+
+def _attach_slave(env_obj, host, port):
+    """Expose a slave-connection accessor on the RLTest Environment.
+
+    RLTest's env.getSlaveConnection() normally returns a redis client for the
+    replica spawned by RLTest. Under our existing-env stub we override it to
+    return a client pointing at the supplied (host, port)."""
+    def _get_slave_connection(*_args, **_kwargs):
+        return redis.Redis(host=host, port=port, decode_responses=True)
+    env_obj.getSlaveConnection = _get_slave_connection
+
 
 def skip():
     def decorate(f):

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -42,18 +42,6 @@ _SPAWNED_CIDS = []
 _JOB_NETWORK = None
 _JOB_MOUNTS = None
 
-# Per-process "current master" / "current replica" tracking for spawn-mode
-# Env() rotation. When a test calls `self.env, self.db = Env(...)` more than
-# once, we stop the previous master and reuse its docker network alias for
-# the new one. That way `self.graph` (set once in __init__ from the original
-# self.db) reconnects transparently to the new container — matching the
-# C-port's "Env() restarts redis on the same port" semantics. Without this,
-# stale references from __init__ keep talking to the old container with
-# its old config, and any test that reassigns Env() mid-flow (test_timeout,
-# test_config, test_udf) sees the new moduleArgs silently ignored.
-_CURRENT_MASTER = None  # dict(alias=str, cid=str) or None
-_CURRENT_REPLICA = None  # dict(alias=str, cid=str) or None
-
 
 def _job_mounts():
     """The job container's mount table: list of (host_source, in_container_dest)
@@ -245,41 +233,6 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
     return alias, 6379, cid
 
 
-def _stop_container(cid):
-    """Capture logs then stop+remove a previously-spawned container.
-
-    Called from Env() before spawning a replacement master/replica so the new
-    container can rebind the same alias. Logs are dumped to tests/flow/logs/
-    immediately (rather than at process exit) since the CID would otherwise
-    disappear before atexit captures it. Best-effort: failures don't propagate.
-    """
-    log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
-    os.makedirs(log_dir, exist_ok=True)
-    short = cid[:12]
-    try:
-        with open(os.path.join(log_dir, f"spawned-{short}.log"), "wb") as f:
-            subprocess.run(
-                ["docker", "logs", cid],
-                stdout=f, stderr=subprocess.STDOUT, check=False,
-            )
-        # SIGTERM with 10s grace so ASAN's at-exit reports land before SIGKILL.
-        subprocess.run(
-            ["docker", "stop", "--time", "10", cid],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
-        )
-        subprocess.run(
-            ["docker", "rm", "-f", cid],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
-        )
-    except Exception:
-        pass
-    # Best-effort removal from the cleanup list so atexit doesn't double-stop.
-    try:
-        _SPAWNED_CIDS.remove(cid)
-    except ValueError:
-        pass
-
-
 @atexit.register
 def _cleanup_spawned():
     # Capture docker stdout/stderr for each spawned container before tearing
@@ -413,26 +366,9 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # startEnv() pings the address; if it doesn't resolve, construction
     # raises before we can override anything. flow.sh's --existing-env-addr
     # is a placeholder that gets superseded here.
-    #
-    # If we already have a master from a previous Env() call in this test
-    # process, stop it and reuse its docker network alias for the new
-    # container. The reused alias means `self.graph` (set once in __init__
-    # via the original self.db) reconnects transparently to the new master
-    # — matching the C-port's "Env() restarts redis on the same port"
-    # semantics that tests like test_timeout.test07 depend on. Same for the
-    # replica.
-    global _CURRENT_MASTER, _CURRENT_REPLICA
-    if _CURRENT_MASTER is not None:
-        _stop_container(_CURRENT_MASTER["cid"])
-        master_alias_reuse = _CURRENT_MASTER["alias"]
-        _CURRENT_MASTER = None
-    else:
-        master_alias_reuse = None
     master_alias, master_port, master_cid = _spawn_falkordb(
         test_image, falkordb_args=moduleArgs or "",
-        alias=master_alias_reuse,
         enable_debug_command=enableDebugCommand)
-    _CURRENT_MASTER = {"alias": master_alias, "cid": master_cid}
     host, port = master_alias, master_port
     Defaults.external_addr = f"{master_alias}:{master_port}"
     env_obj = Environment(decodeResponses=True, env='existing-env')
@@ -441,26 +377,13 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # parse redis logs (test_encode_decode.test_10) use this when present.
     env_obj.read_log = _make_docker_log_reader(master_cid)
     if useSlaves:
-        if _CURRENT_REPLICA is not None:
-            _stop_container(_CURRENT_REPLICA["cid"])
-            replica_alias_reuse = _CURRENT_REPLICA["alias"]
-            _CURRENT_REPLICA = None
-        else:
-            replica_alias_reuse = None
-        replica_alias, _, replica_cid = _spawn_falkordb(
+        replica_alias, _, _ = _spawn_falkordb(
             test_image,
             falkordb_args=moduleArgs or "",
             redis_args=f"--replicaof {master_alias} 6379",
-            alias=replica_alias_reuse,
             enable_debug_command=enableDebugCommand,
         )
-        _CURRENT_REPLICA = {"alias": replica_alias, "cid": replica_cid}
         _attach_slave(env_obj, replica_alias, 6379)
-    elif _CURRENT_REPLICA is not None:
-        # New master came up without a replica; stop the old one so it can't
-        # try to replicate from a container that no longer exists.
-        _stop_container(_CURRENT_REPLICA["cid"])
-        _CURRENT_REPLICA = None
 
     # Some flow tests construct their own connection pools from self.env.port
     # (assuming RLTest's spawned redis on localhost). Override the env stub's

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -270,13 +270,22 @@ def _cleanup_spawned():
 def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, shardsCount=None):
     """Construct an RLTest Environment and a FalkorDB client.
 
-    Two execution modes:
+    Three execution modes:
 
     1. Local dev (FALKORDB_TEST_IMAGE unset):
        RLTest spawns its own redis-server with --loadmodule + moduleArgs.
        Behavior identical to the original Env(). Untouched by the CI path.
 
-    2. CI (FALKORDB_TEST_IMAGE set):
+    2. CI services mode (FALKORDB_TEST_IMAGE set, FALKORDB_USE_SERVICE=1):
+       Connect to a long-running GHA `services:` container at
+       FALKORDB_HOST:FALKORDB_PORT — no docker run, no per-class spawn.
+       Selected by the matrix for test files whose Env() invocations carry
+       no special flags (classified by tests/flow/test_matrix_split.py).
+       FLUSHALL between Env() calls gives class-level isolation since the
+       service is shared across all classes in the cell.
+       Passing any special flag here is a classifier miss and raises.
+
+    3. CI spawn mode (FALKORDB_TEST_IMAGE set, FALKORDB_USE_SERVICE unset):
        Spawn a dedicated container from the RC image per Env() call, with
        -e FALKORDB_ARGS=... baked from moduleArgs so cross-key validation
        (TIMEOUT vs TIMEOUT_MAX, immutable CACHE_SIZE/THREAD_COUNT/...) fires
@@ -290,6 +299,7 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
        startup; cells run in parallel so wall-clock impact is small.
     """
     test_image = os.getenv("FALKORDB_TEST_IMAGE", "")
+    use_service = os.getenv("FALKORDB_USE_SERVICE", "") != ""
 
     # Mode 1: local dev — original RLTest spawn behavior, untouched.
     if not test_image:
@@ -302,7 +312,34 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
         db = FalkorDB("localhost", env_obj.port)
         return (env_obj, db)
 
-    # Mode 2: CI. Always private spawn — every Env() call gets a fresh master
+    # Mode 2: services — shared GHA service container per matrix cell.
+    if use_service:
+        if moduleArgs or useSlaves or enableDebugCommand or env != 'oss' or shardsCount:
+            raise RuntimeError(
+                "Services-mode Env() doesn't support moduleArgs / useSlaves / "
+                "enableDebugCommand / oss-cluster / shardsCount. This file was "
+                "routed to the services bucket but uses a special flag; either "
+                "reclassify in tests/flow/test_matrix_split.py or remove the flag. "
+                f"Got moduleArgs={moduleArgs!r} useSlaves={useSlaves} "
+                f"enableDebugCommand={enableDebugCommand} env={env!r} "
+                f"shardsCount={shardsCount}."
+            )
+        host = os.getenv("FALKORDB_HOST", "falkordb")
+        port = int(os.getenv("FALKORDB_PORT", "6379"))
+        # Wipe the shared service back to a clean state so each class starts
+        # fresh — mirrors the per-class isolation spawn-mode gets for free.
+        redis.Redis(host=host, port=port).flushall()
+        Defaults.external_addr = f"{host}:{port}"
+        env_obj = Environment(decodeResponses=True, env='existing-env')
+        env_obj.port = port
+        env_obj.host = host
+        if hasattr(env_obj, "envRunner") and env_obj.envRunner is not None:
+            env_obj.envRunner.port = port
+            env_obj.envRunner.host = host
+        db = FalkorDB(host, port)
+        return (env_obj, db)
+
+    # Mode 3: CI spawn — every Env() call gets a fresh master container
     # (plus replica when useSlaves=True). Order matters: spawn the container
     # *first*, then point RLTest's existing-env address at it via Defaults
     # before constructing the Environment. Environment(env='existing-env')'s

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -235,7 +235,29 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
 
 @atexit.register
 def _cleanup_spawned():
+    # Capture docker stdout/stderr for each spawned container before tearing
+    # it down. tests/flow/logs/ is the directory RLTest uses for its own
+    # per-test logs and is uploaded as a GHA artifact on failure, so dropping
+    # files there means a failed run carries everything needed for post-mortem:
+    #   - redis-server lifecycle messages (default destination: stderr)
+    #   - module RedisModule_Log output (routes through redis's logger)
+    #   - ASAN/LSan reports (default destination: stderr, no log_path set)
+    log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+    os.makedirs(log_dir, exist_ok=True)
     for cid in _SPAWNED_CIDS:
+        short = cid[:12]
+        # Graceful SIGTERM with a 10s grace before SIGKILL gives ASAN's
+        # at-exit leak detection time to print before the container dies;
+        # `docker rm -f` alone would SIGKILL immediately and drop those.
+        subprocess.run(
+            ["docker", "stop", "--time", "10", cid],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+        with open(os.path.join(log_dir, f"spawned-{short}.log"), "wb") as f:
+            subprocess.run(
+                ["docker", "logs", cid],
+                stdout=f, stderr=subprocess.STDOUT, check=False,
+            )
         subprocess.run(
             ["docker", "rm", "-f", cid],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -313,15 +313,19 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
         return (env_obj, db)
 
     # Mode 2: services — shared GHA service container per matrix cell.
+    # enableDebugCommand=True is a no-op here because the services job runs
+    # the falkordb container with REDIS_ARGS=--enable-debug-command yes; the
+    # flag was historically a spawn-trigger but the classifier no longer
+    # routes on it. useSlaves=True is supported via a second `replica`
+    # service the job runs with --replicaof falkordb 6379.
     if use_service:
-        if moduleArgs or useSlaves or enableDebugCommand or env != 'oss' or shardsCount:
+        if moduleArgs or env != 'oss' or shardsCount:
             raise RuntimeError(
-                "Services-mode Env() doesn't support moduleArgs / useSlaves / "
-                "enableDebugCommand / oss-cluster / shardsCount. This file was "
-                "routed to the services bucket but uses a special flag; either "
-                "reclassify in tests/flow/test_matrix_split.py or remove the flag. "
-                f"Got moduleArgs={moduleArgs!r} useSlaves={useSlaves} "
-                f"enableDebugCommand={enableDebugCommand} env={env!r} "
+                "Services-mode Env() doesn't support moduleArgs / "
+                "oss-cluster / shardsCount. This file was routed to the "
+                "services bucket but uses a special flag; either reclassify "
+                "in tests/flow/test_matrix_split.py or remove the flag. "
+                f"Got moduleArgs={moduleArgs!r} env={env!r} "
                 f"shardsCount={shardsCount}."
             )
         host = os.getenv("FALKORDB_HOST", "falkordb")
@@ -336,6 +340,16 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
         if hasattr(env_obj, "envRunner") and env_obj.envRunner is not None:
             env_obj.envRunner.port = port
             env_obj.envRunner.host = host
+        if useSlaves:
+            replica_host = os.getenv("FALKORDB_REPLICA_HOST", "replica")
+            replica_port = int(os.getenv("FALKORDB_REPLICA_PORT", "6379"))
+            # Both service containers come up in parallel; the replica may
+            # need a few seconds to discover and sync from master before
+            # the test starts querying it. Block until INFO replication
+            # reports master_link_status=up so the test never hits a
+            # half-replicated state.
+            _wait_for_replication(replica_host, replica_port)
+            _attach_slave(env_obj, replica_host, replica_port)
         db = FalkorDB(host, port)
         return (env_obj, db)
 
@@ -378,6 +392,27 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
 
     db = FalkorDB(host, port)
     return (env_obj, db)
+
+
+def _wait_for_replication(host, port, attempts=50, interval=0.2):
+    """Block until the replica at host:port reports it has finished syncing
+    from its master (master_link_status=up, master_sync_in_progress=0).
+    Services come up in parallel and the replica's `--replicaof` only
+    starts trying to connect once redis is initialized, so the first few
+    INFO replication calls may show 'down' or 'connecting'."""
+    r = redis.Redis(host=host, port=port)
+    for _ in range(attempts):
+        try:
+            info = r.info('replication')
+            if (info.get('master_link_status') == 'up'
+                    and int(info.get('master_sync_in_progress', 1)) == 0):
+                return
+        except Exception:
+            pass
+        time.sleep(interval)
+    raise RuntimeError(
+        f"replica at {host}:{port} did not reach master_link_status=up "
+        f"in {attempts * interval:.1f}s")
 
 
 def _make_docker_log_reader(cid):

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -292,10 +292,18 @@ def _attach_slave(env_obj, host, port):
 
     RLTest's env.getSlaveConnection() normally returns a redis client for the
     replica spawned by RLTest. Under our existing-env stub we override it to
-    return a client pointing at the supplied (host, port)."""
+    return a client pointing at the supplied (host, port).
+
+    Also stash `replica_host`/`replica_port` on the env so test code that
+    constructs its own clients (FalkorDB, AsyncRedis, etc.) at the replica
+    can address it directly. RLTest's original model puts the replica at
+    port+1 on localhost — that assumption doesn't hold under docker-per-class
+    where the replica is a sibling container on a network alias."""
     def _get_slave_connection(*_args, **_kwargs):
         return redis.Redis(host=host, port=port, decode_responses=True)
     env_obj.getSlaveConnection = _get_slave_connection
+    env_obj.replica_host = host
+    env_obj.replica_port = port
 
 
 def skip():

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -39,6 +39,70 @@ OS = {'darwin': 'macos', 'linux': 'linux', 'win32': 'windows'}.get(sys.platform,
 
 _SPAWNED_CIDS = []
 _JOB_NETWORK = None
+_JOB_MOUNTS = None
+
+
+def _job_mounts():
+    """The job container's mount table: list of (host_source, in_container_dest)
+    tuples, sorted by destination length (longest first) so the deepest mount
+    matches before any parent. Used to translate an in-container path to its
+    host-side equivalent for bind-mounting into spawned sibling containers.
+
+    The spawned containers go through the host docker daemon (via the bind-
+    mounted /var/run/docker.sock), so `-v <src>:<dest>` interprets <src> as a
+    *host* path — not as a path inside the job container. Without this
+    translation, mounting e.g. /__w/repo/repo/tests/flow/csvs (a job-container
+    path) silently creates a fresh empty directory on the host instead of
+    surfacing the test's CSV files."""
+    global _JOB_MOUNTS
+    if _JOB_MOUNTS is not None:
+        return _JOB_MOUNTS
+    hostname = socket.gethostname()
+    # On bare-metal-host dev runs the hostname doesn't match any container,
+    # so `docker inspect` exits non-zero. Treat that as "no mount table" —
+    # _host_path_for then returns paths unchanged, which is correct because
+    # IMPORT_FOLDER is already a host path in that scenario.
+    proc = subprocess.run(
+        ["docker", "inspect", hostname,
+         "-f", "{{range .Mounts}}{{.Source}}={{.Destination}}\n{{end}}"],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False,
+    )
+    mounts = []
+    if proc.returncode == 0:
+        for line in proc.stdout.decode().splitlines():
+            line = line.strip()
+            if "=" not in line:
+                continue
+            src, dest = line.split("=", 1)
+            mounts.append((src, dest))
+        mounts.sort(key=lambda m: len(m[1]), reverse=True)
+    _JOB_MOUNTS = mounts
+    return mounts
+
+
+def _host_path_for(in_container_path):
+    """Translate an in-container absolute path to the host path that backs it,
+    via the job container's mount table. If no mount covers the path, return
+    it unchanged (local dev: the spawn happens directly on the host, so the
+    path is already the host path)."""
+    for src, dest in _job_mounts():
+        if in_container_path == dest or in_container_path.startswith(dest.rstrip("/") + "/"):
+            return src + in_container_path[len(dest):]
+    return in_container_path
+
+
+def _import_folder_arg(falkordb_args):
+    """Extract IMPORT_FOLDER's value from a module-args string. moduleArgs is
+    a space-separated `KEY VALUE KEY VALUE ...` sequence (matches the format
+    redis-server's --loadmodule consumes), so the value is the token directly
+    after IMPORT_FOLDER. Returns None if absent."""
+    if not falkordb_args:
+        return None
+    toks = falkordb_args.split()
+    for i, t in enumerate(toks):
+        if t == "IMPORT_FOLDER" and i + 1 < len(toks):
+            return toks[i + 1]
+    return None
 
 
 def _job_network():
@@ -113,12 +177,24 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
     alias = alias or f"falkordb-{uuid.uuid4().hex[:8]}"
     if enable_debug_command:
         redis_args = f"--enable-debug-command yes {redis_args}".strip()
+    # If moduleArgs sets IMPORT_FOLDER to a job-container path (e.g.
+    # tests/flow/test_load_csv.py points it at .../tests/flow/csvs/), bind-mount
+    # the matching host path into the spawned container at the same path so
+    # LOAD CSV's file:// resolution under that folder sees the test fixtures.
+    # _host_path_for translates via the job container's mount table; on local
+    # dev (no mounts to traverse) it returns the path unchanged.
+    extra_args = []
+    import_folder = _import_folder_arg(falkordb_args)
+    if import_folder:
+        host_path = _host_path_for(import_folder)
+        extra_args += ["-v", f"{host_path}:{import_folder}"]
     cmd = [
         "docker", "run", "-d",
         "--network", _job_network(),
         "--network-alias", alias,
         "-e", f"FALKORDB_ARGS={falkordb_args}",
         "-e", f"REDIS_ARGS={redis_args}",
+        *extra_args,
         image,
     ]
     cid = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode().strip()

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -114,23 +114,24 @@ def _cleanup_spawned():
 def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, shardsCount=None):
     """Construct an RLTest Environment and a FalkorDB client.
 
-    Three execution modes:
+    Two execution modes:
 
     1. Local dev (FALKORDB_TEST_IMAGE unset):
        RLTest spawns its own redis-server with --loadmodule + moduleArgs.
        Behavior identical to the original Env(). Untouched by the CI path.
 
-    2. CI default (FALKORDB_TEST_IMAGE set, no moduleArgs, no useSlaves):
-       Connect to the shared `master` GHA service container declared in
-       rust-pr.yml. Cheapest path — no per-class container spin-up.
+    2. CI (FALKORDB_TEST_IMAGE set):
+       Spawn a dedicated container from the RC image per Env() call, with
+       -e FALKORDB_ARGS=... baked from moduleArgs so cross-key validation
+       (TIMEOUT vs TIMEOUT_MAX, immutable CACHE_SIZE/THREAD_COUNT/...) fires
+       the same way it would under --loadmodule. For useSlaves=True, an
+       additional replica container is spawned on the same docker network
+       with REDIS_ARGS='--replicaof <alias> 6379'. Containers live for the
+       test process's lifetime and are cleaned up by atexit.
 
-    3. CI private spawn (FALKORDB_TEST_IMAGE set, moduleArgs OR useSlaves):
-       Spawn a dedicated container from the RC image with -e FALKORDB_ARGS=...
-       baked from moduleArgs (so cross-key validation fires the same way it
-       would under --loadmodule). For useSlaves=True, additionally spawn a
-       paired replica with -e REDIS_ARGS='--replicaof <alias> 6379' on the
-       same docker network. Containers live for the test process's lifetime
-       and are cleaned up by atexit.
+       Every Env() call gets a fresh container — full per-class isolation,
+       no cross-test state leakage. Each call adds ~1-2s of container
+       startup; cells run in parallel so wall-clock impact is small.
     """
     test_image = os.getenv("FALKORDB_TEST_IMAGE", "")
 
@@ -145,34 +146,20 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
         db = FalkorDB("localhost", env_obj.port)
         return (env_obj, db)
 
-    # Modes 2 & 3: CI. The RLTest Environment is a stub (env='existing-env');
-    # we manage connectivity ourselves so it doesn't try to spawn redis.
+    # Mode 2: CI. Always private spawn — every Env() call gets a fresh master
+    # (plus replica when useSlaves=True). The RLTest Environment is a stub
+    # (env='existing-env') so it doesn't try to manage redis lifecycle itself.
     env_obj = Environment(decodeResponses=True, env='existing-env')
-
-    # Private-spawn when the test cares about something the shared `master`
-    # service can't deliver:
-    #   - moduleArgs (any kind, not just load-time-immutable): the args go
-    #     in -e FALKORDB_ARGS so cross-key validation (TIMEOUT vs TIMEOUT_MAX,
-    #     immutable-key load-time checks, etc.) fires the same way it would
-    #     under RLTest's spawned-redis model.
-    #   - useSlaves: monitor-style assertions need a master that's seen *only*
-    #     this test's traffic. The shared master has earlier-test history.
-    if moduleArgs or useSlaves:
-        # Mode 3: private spawn.
-        master_alias, master_port, _ = _spawn_falkordb(
-            test_image, falkordb_args=moduleArgs or "")
-        host, port = master_alias, master_port
-        if useSlaves:
-            replica_alias, _, _ = _spawn_falkordb(
-                test_image,
-                falkordb_args=moduleArgs or "",
-                redis_args=f"--replicaof {master_alias} 6379",
-            )
-            _attach_slave(env_obj, replica_alias, 6379)
-    else:
-        # Mode 2: shared services (no module config customization needed).
-        host = os.getenv("FALKORDB_HOST", "master")
-        port = int(os.getenv("FALKORDB_PORT", "6379"))
+    master_alias, master_port, _ = _spawn_falkordb(
+        test_image, falkordb_args=moduleArgs or "")
+    host, port = master_alias, master_port
+    if useSlaves:
+        replica_alias, _, _ = _spawn_falkordb(
+            test_image,
+            falkordb_args=moduleArgs or "",
+            redis_args=f"--replicaof {master_alias} 6379",
+        )
+        _attach_slave(env_obj, replica_alias, 6379)
 
     # Some flow tests construct their own connection pools from self.env.port
     # (assuming RLTest's spawned redis on localhost). Override the env stub's

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -42,6 +42,18 @@ _SPAWNED_CIDS = []
 _JOB_NETWORK = None
 _JOB_MOUNTS = None
 
+# Per-process "current master" / "current replica" tracking for spawn-mode
+# Env() rotation. When a test calls `self.env, self.db = Env(...)` more than
+# once, we stop the previous master and reuse its docker network alias for
+# the new one. That way `self.graph` (set once in __init__ from the original
+# self.db) reconnects transparently to the new container — matching the
+# C-port's "Env() restarts redis on the same port" semantics. Without this,
+# stale references from __init__ keep talking to the old container with
+# its old config, and any test that reassigns Env() mid-flow (test_timeout,
+# test_config, test_udf) sees the new moduleArgs silently ignored.
+_CURRENT_MASTER = None  # dict(alias=str, cid=str) or None
+_CURRENT_REPLICA = None  # dict(alias=str, cid=str) or None
+
 
 def _job_mounts():
     """The job container's mount table: list of (host_source, in_container_dest)
@@ -233,6 +245,41 @@ def _spawn_falkordb(image, falkordb_args="", redis_args="", alias=None,
     return alias, 6379, cid
 
 
+def _stop_container(cid):
+    """Capture logs then stop+remove a previously-spawned container.
+
+    Called from Env() before spawning a replacement master/replica so the new
+    container can rebind the same alias. Logs are dumped to tests/flow/logs/
+    immediately (rather than at process exit) since the CID would otherwise
+    disappear before atexit captures it. Best-effort: failures don't propagate.
+    """
+    log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    short = cid[:12]
+    try:
+        with open(os.path.join(log_dir, f"spawned-{short}.log"), "wb") as f:
+            subprocess.run(
+                ["docker", "logs", cid],
+                stdout=f, stderr=subprocess.STDOUT, check=False,
+            )
+        # SIGTERM with 10s grace so ASAN's at-exit reports land before SIGKILL.
+        subprocess.run(
+            ["docker", "stop", "--time", "10", cid],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+        subprocess.run(
+            ["docker", "rm", "-f", cid],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        )
+    except Exception:
+        pass
+    # Best-effort removal from the cleanup list so atexit doesn't double-stop.
+    try:
+        _SPAWNED_CIDS.remove(cid)
+    except ValueError:
+        pass
+
+
 @atexit.register
 def _cleanup_spawned():
     # Capture docker stdout/stderr for each spawned container before tearing
@@ -366,9 +413,26 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # startEnv() pings the address; if it doesn't resolve, construction
     # raises before we can override anything. flow.sh's --existing-env-addr
     # is a placeholder that gets superseded here.
+    #
+    # If we already have a master from a previous Env() call in this test
+    # process, stop it and reuse its docker network alias for the new
+    # container. The reused alias means `self.graph` (set once in __init__
+    # via the original self.db) reconnects transparently to the new master
+    # — matching the C-port's "Env() restarts redis on the same port"
+    # semantics that tests like test_timeout.test07 depend on. Same for the
+    # replica.
+    global _CURRENT_MASTER, _CURRENT_REPLICA
+    if _CURRENT_MASTER is not None:
+        _stop_container(_CURRENT_MASTER["cid"])
+        master_alias_reuse = _CURRENT_MASTER["alias"]
+        _CURRENT_MASTER = None
+    else:
+        master_alias_reuse = None
     master_alias, master_port, master_cid = _spawn_falkordb(
         test_image, falkordb_args=moduleArgs or "",
+        alias=master_alias_reuse,
         enable_debug_command=enableDebugCommand)
+    _CURRENT_MASTER = {"alias": master_alias, "cid": master_cid}
     host, port = master_alias, master_port
     Defaults.external_addr = f"{master_alias}:{master_port}"
     env_obj = Environment(decodeResponses=True, env='existing-env')
@@ -377,13 +441,26 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # parse redis logs (test_encode_decode.test_10) use this when present.
     env_obj.read_log = _make_docker_log_reader(master_cid)
     if useSlaves:
-        replica_alias, _, _ = _spawn_falkordb(
+        if _CURRENT_REPLICA is not None:
+            _stop_container(_CURRENT_REPLICA["cid"])
+            replica_alias_reuse = _CURRENT_REPLICA["alias"]
+            _CURRENT_REPLICA = None
+        else:
+            replica_alias_reuse = None
+        replica_alias, _, replica_cid = _spawn_falkordb(
             test_image,
             falkordb_args=moduleArgs or "",
             redis_args=f"--replicaof {master_alias} 6379",
+            alias=replica_alias_reuse,
             enable_debug_command=enableDebugCommand,
         )
+        _CURRENT_REPLICA = {"alias": replica_alias, "cid": replica_cid}
         _attach_slave(env_obj, replica_alias, 6379)
+    elif _CURRENT_REPLICA is not None:
+        # New master came up without a replica; stop the old one so it can't
+        # try to replicate from a container that no longer exists.
+        _stop_container(_CURRENT_REPLICA["cid"])
+        _CURRENT_REPLICA = None
 
     # Some flow tests construct their own connection pools from self.env.port
     # (assuming RLTest's spawned redis on localhost). Override the env stub's

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -319,20 +319,26 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
     # routes on it. useSlaves=True is supported via a second `replica`
     # service the job runs with --replicaof falkordb 6379.
     if use_service:
-        if moduleArgs or env != 'oss' or shardsCount:
+        if env != 'oss' or shardsCount:
             raise RuntimeError(
-                "Services-mode Env() doesn't support moduleArgs / "
-                "oss-cluster / shardsCount. This file was routed to the "
-                "services bucket but uses a special flag; either reclassify "
-                "in tests/flow/test_matrix_split.py or remove the flag. "
-                f"Got moduleArgs={moduleArgs!r} env={env!r} "
-                f"shardsCount={shardsCount}."
+                "Services-mode Env() doesn't support oss-cluster / "
+                "shardsCount. This file was routed to the services bucket "
+                "but uses a cluster flag; either reclassify in "
+                "tests/flow/test_matrix_split.py or remove the flag. "
+                f"Got env={env!r} shardsCount={shardsCount}."
             )
         host = os.getenv("FALKORDB_HOST", "falkordb")
         port = int(os.getenv("FALKORDB_PORT", "6379"))
         # Wipe the shared service back to a clean state so each class starts
         # fresh — mirrors the per-class isolation spawn-mode gets for free.
         redis.Redis(host=host, port=port).flushall()
+        # moduleArgs (runtime-mutable keys only — the classifier guarantees
+        # immutable keys go to spawn) are applied via GRAPH.CONFIG SET.
+        # A failed SET propagates as RuntimeError so tests that expect
+        # invalid-args to raise still catch via their try/except wrappers
+        # (e.g. test_timeout.test05_invalid_loadtime_config relies on this).
+        if moduleArgs:
+            _apply_module_args_via_config_set(host, port, moduleArgs)
         Defaults.external_addr = f"{host}:{port}"
         env_obj = Environment(decodeResponses=True, env='existing-env')
         env_obj.port = port
@@ -392,6 +398,36 @@ def Env(moduleArgs=None, env='oss', useSlaves=False, enableDebugCommand=False, s
 
     db = FalkorDB(host, port)
     return (env_obj, db)
+
+
+def _apply_module_args_via_config_set(host, port, module_args):
+    """Apply space-separated `KEY VALUE` pairs via GRAPH.CONFIG SET.
+
+    The classifier (tests/flow/test_matrix_split.py) only routes files to
+    services if every moduleArgs key is runtime-mutable. So this can apply
+    each pair without checking. If a SET returns an error (e.g. invalid
+    value, or a combination the module rejects like TIMEOUT alongside
+    TIMEOUT_DEFAULT), we surface it as RuntimeError — tests that
+    intentionally expect Env() to raise (test_timeout.test05) still catch
+    via their bare except."""
+    toks = module_args.split()
+    if len(toks) % 2 != 0:
+        raise RuntimeError(
+            f"moduleArgs must be space-separated KEY VALUE pairs: "
+            f"got {module_args!r}"
+        )
+    conn = redis.Redis(host=host, port=port)
+    for i in range(0, len(toks), 2):
+        key, value = toks[i], toks[i + 1]
+        try:
+            conn.execute_command("GRAPH.CONFIG", "SET", key, value)
+        except redis.ResponseError as e:
+            raise RuntimeError(
+                f"GRAPH.CONFIG SET {key} {value} failed: {e}. "
+                "If this key is actually immutable, add it to "
+                "IMMUTABLE_MODULE_ARGS in tests/flow/test_matrix_split.py "
+                "so this file routes to the spawn bucket."
+            ) from e
 
 
 def _wait_for_replication(host, port, attempts=50, interval=0.2):

--- a/tests/flow/test_cache.py
+++ b/tests/flow/test_cache.py
@@ -259,7 +259,7 @@ class testCache():
         async def run(self):
             # connection pool with 16 connections
             # blocking when there's no connections available
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph('cache_eviction')
 

--- a/tests/flow/test_concurrent_query.py
+++ b/tests/flow/test_concurrent_query.py
@@ -23,7 +23,7 @@ async def delete_graph(g):
 class testConcurrentQueryFlow(FlowTestsBase):
     def __init__(self):
         self.env, self.db = Env()
-        self.conn = redis.Redis(os.getenv("FALKORDB_HOST", "localhost"), self.env.port)
+        self.conn = redis.Redis(self.env.host, self.env.port)
         self.graph = self.db.select_graph(GRAPH_ID)
 
     def setUp(self):
@@ -32,7 +32,7 @@ class testConcurrentQueryFlow(FlowTestsBase):
 
     def run_queries_concurrently(self, queries):
         async def run(self, queries):            
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
@@ -109,7 +109,7 @@ class testConcurrentQueryFlow(FlowTestsBase):
     def test_04_concurrent_delete(self):
         async def run(self):
             self.graph.query("RETURN 1")
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
@@ -130,8 +130,8 @@ class testConcurrentQueryFlow(FlowTestsBase):
     # Try to delete a graph while multiple queries are executing.
     def test_05_concurrent_read_delete(self):
         async def run(self):
-            async_conn = AsyncRedis(host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port)
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            async_conn = AsyncRedis(host=self.env.host, port=self.env.port)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
@@ -198,10 +198,10 @@ class testConcurrentQueryFlow(FlowTestsBase):
         async def run(self):
             # connect to async graph via a connection pool
             # which will block if there are no available connections
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
-            async_conn = AsyncRedis(host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port)
+            async_conn = AsyncRedis(host=self.env.host, port=self.env.port)
 
             # Test setup - validate that graph exists and possible results are None
             self.graph.query("RETURN 1")
@@ -233,12 +233,12 @@ class testConcurrentQueryFlow(FlowTestsBase):
         async def run(self):
             # connect to async graph via a connection pool
             # which will block if there are no available connections
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
             # single async connection
-            async_conn = AsyncRedis(host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port)
+            async_conn = AsyncRedis(host=self.env.host, port=self.env.port)
 
             # Test setup - validate that graph exists and possible results are None
             # Create new empty graph with ID SECONDARY_GRAPH_ID
@@ -284,12 +284,12 @@ class testConcurrentQueryFlow(FlowTestsBase):
         async def run(self):
             # connect to async graph via a connection pool
             # which will block if there are no available connections
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
             # single async connection
-            async_conn = AsyncRedis(host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port)
+            async_conn = AsyncRedis(host=self.env.host, port=self.env.port)
 
             # Test setup - validate that graph exists and possible results are None
             self.graph.query("MATCH (n) RETURN n")
@@ -349,7 +349,7 @@ class testConcurrentQueryFlow(FlowTestsBase):
         async def run(self):
             self.graph.query("RETURN 1")
 
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 
@@ -400,7 +400,7 @@ class testConcurrentQueryFlow(FlowTestsBase):
 
     def test_11_concurrent_resize_zero_matrix(self):
         async def run(self):
-            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=os.getenv("FALKORDB_HOST", "localhost"), port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=16, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -366,7 +366,10 @@ class testConfigTempFolder:
     def test_01_temp_folder_is_file(self):
         # try setting TEMP_FOLDER to a file
         # expecting config update to fail
-        fd, file_path = tempfile.mkstemp()
+        # mountable_mkstemp puts the file under the workspace so it is
+        # visible to the docker-per-class spawned container via the
+        # bind-mount logic in common._spawn_falkordb.
+        fd, file_path = mountable_mkstemp()
         os.close(fd)
 
         # try updating TEMP_FOLDER
@@ -397,8 +400,9 @@ class testConfigTempFolder:
         # try setting TEMP_FOLDER to a folder which we can't write to
         # expecting config update to fail, as write access is mandatory
 
-        # create a temp folder with no write access
-        no_perm_dir = tempfile.mkdtemp()
+        # create a temp folder with no write access (workspace-rooted so
+        # spawned sibling containers see it via the bind-mount in common.py)
+        no_perm_dir = mountable_mkdtemp()
         os.chmod(no_perm_dir, stat.S_IREAD)
 
         # check if directory is truly unwritable
@@ -422,7 +426,8 @@ class testConfigTempFolder:
         # try setting TEMP_FOLDER to a valid folder
         # expecting config update to succeed
 
-        valid_dir = tempfile.mkdtemp()
+        # workspace-rooted so the spawned container can see it
+        valid_dir = mountable_mkdtemp()
 
         try:
             self.set_temp_folder(valid_dir)

--- a/tests/flow/test_effects.py
+++ b/tests/flow/test_effects.py
@@ -98,7 +98,9 @@ class testEffects():
 
         self.effects_enable()
 
-        self.monitor_thread = threading.Thread(target=self.monitor_thread)
+        # daemon=True so a stuck listen() (replica killed mid-MONITOR, container
+        # gone, …) doesn't keep the test process alive past test completion.
+        self.monitor_thread = threading.Thread(target=self.monitor_thread, daemon=True)
         self.monitor_thread.start()
         # wait for monitor thread to attach
         while MONITOR_ATTACHED is False:

--- a/tests/flow/test_encode_decode.py
+++ b/tests/flow/test_encode_decode.py
@@ -195,43 +195,48 @@ class test_encode_decode(FlowTestsBase):
         # stdout, exposed via env.read_log() (file-handle-like read()).
         # Under RLTest the log is a real file on disk addressed via
         # envRunner._getFileName + env.logDir.
+        logfile = None
         if hasattr(self.env, "read_log"):
             read_log = self.env.read_log
         else:
             logfilename = self.env.envRunner._getFileName("master", ".log")
             logfile = open(f"{self.env.logDir}/{logfilename}")
             read_log = logfile.read
-        # advance past startup logs; the regex below only matches save events
-        read_log()
+        try:
+            # advance past startup logs; the regex below only matches save events
+            read_log()
 
-        # Set configuration
-        response = self.db.config_set("VKEY_MAX_ENTITY_COUNT", 10)
-        self.env.assertEqual(response, "OK")
+            # Set configuration
+            response = self.db.config_set("VKEY_MAX_ENTITY_COUNT", 10)
+            self.env.assertEqual(response, "OK")
 
-        # Create 30 nodes
-        self.graph.query("UNWIND range(0, 30) as v CREATE (:L {v: v})")
+            # Create 30 nodes
+            self.graph.query("UNWIND range(0, 30) as v CREATE (:L {v: v})")
 
-        # Save RDB & Load from RDB
-        self.redis_con.save()
+            # Save RDB & Load from RDB
+            self.redis_con.save()
 
-        # Set configuration
-        response = self.db.config_set("VKEY_MAX_ENTITY_COUNT", 5)
-        self.env.assertEqual(response, "OK")
+            # Set configuration
+            response = self.db.config_set("VKEY_MAX_ENTITY_COUNT", 5)
+            self.env.assertEqual(response, "OK")
 
-        # Save RDB & Load from RDB
-        self.redis_con.save()
+            # Save RDB & Load from RDB
+            self.redis_con.save()
 
-        log = read_log()
+            log = read_log()
 
-        matches = re.findall(
-            f"Created (.) virtual keys for graph {GRAPH_ID}", log)
+            matches = re.findall(
+                f"Created (.) virtual keys for graph {GRAPH_ID}", log)
 
-        self.env.assertEqual(matches, ['3', '6'])
+            self.env.assertEqual(matches, ['3', '6'])
 
-        matches = re.findall(
-            f"Deleted (.) virtual keys for graph {GRAPH_ID}", log)
+            matches = re.findall(
+                f"Deleted (.) virtual keys for graph {GRAPH_ID}", log)
 
-        self.env.assertEqual(matches, ['3', '6'])
+            self.env.assertEqual(matches, ['3', '6'])
+        finally:
+            if logfile is not None:
+                logfile.close()
 
     def test_11_decode_single_edge_relation_with_deleted_nodes(self):
         # Set configuration

--- a/tests/flow/test_encode_decode.py
+++ b/tests/flow/test_encode_decode.py
@@ -191,9 +191,18 @@ class test_encode_decode(FlowTestsBase):
     # test changes to the VKEY_MAX_ENTITY_COUNT configuration are reflected in
     # the number of virtual keys created
     def test_10_vkey_max_entity_count(self):
-        logfilename = self.env.envRunner._getFileName("master", ".log")
-        logfile = open(f"{self.env.logDir}/{logfilename}")
-        log = logfile.read()
+        # Under docker-per-class the redis log lives in the container's
+        # stdout, exposed via env.read_log() (file-handle-like read()).
+        # Under RLTest the log is a real file on disk addressed via
+        # envRunner._getFileName + env.logDir.
+        if hasattr(self.env, "read_log"):
+            read_log = self.env.read_log
+        else:
+            logfilename = self.env.envRunner._getFileName("master", ".log")
+            logfile = open(f"{self.env.logDir}/{logfilename}")
+            read_log = logfile.read
+        # advance past startup logs; the regex below only matches save events
+        read_log()
 
         # Set configuration
         response = self.db.config_set("VKEY_MAX_ENTITY_COUNT", 10)
@@ -212,7 +221,7 @@ class test_encode_decode(FlowTestsBase):
         # Save RDB & Load from RDB
         self.redis_con.save()
 
-        log = logfile.read()
+        log = read_log()
 
         matches = re.findall(
             f"Created (.) virtual keys for graph {GRAPH_ID}", log)

--- a/tests/flow/test_graph_copy.py
+++ b/tests/flow/test_graph_copy.py
@@ -314,9 +314,13 @@ class testGraphCopy():
         # the WAIT command forces master slave sync to complete
         master_con.execute_command("WAIT", "1", "0")
 
-        # make sure dest graph was replicated
-        # assuming replica port is env port+1
-        replica_db = FalkorDB("localhost", self.env.port+1)
+        # make sure dest graph was replicated.
+        # Under RLTest (local dev) the replica lives on the same host at
+        # port+1; under docker-per-class the replica is a sibling container
+        # exposed via env.replica_host:env.replica_port.
+        replica_host = getattr(self.env, "replica_host", "localhost")
+        replica_port = getattr(self.env, "replica_port", self.env.port + 1)
+        replica_db = FalkorDB(replica_host, replica_port)
         replica_cloned_graph = replica_db.select_graph(copy_graph_id)
         
         # make sure src graph on master is the same as cloned graph on replica

--- a/tests/flow/test_index_create.py
+++ b/tests/flow/test_index_create.py
@@ -254,6 +254,7 @@ class testIndexCreationFlow:
             pool = BlockingConnectionPool(
                 max_connections=16,
                 timeout=None,
+                host=self.env.host,
                 port=self.env.port,
                 decode_responses=True,
             )

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Split flow_tests_done.txt into two GHA-matrix arrays based on whether each
+test file calls Env() with arguments that require a private redis instance.
+
+A file goes to `spawn_files` if ANY Env() invocation passes one of:
+  - moduleArgs       — load-time module config (some keys are immutable)
+  - useSlaves        — needs a replica spawned by RLTest's framework
+  - enableDebugCommand — needs --enable-debug-command yes (we could pass this
+                         on the service container too, but for simplicity we
+                         keep these on spawn for now)
+  - env='oss-cluster' — needs a multi-node cluster
+  - shardsCount      — same as above
+
+Otherwise the file goes to `services_files` — it can reuse a shared GHA
+service container that's brought up once per matrix cell.
+
+Outputs are emitted as `services_files=<json>` and `spawn_files=<json>` lines
+suitable for `>> $GITHUB_OUTPUT`."""
+
+import json
+import os
+import re
+import sys
+
+# `Env(` followed by anything (across lines) that contains one of the
+# spawn-forcing keywords. re.DOTALL makes . match newlines for multi-line
+# Env() calls. We anchor on Env( to avoid matching the keywords elsewhere.
+SPAWN_RE = re.compile(
+    r"\bEnv\s*\([^)]*\b(moduleArgs|useSlaves|enableDebugCommand|"
+    r"oss-cluster|shardsCount)\b",
+    re.DOTALL,
+)
+
+
+def files_for_entry(entry):
+    """Resolve a flow_tests_done.txt entry to the list of .py files to scan.
+
+    Entries come in three shapes:
+      - `tests/flow/test_xyz.py`    — direct .py file
+      - `tests/flow/test_xyz`       — .py file with the extension omitted
+      - `tests/flow/test_xyz`       — directory containing *.py files
+    """
+    if os.path.isfile(entry):
+        return [entry]
+    if os.path.isfile(entry + ".py"):
+        return [entry + ".py"]
+    if os.path.isdir(entry):
+        out = []
+        for root, _, names in os.walk(entry):
+            for n in names:
+                if n.endswith(".py"):
+                    out.append(os.path.join(root, n))
+        return out
+    return []
+
+
+def needs_spawn(paths):
+    for p in paths:
+        try:
+            with open(p, encoding="utf-8") as f:
+                if SPAWN_RE.search(f.read()):
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def main():
+    list_path = "flow_tests_done.txt"
+    if len(sys.argv) > 1:
+        list_path = sys.argv[1]
+
+    services, spawn = [], []
+    with open(list_path) as f:
+        for line in f:
+            entry = line.strip()
+            if not entry:
+                continue
+            paths = files_for_entry(entry)
+            if not paths:
+                # Unresolvable entry — treat as spawn to be safe (better to
+                # over-spawn than to miss a moduleArgs file).
+                spawn.append(entry)
+                continue
+            (spawn if needs_spawn(paths) else services).append(entry)
+
+    print(f"services_files={json.dumps(services)}")
+    print(f"spawn_files={json.dumps(spawn)}")
+    # `test_files` is the union for callers that don't care about the split
+    # (coverage-flow runs against a locally-built .so, no docker involved).
+    print(f"test_files={json.dumps(services + spawn)}")
+    # On stderr so it shows up in the GHA log without polluting $GITHUB_OUTPUT.
+    print(f"  services: {len(services)}, spawn: {len(spawn)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -54,6 +54,14 @@ IMMUTABLE_MODULE_ARGS = (
     "DELAY_INDEXING",
     "JS_HEAP_SIZE",
     "JS_STACK_SIZE",
+    # TIMEOUT is *conditionally* immutable: settable via GRAPH.CONFIG SET only
+    # when both TIMEOUT_DEFAULT and TIMEOUT_MAX are 0 (see config_cmd.rs's
+    # validate_timeout_cross_constraints). In a shared service container,
+    # earlier tests in the same file that set TIMEOUT_DEFAULT/TIMEOUT_MAX make
+    # later TIMEOUT writes fail with "deprecated" errors. Force tests that
+    # pass `moduleArgs=...TIMEOUT...` into the spawn bucket so each Env() gets
+    # a fresh container with TIMEOUT applied at module load.
+    "TIMEOUT",
 )
 
 # `Env(...moduleArgs="...string...")` — capture the literal string content.
@@ -98,9 +106,14 @@ def needs_spawn(paths):
         if CLUSTER_RE.search(content):
             return True
         # moduleArgs with at least one immutable key — spawn.
+        # Word-boundary match so e.g. "TIMEOUT" doesn't false-positive against
+        # "TIMEOUT_DEFAULT" or "TIMEOUT_MAX" (those are genuinely runtime-mutable).
         for match in MODULE_ARGS_RE.finditer(content):
             args_str = match.group(1)
-            if any(key in args_str for key in IMMUTABLE_MODULE_ARGS):
+            if any(
+                re.search(rf"\b{re.escape(key)}\b", args_str)
+                for key in IMMUTABLE_MODULE_ARGS
+            ):
                 return True
     return False
 

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -3,22 +3,22 @@
 test file calls Env() with arguments that require a private redis instance.
 
 A file goes to `spawn_files` if ANY Env() invocation passes one of:
-  - moduleArgs       — load-time module config (some keys like CACHE_SIZE,
-                       IMPORT_FOLDER, NODE_CREATION_BUFFER are immutable)
+  - moduleArgs WITH an immutable key (see IMMUTABLE_MODULE_ARGS below) —
+    immutable keys can't be set at runtime via GRAPH.CONFIG SET, so the
+    test genuinely needs a private redis loaded with those args
   - env='oss-cluster' — needs a multi-node cluster
   - shardsCount      — same as above
 
 NOT spawn-forcing (the services job handles these directly):
-  - enableDebugCommand — the services container is launched with
-                         REDIS_ARGS=--enable-debug-command yes, so DEBUG
-                         RELOAD / DEBUG SLEEP work out of the box
-  - useSlaves          — the services job runs a second `replica` container
-                         configured with --replicaof falkordb 6379;
-                         common.py services mode wires it through
-                         env.replica_host/port + _attach_slave
-
-Otherwise the file goes to `services_files` — it can reuse the shared GHA
-service container that's brought up once per matrix cell.
+  - enableDebugCommand — services container is launched with
+                         REDIS_ARGS=--enable-debug-command yes
+  - useSlaves          — services job runs a second `replica` container
+                         (common.py services mode + _attach_slave)
+  - moduleArgs with only runtime-mutable keys (TIMEOUT*, MAX_QUEUED_QUERIES,
+                         RESULTSET_SIZE, QUERY_MEM_CAPACITY,
+                         DELTA_MAX_PENDING_CHANGES, VKEY_MAX_ENTITY_COUNT) —
+                         common.py applies these via GRAPH.CONFIG SET on the
+                         shared service after FLUSHALL.
 
 Outputs are emitted as `services_files=<json>` and `spawn_files=<json>` lines
 suitable for `>> $GITHUB_OUTPUT`."""
@@ -28,11 +28,39 @@ import os
 import re
 import sys
 
-# `Env(` followed by anything (across lines) that contains one of the
-# spawn-forcing keywords. re.DOTALL makes . match newlines for multi-line
-# Env() calls. We anchor on Env( to avoid matching the keywords elsewhere.
-SPAWN_RE = re.compile(
-    r"\bEnv\s*\([^)]*\b(moduleArgs|oss-cluster|shardsCount)\b",
+# Cluster topology forces spawn regardless of moduleArgs.
+CLUSTER_RE = re.compile(
+    r"\bEnv\s*\([^)]*\b(oss-cluster|shardsCount)\b",
+    re.DOTALL,
+)
+
+# moduleArgs keys that can't be changed at runtime — these force spawn so
+# the module loads with the right value baked in. Anything not on this list
+# is assumed runtime-mutable via GRAPH.CONFIG SET and can ride a shared
+# service container. The list is conservative; add to it (don't remove from
+# it) if a key turns out to be load-time-only.
+IMMUTABLE_MODULE_ARGS = (
+    "CACHE_SIZE",
+    "THREAD_COUNT",
+    "OMP_THREAD_COUNT",
+    "IMPORT_FOLDER",
+    "TEMP_FOLDER",
+    "NODE_CREATION_BUFFER",
+    "BOLT_PORT",
+    "EFFECTS_THRESHOLD",
+    "MAX_INFO_QUERIES",
+    "ASYNC_DELETE",
+    "CMD_INFO",
+    "DELAY_INDEXING",
+    "JS_HEAP_SIZE",
+    "JS_STACK_SIZE",
+)
+
+# `Env(...moduleArgs="...string...")` — capture the literal string content.
+# Handles f-strings (`f"..."`) and both quote styles. re.DOTALL so the
+# literal can span multiple lines.
+MODULE_ARGS_RE = re.compile(
+    r"\bmoduleArgs\s*=\s*f?['\"]([^'\"]*)['\"]",
     re.DOTALL,
 )
 
@@ -63,10 +91,17 @@ def needs_spawn(paths):
     for p in paths:
         try:
             with open(p, encoding="utf-8") as f:
-                if SPAWN_RE.search(f.read()):
-                    return True
+                content = f.read()
         except OSError:
             continue
+        # Cluster topology — always spawn.
+        if CLUSTER_RE.search(content):
+            return True
+        # moduleArgs with at least one immutable key — spawn.
+        for match in MODULE_ARGS_RE.finditer(content):
+            args_str = match.group(1)
+            if any(key in args_str for key in IMMUTABLE_MODULE_ARGS):
+                return True
     return False
 
 

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -3,15 +3,21 @@
 test file calls Env() with arguments that require a private redis instance.
 
 A file goes to `spawn_files` if ANY Env() invocation passes one of:
-  - moduleArgs       — load-time module config (some keys are immutable)
-  - useSlaves        — needs a replica spawned by RLTest's framework
-  - enableDebugCommand — needs --enable-debug-command yes (we could pass this
-                         on the service container too, but for simplicity we
-                         keep these on spawn for now)
+  - moduleArgs       — load-time module config (some keys like CACHE_SIZE,
+                       IMPORT_FOLDER, NODE_CREATION_BUFFER are immutable)
   - env='oss-cluster' — needs a multi-node cluster
   - shardsCount      — same as above
 
-Otherwise the file goes to `services_files` — it can reuse a shared GHA
+NOT spawn-forcing (the services job handles these directly):
+  - enableDebugCommand — the services container is launched with
+                         REDIS_ARGS=--enable-debug-command yes, so DEBUG
+                         RELOAD / DEBUG SLEEP work out of the box
+  - useSlaves          — the services job runs a second `replica` container
+                         configured with --replicaof falkordb 6379;
+                         common.py services mode wires it through
+                         env.replica_host/port + _attach_slave
+
+Otherwise the file goes to `services_files` — it can reuse the shared GHA
 service container that's brought up once per matrix cell.
 
 Outputs are emitted as `services_files=<json>` and `spawn_files=<json>` lines
@@ -26,8 +32,7 @@ import sys
 # spawn-forcing keywords. re.DOTALL makes . match newlines for multi-line
 # Env() calls. We anchor on Env( to avoid matching the keywords elsewhere.
 SPAWN_RE = re.compile(
-    r"\bEnv\s*\([^)]*\b(moduleArgs|useSlaves|enableDebugCommand|"
-    r"oss-cluster|shardsCount)\b",
+    r"\bEnv\s*\([^)]*\b(moduleArgs|oss-cluster|shardsCount)\b",
     re.DOTALL,
 )
 

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -54,13 +54,6 @@ IMMUTABLE_MODULE_ARGS = (
     "DELAY_INDEXING",
     "JS_HEAP_SIZE",
     "JS_STACK_SIZE",
-    # TIMEOUT is *conditionally* immutable: settable via GRAPH.CONFIG SET only
-    # when both TIMEOUT_DEFAULT and TIMEOUT_MAX are 0 (see config_cmd.rs's
-    # validate_timeout_cross_constraints). In a shared service container,
-    # earlier tests in the same file that set TIMEOUT_DEFAULT/TIMEOUT_MAX make
-    # later TIMEOUT writes fail with "deprecated" errors. Force tests that
-    # pass `moduleArgs=...TIMEOUT...` into the spawn bucket so each Env() gets
-    # a fresh container with TIMEOUT applied at module load.
     "TIMEOUT",
 )
 

--- a/tests/flow/test_matrix_split.py
+++ b/tests/flow/test_matrix_split.py
@@ -72,6 +72,15 @@ MODULE_ARGS_RE = re.compile(
     re.DOTALL,
 )
 
+# `Env(..., moduleArgs=<variable_or_expression>, ...)` — anything where the
+# value isn't a string literal. The classifier can't introspect the
+# variable's runtime value, so it has to conservatively force the file into
+# the spawn bucket (immutable keys might be in there). Negative lookahead
+# excludes the literal forms MODULE_ARGS_RE already covers.
+MODULE_ARGS_NONLITERAL_RE = re.compile(
+    r"\bmoduleArgs\s*=\s*(?!f?['\"])\S",
+)
+
 
 def files_for_entry(entry):
     """Resolve a flow_tests_done.txt entry to the list of .py files to scan.
@@ -87,8 +96,12 @@ def files_for_entry(entry):
         return [entry + ".py"]
     if os.path.isdir(entry):
         out = []
-        for root, _, names in os.walk(entry):
-            for n in names:
+        # Sort to make the matrix-cell ordering deterministic across runs;
+        # otherwise os.walk's directory-entry order varies by filesystem and
+        # diffing CI logs across runs becomes harder.
+        for root, dirs, names in os.walk(entry):
+            dirs.sort()
+            for n in sorted(names):
                 if n.endswith(".py"):
                     out.append(os.path.join(root, n))
         return out
@@ -115,6 +128,11 @@ def needs_spawn(paths):
                 for key in IMMUTABLE_MODULE_ARGS
             ):
                 return True
+        # moduleArgs passed via variable/expression — we can't introspect
+        # the value, so conservatively force spawn. Better to over-spawn
+        # than to misclassify a file that needs load-time args.
+        if MODULE_ARGS_NONLITERAL_RE.search(content):
+            return True
     return False
 
 
@@ -137,6 +155,11 @@ def main():
                 continue
             (spawn if needs_spawn(paths) else services).append(entry)
 
+    # Sort each bucket so the matrix cells come out in the same order across
+    # runs. Without this the order is whatever flow_tests_done.txt happens to
+    # be in, which is usually stable but not guaranteed.
+    services.sort()
+    spawn.sort()
     print(f"services_files={json.dumps(services)}")
     print(f"spawn_files={json.dumps(spawn)}")
     # `test_files` is the union for callers that don't care about the split

--- a/tests/flow/test_pending_queries_limit.py
+++ b/tests/flow/test_pending_queries_limit.py
@@ -36,7 +36,7 @@ class testPendingQueryLimit():
             # blocking when there's no connections available
             n = self.db.config_get("THREAD_COUNT") * 5
             limit = self.db.config_get("MAX_QUEUED_QUERIES")
-            pool = BlockingConnectionPool(max_connections=n, timeout=None, port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=n, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 

--- a/tests/flow/test_query_mem_limit.py
+++ b/tests/flow/test_query_mem_limit.py
@@ -33,7 +33,7 @@ class testQueryMemoryLimit():
             thread_count = int(self.db.config_get("THREAD_COUNT"))
 
             # connection pool blocking when there's no available connections 
-            pool = BlockingConnectionPool(max_connections=thread_count, timeout=None, port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=thread_count, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 

--- a/tests/flow/test_slowlog.py
+++ b/tests/flow/test_slowlog.py
@@ -14,7 +14,7 @@ class testSlowLog():
 
     def populate_slowlog(self, n):
         async def populate(self, n):
-            pool = BlockingConnectionPool(max_connections=n, timeout=None, port=self.env.port, decode_responses=True)
+            pool = BlockingConnectionPool(max_connections=n, timeout=None, host=self.env.host, port=self.env.port, decode_responses=True)
             db = FalkorDB(connection_pool=pool)
             g = db.select_graph(GRAPH_ID)
 

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -140,6 +140,11 @@ class testQueryTimeout():
 
     def test06_error_timeout_default_higher_than_timeout_max(self):
         self.env, self.db = Env(moduleArgs="TIMEOUT_DEFAULT 10 TIMEOUT_MAX 10")
+        # Refresh self.graph: spawn-mode Env() returns a new client/container,
+        # so the self.graph captured in __init__ would still talk to the old
+        # one (with its now-stale config). Subsequent tests in this class
+        # query via self.graph and rely on the new TIMEOUT_DEFAULT.
+        self.graph = self.db.select_graph(GRAPH_ID)
 
         # get current timeout configuration
         max_timeout = self.db.config_get("TIMEOUT_MAX")
@@ -219,6 +224,7 @@ class testQueryTimeout():
     def test09_fallback(self):
         self.env.stop()
         self.env, self.db = Env(moduleArgs="TIMEOUT 1")
+        self.graph = self.db.select_graph(GRAPH_ID)
 
         configs = ["TIMEOUT_DEFAULT", "TIMEOUT_MAX"]
 
@@ -259,6 +265,7 @@ class testQueryTimeout():
         # reset timeout params to default
         self.env.stop()
         self.env, self.db = Env()
+        self.graph = self.db.select_graph(GRAPH_ID)
 
         # Set timeout parameters to small values (1 millisecond)
         self.db.config_set("TIMEOUT_MAX", 1)
@@ -282,6 +289,7 @@ class testQueryTimeout():
     def test12_concurrent_timeout(self):
         self.env.stop()
         self.env, self.db = Env()
+        self.graph = self.db.select_graph(GRAPH_ID)
 
         self.graph.query("UNWIND range(1, 1000) AS x CREATE (:N {v:x})")
 

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -98,10 +98,15 @@ class testQueryTimeout():
             try:
                 res = self.graph.query(q, timeout=5)
                 timeouts.append(res.run_time_ms)
-            except Exception:
-                # query timed out before `res` was bound; the loop below
-                # only needs a number we can clamp into a tighter retry
-                # timeout, so use the timeout we just spent as the upper bound
+            except ResponseError as error:
+                # The only ResponseError we expect here is "Query timed out"
+                # — anything else (Cypher error, wrong arity, ...) is a real
+                # problem and should surface, not be papered over.
+                self.env.assertContains("Query timed out", str(error))
+                # `res` is unbound when the query raises, so we can't use
+                # res.run_time_ms. The second loop only needs a number that
+                # clamps into [1, 10] ms; the just-attempted 5 ms is a
+                # reasonable upper-bound proxy (the query took at least that).
                 timeouts.append(5)
 
         for i, q in enumerate(queries):

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -286,6 +286,7 @@ class testQueryTimeout():
             # connection pool with 16 connections
             # blocking when there's no connections available
             pool = BlockingConnectionPool(max_connections=16, timeout=None,
+                                          host=self.env.host,
                                           port=self.env.port,
                                           decode_responses=True)
 

--- a/tests/flow/test_timeout.py
+++ b/tests/flow/test_timeout.py
@@ -98,8 +98,11 @@ class testQueryTimeout():
             try:
                 res = self.graph.query(q, timeout=5)
                 timeouts.append(res.run_time_ms)
-            except:
-                timeouts.append(res.run_time_ms)
+            except Exception:
+                # query timed out before `res` was bound; the loop below
+                # only needs a number we can clamp into a tighter retry
+                # timeout, so use the timeout we just spent as the upper bound
+                timeouts.append(5)
 
         for i, q in enumerate(queries):
             try:

--- a/tests/flow/test_udf.py
+++ b/tests/flow/test_udf.py
@@ -20,7 +20,10 @@ def udf_list(db, lib=None, with_code=None):
 
 class testUDF():
     def __init__(self):
-        self.env, self.db = Env()
+        # Three tests in this class call env.restart_and_reload(), which is
+        # backed by DEBUG RELOAD. Redis rejects DEBUG by default; the flag
+        # adds --enable-debug-command yes to the spawn.
+        self.env, self.db = Env(enableDebugCommand=True)
         self.graph = self.db.select_graph(GRAPH_ID)
         self.conn = self.env.getConnection()
 


### PR DESCRIPTION
## Summary

Replaces the single-shared-redis services-block model in `test-flow` with a hybrid model that tests against the actual shipping artifact (the RC image) with proper per-class isolation. Builds on top of PR #451 (`feat/docker-release`); will merge back into it before that PR lands on main.

## Three execution modes in `tests/flow/common.py` Env()

1. **Local dev** (`FALKORDB_TEST_IMAGE` unset): RLTest spawns redis-server with `--loadmodule` + moduleArgs. Identical to the original behavior — `cargo build && ./flow.sh` keeps working.
2. **CI shared master** (no `moduleArgs`, no `useSlaves`): connect to the long-lived `master` GHA service. Cheapest path; covers ~85% of flow-test files.
3. **CI private spawn** (`moduleArgs` OR `useSlaves`): spawn a dedicated container from the RC image via `docker run`. moduleArgs go in `-e FALKORDB_ARGS=...` so cross-key validation fires the same way it would under `--loadmodule`. For `useSlaves=True` a paired replica is spawned with `REDIS_ARGS=\"--replicaof <master-alias> 6379\"`; the env stub exposes `getSlaveConnection()` pointing at it.

## Mechanics

- **`build/Dockerfile`**: toolchain image ships `docker.io` (just the CLI matters; the daemon is never started in our container).
- **`rust-pr.yml` test-flow**: `container.options` bind-mounts `/var/run/docker.sock`. Master + replica services declared with `FALKORDB_ARGS=\"\"` and `REDIS_ARGS=\"--replicaof master 6379\"` on the replica.
- **`tests/flow/common.py`**: new helpers — `_job_network`, `_spawn_falkordb` (subprocess docker CLI), `_wait_for_redis`, `_cleanup_spawned` (atexit). Removes the prior CONFIG-SET dispatch and the `_LOAD_TIME_CONFIG_KEYS` gate.
- **`flow.sh`**: signal renamed `EXISTING_ENV` → `FALKORDB_TEST_IMAGE`.
- **6 test files patched** to pass `host=self.env.host` on custom connection pools — `test_cache`, `test_pending_queries_limit`, `test_slowlog`, `test_query_mem_limit`, `test_timeout`, `test_index_create`.

## Verified locally against rc-pr-451

- ✅ `test_imdb` — shared master path
- ✅ `test_cache` (14/14) — private spawn with `CACHE_SIZE 16`
- ✅ `test_bulk_insertion` (12/12) — subprocess + host-aware
- ✅ `test_replication` — useSlaves private master+replica

Remaining failures in CI will be real test-logic issues (e.g. `test_timeout`'s queries completing under the timeout threshold under the newer runtime, `test_constraint`'s state-machine timing assertions) unrelated to this infrastructure.

## Test plan

- [ ] CI green on PR-against-feat/docker-release
- [ ] Revert the temporary `feat/docker-release` entry in `rust-pr.yml` `branches:` before merging back
- [ ] Squash-merge into feat/docker-release; that PR then lands on main with the full flow-test migration intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)