### PR TITLE
fix: runtime regressions surfaced by docker-per-class CI (stacked)

### DIFF
--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -9,11 +9,15 @@ on:
     #
     # `feat/docker-release` is included temporarily so this PR
     # (feat/docker-per-class-tests → feat/docker-release) can run its own CI.
-    # Drop the entry before merging back to main.
+    # `feat/docker-per-class-tests` is included so the stacked
+    # runtime-regressions PR (feat/runtime-regressions → feat/docker-per-class-tests)
+    # validates each commit (C0-C4) against the per-class CI infra.
+    # Drop both entries before merging back to main.
     branches:
       - "main"
       - "[0-9]+.[0-9]+"
       - "feat/docker-release"
+      - "feat/docker-per-class-tests"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/rust-pr.yml
+++ b/.github/workflows/rust-pr.yml
@@ -43,10 +43,22 @@ jobs:
       - name: Check if specific file changed
         id: check
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Diff against the merge-base with main, not the immediate PR base.
+        # On a regular main-targeting PR these are identical. On a stacked PR
+        # (whose base is itself a branch like feat/docker-per-class-tests) the
+        # immediate-base diff hides toolchain changes from the parent stack,
+        # which causes downstream jobs to fall back to :latest — but :latest
+        # doesn't exist on GHCR (it's only populated when the stack lands on
+        # main). Diffing from main detects any build/Dockerfile change
+        # anywhere in the stack and rebuilds pr-<N> for this PR.
         run: |
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q "build/Dockerfile"; then
+          # actions/checkout above used fetch-depth: 0 so we have full history,
+          # but only the PR's branch is fetched by default — pull main as a ref
+          # too so merge-base can find the actual divergence point.
+          git fetch --no-tags origin main
+          MERGE_BASE=$(git merge-base origin/main "$HEAD_SHA")
+          if git diff --name-only "$MERGE_BASE" "$HEAD_SHA" | grep -q "build/Dockerfile"; then
             echo "changed=true"
             echo "changed=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

Stacked PR carrying the runtime fixes for the six bugs the docker-per-class CI surfaced. Branch off \`feat/docker-per-class-tests\`. Will grow to five commits (C0–C4) per the [plan](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/feat/runtime-regressions/.claude/plans/let-s-plan-how-to-snoopy-flurry.md#phase-4-stacked-pr-fix-for-runtime-regressions-revealed-by-docker-per-class-ci); **draft until all five land + CI is green**.

## Bugs targeted

| Tag | Failing tests | Root cause | Fix commit |
|-----|---------------|------------|------------|
| **A** | test_edge_index_updates, test_edge_index_scans | \`VersionedMatrix::set_all\` loops setElement; at ~1500 entries GraphBLAS returns an error code that the release-mode \`debug_assert_eq!\` swallows; matrix becomes \`GrB_INVALID_OBJECT\`; next mutation panics on \`GrB_Matrix_dup(invalid)\` | C0 (surface error) + C2 (root-cause fix) |
| **B** | test_index_updates, test_imdb | CREATE after a range index already exists doesn't propagate new nodes to the index | C3 |
| **C** | test_constraint, test_encode_decode, test_stress | BGSAVE pre-fork races writer-thread GraphBLAS mutations; \`GrB_Matrix_wait\` returns NULL_POINTER. Per issue #452. | C1 |
| **D** | test_graph_copy.test_08 | Suspected downstream of (C) — replica's first matrix op after fork hits state corrupted by the same race | C1 likely; folds into C2 if it persists |
| **E** | test_msf | LAGraph MSF returns fewer edges than expected; may be downstream of A/C | C4 |
| **F** | test_persistency.test_bulk_insert | Click CliRunner exits 1 with empty stdout; tool-side | C4 |

## Commit landing order

- **C0** (this one — \`c8af74a\`): promote \`debug_assert_eq!(info, GrB_SUCCESS)\` → \`assert_eq!\` across 46 sites in matrix.rs + vector.rs. Surfaces silent FFI errors. Prerequisite for C2 — needed to see the actual \`GrB_Info\` GraphBLAS is returning at the failing size.
- **+ \`56ed7bc\`**: temp CI trigger so this PR validates (drops with the rest of the stack on main).
- **C1**: BGSAVE/fork-safe writers (issue #452 implementation).
- **C2**: set_all correctness (closes #471).
- **C3**: CREATE-after-index population (closes #472).
- **C4**: test_msf + test_persistency follow-ups.

Each commit gates the next via this PR's CI run. No-squash on merge — per-commit history is the value here.

## Test plan

- [ ] Per-class CI green on each commit (this PR's own CI loop)
- [ ] Issue #452 reproducer (50k entities + 1500 stress tasks + concurrent BGSAVE under ASAN) completes cleanly after C1
- [ ] \`tests/flow/test_stress.py::testStressFlow::test01_bgsave_stress\` passes under ASAN after C1
- [ ] Local repro \`UNWIND range(1,1500) CREATE …\` then \`MATCH (n) RETURN count(*)\` returns 1500 + next CREATE doesn't panic, after C2
- [ ] Index-after-create local repro: 500 :L + 5 indexes + 100 more :L → indexed == label == 600, after C3

🤖 Generated with [Claude Code](https://claude.com/claude-code)