### PR TITLE
feat(index): add field_order to preserve attribute insertion order

### DIFF
--- a/graph/src/index/indexer.rs
+++ b/graph/src/index/indexer.rs
@@ -766,6 +766,7 @@ impl Indexer {
                     progress,
                     total,
                     fields: index.fields().clone(),
+                    field_order: index.field_order().to_vec(),
                     language: index.language().cloned(),
                     stopwords: index.stopwords().cloned(),
                     entity_type: String::new(),

--- a/graph/src/index/mod.rs
+++ b/graph/src/index/mod.rs
@@ -260,6 +260,11 @@ pub struct IndexInfo {
     pub progress: u64,
     pub total: u64,
     pub fields: HashMap<Arc<String>, Vec<Arc<Field>>>,
+    /// Attribute names in insertion order. Mirrors `fields.keys()` but
+    /// preserves the order the user added them, since `HashMap` iteration
+    /// is non-deterministic and `CALL db.indexes()` must surface
+    /// properties in the order they were declared for parity with edge.
+    pub field_order: Vec<Arc<String>>,
     pub language: Option<Arc<String>>,
     pub stopwords: Option<Vec<Arc<String>>>,
     pub entity_type: String,
@@ -767,6 +772,9 @@ pub struct Index {
     id: u64,
     rs_idx: *mut RSIndex,
     fields: HashMap<Arc<String>, Vec<Arc<Field>>>,
+    /// Attribute keys in insertion order. Tracked alongside `fields` so
+    /// `CALL db.indexes()` can return `properties` in declaration order.
+    field_order: Vec<Arc<String>>,
     pending_slots: Mutex<PendingSlots>,
     progress: u64,
     total: u64,
@@ -853,6 +861,7 @@ impl Default for Index {
             id,
             rs_idx: std::ptr::null_mut(),
             fields: HashMap::new(),
+            field_order: Vec::new(),
             pending_slots: Mutex::new(PendingSlots {
                 current_generation: id,
                 current_pending: 0,
@@ -1716,6 +1725,9 @@ impl Index {
         attr: Arc<String>,
         field: Arc<Field>,
     ) {
+        if !self.fields.contains_key(&attr) {
+            self.field_order.push(attr.clone());
+        }
         self.fields.insert(attr, vec![field]);
     }
 
@@ -1724,7 +1736,11 @@ impl Index {
         &mut self,
         attr: &Arc<String>,
     ) -> bool {
-        self.fields.remove(attr).is_some()
+        let removed = self.fields.remove(attr).is_some();
+        if removed {
+            self.field_order.retain(|a| a != attr);
+        }
+        removed
     }
 
     /// Retain only fields that don't match the given index type for a specific attribute.
@@ -1754,6 +1770,12 @@ impl Index {
     #[must_use]
     pub const fn fields(&self) -> &HashMap<Arc<String>, Vec<Arc<Field>>> {
         &self.fields
+    }
+
+    /// Attribute keys in insertion order.
+    #[must_use]
+    pub fn field_order(&self) -> &[Arc<String>] {
+        &self.field_order
     }
 
     /// Iterate over all Field objects (flattened across all attributes).

--- a/graph/src/runtime/functions/procedures.rs
+++ b/graph/src/runtime/functions/procedures.rs
@@ -122,17 +122,16 @@ pub fn register(funcs: &mut Functions) {
                              progress,
                              total,
                              fields,
+                             field_order,
                              language,
                              stopwords,
                              entity_type,
                          }| {
                             let mut map = OrderMap::default();
                             map.insert(Arc::new(String::from("label")), Value::String(label));
-                            let mut sorted_keys: Vec<_> = fields.keys().cloned().collect();
-                            sorted_keys.sort();
                             map.insert(
                                 Arc::new(String::from("properties")),
-                                Value::List(Arc::new(sorted_keys.iter().map(|f| Value::String(f.clone())).collect())),
+                                Value::List(Arc::new(field_order.iter().map(|f| Value::String(f.clone())).collect())),
                             );
                             let mut types_map = OrderMap::default();
                             // Per-attribute index types. A single attribute
@@ -141,7 +140,7 @@ pub fn register(funcs: &mut Functions) {
                             // `range:a:numeric:arr`, `range:a:string:arr`),
                             // so dedupe — but do not impose an order; callers
                             // that care should compare as sets.
-                            for attr in &sorted_keys {
+                            for attr in &field_order {
                                 let mut seen = [false; 3];
                                 let mut types = thin_vec![];
                                 for field in &fields[attr] {
@@ -163,10 +162,13 @@ pub fn register(funcs: &mut Functions) {
                                 Arc::new(String::from("language")),
                                 language.map_or_else(|| Value::Null, Value::String),
                             );
+                            let is_fulltext = field_order.iter().any(|attr| {
+                                fields.get(attr).is_some_and(|fs| fs.iter().any(|f| f.ty == IndexType::Fulltext))
+                            });
                             map.insert(
                                 Arc::new(String::from("stopwords")),
                                 stopwords.map_or_else(
-                                    || Value::Null,
+                                    || if is_fulltext { Value::List(Arc::new(thin_vec![])) } else { Value::Null },
                                     |sw| Value::List(Arc::new(sw.into_iter().map(Value::String).collect())),
                                 ),
                             );
@@ -194,14 +196,12 @@ pub fn register(funcs: &mut Functions) {
                             // lookups (`a:numeric:arr`, `a:string:arr`) —
                             // and we surface all of them here for parity
                             // with the original FalkorDB implementation.
-                            // Walk attributes in `sorted_keys` order
-                            // (not the underlying HashMap's random
-                            // iteration order) so the output is
-                            // deterministic across runs — tests and
-                            // clients parsing this list can rely on
-                            // stable ordering.
+                            // Walk attributes in `field_order` (declaration
+                            // order) so the output is deterministic across
+                            // runs — tests and clients parsing this list
+                            // can rely on stable ordering.
                             let mut rs_field_names = thin_vec![];
-                            for attr_key in &sorted_keys {
+                            for attr_key in &field_order {
                                 let Some(field_list) = fields.get(attr_key) else {
                                     continue;
                                 };

--- a/src/serializers/decoder/mod.rs
+++ b/src/serializers/decoder/mod.rs
@@ -317,7 +317,10 @@ fn rebuild_indexes(
             _ => EntityType::Node,
         };
 
-        for (attr_name, fields) in &info.fields {
+        for attr_name in &info.field_order {
+            let Some(fields) = info.fields.get(attr_name) else {
+                continue;
+            };
             for field in fields {
                 // The Field.name includes the type prefix (e.g. "range:val").
                 // The attr_name key in the HashMap is the raw attribute name.

--- a/src/serializers/mod.rs
+++ b/src/serializers/mod.rs
@@ -336,7 +336,12 @@ fn encode_schema_index_block(
 
     let all_fields: Vec<_> = infos
         .iter()
-        .flat_map(|info| info.fields.values().flatten())
+        .flat_map(|info| {
+            info.field_order
+                .iter()
+                .filter_map(move |attr| info.fields.get(attr))
+                .flatten()
+        })
         .collect();
     w.write_unsigned(all_fields.len() as u64);
     for f in &all_fields {
@@ -501,8 +506,12 @@ fn decode_schema_entry(
 
         let field_count = r.read_unsigned()?;
         let mut fields: HashMap<Arc<String>, Vec<Arc<Field>>> = HashMap::new();
+        let mut field_order: Vec<Arc<String>> = Vec::new();
         for _ in 0..field_count {
             let (attr_name, field) = decode_index_field(r)?;
+            if !fields.contains_key(&attr_name) {
+                field_order.push(attr_name.clone());
+            }
             fields.entry(attr_name).or_default().push(Arc::new(field));
         }
 
@@ -512,6 +521,7 @@ fn decode_schema_entry(
             progress: 0,
             total: 0,
             fields,
+            field_order,
             language: Some(Arc::new(language)),
             stopwords: if stopwords.is_empty() {
                 None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Index fields are now returned in deterministic, declaration-ordered sequence instead of unpredictable order.
  * `db.indexes()` output maintains consistent field ordering across all calls.
  * Fulltext indexes now properly report stopwords information, emitting an empty list for fulltext-enabled indexes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->