### PR TITLE
Refactor runtime functions and operations for improved performance an…

### DIFF
--- a/graph/src/parser/ast.rs
+++ b/graph/src/parser/ast.rs
@@ -74,6 +74,7 @@ use crate::{
     runtime::{
         functions::{GraphFn, Type},
         orderset::OrderSet,
+        value::Value,
     },
 };
 
@@ -152,16 +153,10 @@ impl Variable {
 /// - `TVar`: Variable type (`Arc<String>` before binding, `Variable` after)
 #[derive(Clone, Debug)]
 pub enum ExprIR<TVar> {
-    /// NULL literal
-    Null,
-    /// Boolean literal (true/false)
-    Bool(bool),
-    /// Integer literal (i64)
-    Integer(i64),
-    /// Floating point literal (f64)
-    Float(f64),
-    /// String literal
-    String(Arc<String>),
+    /// Literal/constant value. Carries any runtime [`Value`] including
+    /// Null/Bool/Int/Float/String literals as well as folded values like
+    /// Date, Duration, Map, etc.
+    Constant(Value),
     /// List constructor - children are list elements
     List,
     /// Map constructor - children are key-value pairs
@@ -261,11 +256,14 @@ impl<TVar: Display + std::fmt::Debug> Display for ExprIR<TVar> {
         f: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         match self {
-            Self::Null => write!(f, "null"),
-            Self::Bool(b) => write!(f, "{b}"),
-            Self::Integer(i) => write!(f, "{i}"),
-            Self::Float(fl) => write!(f, "{fl}"),
-            Self::String(s) => write!(f, "{s}"),
+            Self::Constant(v) => match v {
+                Value::Null => write!(f, "null"),
+                Value::Bool(b) => write!(f, "{b}"),
+                Value::Int(i) => write!(f, "{i}"),
+                Value::Float(fl) => write!(f, "{fl}"),
+                Value::String(s) => write!(f, "{s}"),
+                _ => write!(f, "const({v:?})"),
+            },
             Self::List => write!(f, "[]"),
             Self::Map => write!(f, "{{}}"),
             Self::Variable(id) => write!(f, "{id}"),
@@ -1037,11 +1035,11 @@ impl<TVar: Eq + Hash + Display> QueryIR<TVar> {
             } => {
                 if proc.name == "db.idx.fulltext.createNodeIndex" {
                     match args[0].root().data() {
-                        ExprIR::String(_) => {}
+                        ExprIR::Constant(Value::String(_)) => {}
                         ExprIR::Map => {
                             let mut has_labels = false;
                             for child in args[0].root().children() {
-                                if let ExprIR::String(label) = child.data()
+                                if let ExprIR::Constant(Value::String(label)) = child.data()
                                     && label.as_str() == "label"
                                 {
                                     has_labels = true;
@@ -1113,7 +1111,7 @@ impl<TVar: Eq + Hash + Display> QueryIR<TVar> {
             }
             Self::Remove(items) => {
                 for item in items {
-                    if  matches!(item.root().data(), ExprIR::Property(_)) && matches!(item.root().child(0).data(), ExprIR::Null) {
+                    if  matches!(item.root().data(), ExprIR::Property(_)) && matches!(item.root().child(0).data(), ExprIR::Constant(Value::Null)) {
                         return Err("Type mismatch: expected Node or Relationship but was Null".to_string());
                     }
                 }

--- a/graph/src/parser/cypher.rs
+++ b/graph/src/parser/cypher.rs
@@ -643,7 +643,9 @@ impl<'a> Parser<'a> {
                 let delimiter = if optional_match_token!(self.lexer => Fieldterminator) {
                     Arc::new(self.parse_expr(false)?)
                 } else {
-                    Arc::new(tree!(ExprIR::String(Arc::new(String::from(',')))))
+                    Arc::new(tree!(ExprIR::Constant(Value::String(Arc::new(
+                        String::from(',')
+                    )))))
                 };
                 Ok(QueryIR::LoadCsv {
                     file_path,
@@ -919,7 +921,7 @@ impl<'a> Parser<'a> {
         let skip = if optional_match_token!(self.lexer => Skip) {
             let skip = Arc::new(self.parse_expr(false)?);
             match skip.root().data() {
-                ExprIR::Integer(i) => {
+                ExprIR::Constant(Value::Int(i)) => {
                     if *i < 0 {
                         return Err(self.lexer.format_error(
                             "SKIP specified value of invalid type, must be a positive integer",
@@ -940,7 +942,7 @@ impl<'a> Parser<'a> {
         let limit = if optional_match_token!(self.lexer => Limit) {
             let limit = Arc::new(self.parse_expr(false)?);
             match limit.root().data() {
-                ExprIR::Integer(i) => {
+                ExprIR::Constant(Value::Int(i)) => {
                     if *i < 0 {
                         return Err(self.lexer.format_error(
                             "LIMIT specified value of invalid type, must be a positive integer",
@@ -1262,7 +1264,7 @@ impl<'a> Parser<'a> {
         if optional_match_token!(self.lexer => Else) {
             children.push(self.parse_expr(false)?);
         } else {
-            children.push(tree!(ExprIR::Null));
+            children.push(tree!(ExprIR::Constant(Value::Null)));
         }
         match_token!(self.lexer => End);
         Ok(tree!(
@@ -1622,21 +1624,21 @@ impl<'a> Parser<'a> {
                 ..
             } => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::Null), false))
+                Ok((tree!(ExprIR::Constant(Value::Null)), false))
             }
             Token::IdentifierOrKeyword {
                 keyword: Some(Keyword::True),
                 ..
             } => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::Bool(true)), false))
+                Ok((tree!(ExprIR::Constant(Value::Bool(true))), false))
             }
             Token::IdentifierOrKeyword {
                 keyword: Some(Keyword::False),
                 ..
             } => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::Bool(false)), false))
+                Ok((tree!(ExprIR::Constant(Value::Bool(false))), false))
             }
             Token::IdentifierOrKeyword { .. } => {
                 let state = self.save_state();
@@ -1685,7 +1687,7 @@ impl<'a> Parser<'a> {
                                     .format_error("COUNT(DISTINCT *) is not supported"));
                             }
                             // Create args array like count(x) does
-                            let mut args = vec![tree!(ExprIR::Integer(1))]; // Dummy value for count(*)
+                            let mut args = vec![tree!(ExprIR::Constant(Value::Int(1)))]; // Dummy value for count(*)
 
                             if distinct {
                                 args = vec![tree!(ExprIR::Distinct; args)];
@@ -1745,15 +1747,15 @@ impl<'a> Parser<'a> {
             }
             Token::Integer(i) => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::Integer(i)), false))
+                Ok((tree!(ExprIR::Constant(Value::Int(i))), false))
             }
             Token::Float(f) => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::Float(f)), false))
+                Ok((tree!(ExprIR::Constant(Value::Float(f))), false))
             }
             Token::String(s) => {
                 self.lexer.next();
-                Ok((tree!(ExprIR::String(s)), false))
+                Ok((tree!(ExprIR::Constant(Value::String(s))), false))
             }
             Token::LBrace => {
                 self.lexer.next();
@@ -1792,8 +1794,8 @@ impl<'a> Parser<'a> {
             lhs = tree!(
                 ExprIR::GetElements,
                 lhs,
-                from.unwrap_or_else(|_| tree!(ExprIR::Integer(0))),
-                to.unwrap_or_else(|_| tree!(ExprIR::Integer(i64::MAX)))
+                from.unwrap_or_else(|_| tree!(ExprIR::Constant(Value::Int(0)))),
+                to.unwrap_or_else(|_| tree!(ExprIR::Constant(Value::Int(i64::MAX))))
             );
         } else {
             match_token!(self.lexer, RBrace);
@@ -2022,8 +2024,9 @@ impl<'a> Parser<'a> {
                             ..
                         } => {
                             while optional_match_token!(self.lexer => Is) {
-                                let is_not =
-                                    tree!(ExprIR::Bool(optional_match_token!(self.lexer => Not)));
+                                let is_not = tree!(ExprIR::Constant(Value::Bool(
+                                    optional_match_token!(self.lexer => Not)
+                                )));
                                 match_token!(self.lexer => Null);
                                 res = tree!(
                                     ExprIR::FuncInvocation(
@@ -2142,12 +2145,15 @@ impl<'a> Parser<'a> {
                 9 => {
                     // unary add or subtract
                     if matches!(res.root().data(), ExprIR::Negate)
-                        && matches!(res.root().child(0).data(), ExprIR::Integer(i64::MIN))
+                        && matches!(
+                            res.root().child(0).data(),
+                            ExprIR::Constant(Value::Int(i64::MIN))
+                        )
                     {
-                        let res = tree!(ExprIR::Integer(i64::MIN));
+                        let res = tree!(ExprIR::Constant(Value::Int(i64::MIN)));
                         parse_expr_return!(stack, res);
                         continue;
-                    } else if matches!(res.root().data(), ExprIR::Integer(i64::MIN)) {
+                    } else if matches!(res.root().data(), ExprIR::Constant(Value::Int(i64::MIN))) {
                         // This case should not happen with proper error handling
                         // i64::MIN without negation means the literal was i64::MAX + 1
                         return Err(format!(
@@ -2178,7 +2184,7 @@ impl<'a> Parser<'a> {
                         }
                     }
                     if self.lexer.current()? == Token::Colon {
-                        let labels = tree!(ExprIR::List; self.parse_labels()?.into_iter().map(|l| tree!(ExprIR::String(l))));
+                        let labels = tree!(ExprIR::List; self.parse_labels()?.into_iter().map(|l| tree!(ExprIR::Constant(Value::String(l)))));
                         res = tree!(
                             ExprIR::FuncInvocation(
                                 get_functions().get("hasLabels", &FnType::Function)?
@@ -2405,7 +2411,7 @@ impl<'a> Parser<'a> {
         Ok(tree!(
             ExprIR::ListComprehension(var.clone()),
             list_expr,
-            condition.unwrap_or_else(|| tree!(ExprIR::Bool(true))),
+            condition.unwrap_or_else(|| tree!(ExprIR::Constant(Value::Bool(true)))),
             expression.map_or_else(|| Ok::<_, String>(tree!(ExprIR::Variable(var))), Ok)?
         ))
     }
@@ -2447,7 +2453,7 @@ impl<'a> Parser<'a> {
         let condition = if optional_match_token!(self.lexer => Where) {
             self.parse_expr(allow_pattern_predicate)?
         } else {
-            tree!(ExprIR::Bool(true))
+            tree!(ExprIR::Constant(Value::Bool(true)))
         };
 
         // Pipe + result expression
@@ -2671,7 +2677,7 @@ impl<'a> Parser<'a> {
             let key = self.parse_ident()?;
             match_token!(self.lexer, Colon);
             let value = self.parse_expr(false)?;
-            attrs.push(tree!(ExprIR::String(key), value));
+            attrs.push(tree!(ExprIR::Constant(Value::String(key)), value));
 
             match self.lexer.current()? {
                 Token::Comma => self.lexer.next(),
@@ -2714,11 +2720,11 @@ impl<'a> Parser<'a> {
                 let ident = self.parse_ident()?;
                 if optional_match_token!(self.lexer, Colon) {
                     let value = self.parse_expr(false)?;
-                    items.push(tree!(ExprIR::String(ident), value));
+                    items.push(tree!(ExprIR::Constant(Value::String(ident)), value));
                 } else {
                     // variable shorthand: name -> name: name
                     items.push(tree!(
-                        ExprIR::String(ident.clone()),
+                        ExprIR::Constant(Value::String(ident.clone())),
                         tree!(ExprIR::Variable(ident))
                     ));
                 }
@@ -2860,7 +2866,7 @@ impl<'a> Parser<'a> {
                 expr = tree!(
                     ExprIR::FuncInvocation(get_functions().get("hasLabels", &FnType::Function)?),
                     expr,
-                    tree!(ExprIR::List; self.parse_labels()?.into_iter().map(|l| tree!(ExprIR::String(l))))
+                    tree!(ExprIR::List; self.parse_labels()?.into_iter().map(|l| tree!(ExprIR::Constant(Value::String(l)))))
                 );
                 remove_items.push(Arc::new(expr));
             } else {

--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -31,7 +31,7 @@ use crate::parser::ast::{
 };
 use crate::runtime::functions::{FnArguments, FnType, Type};
 use crate::runtime::orderset::OrderSet;
-use crate::runtime::value::Value;
+use crate::runtime::value::{Value, ValueTypeOf};
 use crate::tree;
 use orx_tree::{Dfs, Dyn, DynNode, DynTree, NodeRef};
 use std::collections::{HashMap, HashSet};
@@ -2000,8 +2000,13 @@ impl Binder {
                 // `ExprIR::Constant(value)` leaf. The result lives in the
                 // plan cache, so the evaluation cost is paid once.
                 if let ExprIR::FuncInvocation(func) = &new_data
-                    && let Some(args) = collect_constant_args(&children)
                     && let Some(pure_fn) = func.pure_fn
+                    && let Some(args) = collect_constant_args(&children)
+                    && args.len() == func.pure_args_type.len()
+                    && args
+                        .iter()
+                        .zip(func.pure_args_type.iter())
+                        .all(|(v, t)| v.value_of_type(t).is_none())
                     && let Ok(value) = pure_fn(&args)
                 {
                     return Ok(DynTree::new(ExprIR::Constant(value)));

--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -31,6 +31,7 @@ use crate::parser::ast::{
 };
 use crate::runtime::functions::{FnArguments, FnType, Type};
 use crate::runtime::orderset::OrderSet;
+use crate::runtime::value::Value;
 use crate::tree;
 use orx_tree::{Dfs, Dyn, DynNode, DynTree, NodeRef};
 use std::collections::{HashMap, HashSet};
@@ -1843,11 +1844,7 @@ impl Binder {
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let new_data = match node_ref.data().clone() {
-                    ExprIR::Null => ExprIR::Null,
-                    ExprIR::Bool(b) => ExprIR::Bool(b),
-                    ExprIR::Integer(i) => ExprIR::Integer(i),
-                    ExprIR::Float(fl) => ExprIR::Float(fl),
-                    ExprIR::String(s) => ExprIR::String(s),
+                    ExprIR::Constant(v) => ExprIR::Constant(v),
                     ExprIR::List => ExprIR::List,
                     ExprIR::Map => ExprIR::Map,
                     ExprIR::MapProjection => ExprIR::MapProjection,
@@ -1989,6 +1986,26 @@ impl Binder {
                         ExprIR::Pattern(result?)
                     }
                 };
+                // Constructor rewrite: detect `duration({...})`, `date({...})`,
+                // `localtime({...})`, `localdatetime({...})`, `point({...})`
+                // with a single Map-literal argument whose keys are constant
+                // strings. Rewrite to an internal positional-arg function so
+                // the runtime skips per-row Map+Arc allocation.
+                let (new_data, children) = rewrite_struct_constructor(new_data, children);
+
+                // Constant folding: when the bound node is a function
+                // invocation whose arguments are already concrete constants
+                // and the function exposes a Runtime-free `pure_fn`, evaluate
+                // it now and replace the subtree with a single
+                // `ExprIR::Constant(value)` leaf. The result lives in the
+                // plan cache, so the evaluation cost is paid once.
+                if let ExprIR::FuncInvocation(func) = &new_data
+                    && let Some(args) = collect_constant_args(&children)
+                    && let Some(pure_fn) = func.pure_fn
+                    && let Ok(value) = pure_fn(&args)
+                {
+                    return Ok(DynTree::new(ExprIR::Constant(value)));
+                }
                 let mut new_tree = DynTree::new(new_data);
                 let mut root = new_tree.root_mut();
                 for child in children {
@@ -2179,10 +2196,7 @@ impl Binder {
             ExprIR::FuncInvocation(func) => func.ret_type.can_return_boolean(),
 
             // Non-boolean: literals, unary arithmetic, subscript, list comprehension
-            ExprIR::Integer(_)
-            | ExprIR::Float(_)
-            | ExprIR::String(_)
-            | ExprIR::List
+            ExprIR::List
             | ExprIR::Map
             | ExprIR::MapProjection
             | ExprIR::Negate
@@ -2193,9 +2207,7 @@ impl Binder {
             | ExprIR::PatternComprehension(_) => false,
 
             // Boolean literals, comparisons, predicates, and runtime-typed nodes
-            ExprIR::Bool(_)
-            | ExprIR::Null
-            | ExprIR::Eq
+            ExprIR::Eq
             | ExprIR::Neq
             | ExprIR::Lt
             | ExprIR::Gt
@@ -2217,6 +2229,9 @@ impl Binder {
             | ExprIR::Property(_)
             | ExprIR::ShortestPath { .. }
             | ExprIR::Pattern(_) => true,
+
+            // Pre-evaluated constant – only Bool/Null are boolean-shaped
+            ExprIR::Constant(v) => matches!(v, Value::Bool(_) | Value::Null),
         }
     }
 
@@ -2238,15 +2253,10 @@ impl Binder {
             ExprIR::GetElement
             | ExprIR::Property(_)
             | ExprIR::Parameter(_)
-            | ExprIR::Null
             | ExprIR::Reduce { .. } => true,
 
             // Everything else cannot produce a graph entity
-            ExprIR::Integer(_)
-            | ExprIR::Float(_)
-            | ExprIR::String(_)
-            | ExprIR::Bool(_)
-            | ExprIR::List
+            ExprIR::List
             | ExprIR::Map
             | ExprIR::MapProjection
             | ExprIR::Negate
@@ -2276,8 +2286,129 @@ impl Binder {
             | ExprIR::Quantifier { .. }
             | ExprIR::ShortestPath { .. }
             | ExprIR::Pattern(_) => false,
+
+            // Pre-evaluated constant – only Null and entity values count
+            ExprIR::Constant(v) => {
+                matches!(
+                    v,
+                    Value::Null | Value::Node(_) | Value::Relationship(_) | Value::Path(_)
+                )
+            }
         }
     }
+}
+
+/// Try to convert an already-bound expression subtree into a single concrete
+/// [`Value`]. Used for inline constant-folding in the binder.
+///
+/// Returns `Some(value)` only for trees that consist entirely of `Constant`
+/// leaves, plus structural `Map`/`List` whose children are all such leaves.
+fn expr_tree_to_value(tree: &DynTree<ExprIR<Variable>>) -> Option<Value> {
+    fn node_to_value(node: orx_tree::DynNode<ExprIR<Variable>>) -> Option<Value> {
+        match node.data() {
+            ExprIR::Constant(v) => Some(v.clone()),
+            ExprIR::List => {
+                let mut elements = thin_vec::ThinVec::with_capacity(node.num_children());
+                for child in node.children() {
+                    elements.push(node_to_value(child)?);
+                }
+                Some(Value::List(Arc::new(elements)))
+            }
+            ExprIR::Map => {
+                let mut entries: Vec<(Arc<String>, Value)> =
+                    Vec::with_capacity(node.num_children());
+                for child in node.children() {
+                    let ExprIR::Constant(Value::String(key)) = child.data() else {
+                        return None;
+                    };
+                    let val_node = child.get_child(0)?;
+                    entries.push((key.clone(), node_to_value(val_node)?));
+                }
+                Some(Value::Map(Arc::new(entries.into_iter().collect())))
+            }
+            _ => None,
+        }
+    }
+    node_to_value(tree.root())
+}
+
+/// Collect concrete [`Value`]s from each child sub-expression when *all*
+/// children are pure constants. Returns `None` if any child is non-constant.
+fn collect_constant_args(
+    children: &[DynTree<ExprIR<Variable>>]
+) -> Option<thin_vec::ThinVec<Value>> {
+    let mut args = thin_vec::ThinVec::with_capacity(children.len());
+    for child in children {
+        args.push(expr_tree_to_value(child)?);
+    }
+    Some(args)
+}
+
+/// If `new_data` is a constructor `FuncInvocation` (`duration`, `date`,
+/// `localtime`, `localdatetime`, `point`) whose single argument child is a
+/// Map literal with all-constant string keys, rewrite the call to pass
+/// positional arguments instead of the Map. Each Map entry feeds the
+/// matching positional slot; missing slots receive a `Constant(Null)` child.
+/// eval.rs detects the rewritten form via `func.struct_fn.is_some() &&
+/// num_children > 1` and dispatches through a stack `[Value; 10]` array.
+/// Returns the (possibly rewritten) data + children.
+fn rewrite_struct_constructor(
+    new_data: ExprIR<Variable>,
+    children: Vec<DynTree<ExprIR<Variable>>>,
+) -> (ExprIR<Variable>, Vec<DynTree<ExprIR<Variable>>>) {
+    let ExprIR::FuncInvocation(func) = &new_data else {
+        return (new_data, children);
+    };
+    if func.struct_fn.is_none() || func.struct_slots.is_empty() {
+        return (new_data, children);
+    }
+    let slots = func.struct_slots;
+    if children.len() != 1 {
+        return (new_data, children);
+    }
+    // Extract (key, value_tree) pairs in a scoped borrow so `children` can be
+    // moved on the bail-out branches below.
+    let entries: Option<HashMap<String, DynTree<ExprIR<Variable>>>> = {
+        let map_tree = &children[0];
+        if !matches!(map_tree.root().data(), ExprIR::Map) {
+            None
+        } else {
+            let map_root = map_tree.root();
+            let mut entries: HashMap<String, DynTree<ExprIR<Variable>>> = HashMap::new();
+            let mut ok = true;
+            for key_node in map_root.children() {
+                let ExprIR::Constant(Value::String(key)) = key_node.data() else {
+                    ok = false;
+                    break;
+                };
+                let Some(val_node) = key_node.get_child(0) else {
+                    ok = false;
+                    break;
+                };
+                entries.insert(key.as_str().to_string(), val_node.clone_as_tree());
+            }
+            if ok { Some(entries) } else { None }
+        }
+    };
+    let Some(entries) = entries else {
+        return (new_data, children);
+    };
+
+    // Build positional children: one per slot, missing entries → Constant(Null).
+    let mut new_children: Vec<DynTree<ExprIR<Variable>>> = Vec::with_capacity(slots.len());
+    let mut remaining = entries;
+    for slot in slots {
+        let child = remaining
+            .remove(*slot)
+            .unwrap_or_else(|| DynTree::new(ExprIR::Constant(Value::Null)));
+        new_children.push(child);
+    }
+    // Unknown keys → bail (preserve original semantics).
+    if !remaining.is_empty() {
+        return (new_data, children);
+    }
+
+    (new_data, new_children)
 }
 
 /// Recursively walk an ORDER BY expression tree and replace any aggregation
@@ -2358,10 +2489,10 @@ fn raw_exprs_structurally_equal(
         match (a, b) {
             (ExprIR::Variable(va), ExprIR::Variable(vb)) => va == vb,
             (ExprIR::FuncInvocation(fa), ExprIR::FuncInvocation(fb)) => fa.name == fb.name,
-            (ExprIR::String(sa), ExprIR::String(sb)) => sa == sb,
-            (ExprIR::Integer(ia), ExprIR::Integer(ib)) => ia == ib,
-            (ExprIR::Float(fa), ExprIR::Float(fb)) => fa == fb,
-            (ExprIR::Bool(ba), ExprIR::Bool(bb)) => ba == bb,
+            (ExprIR::Constant(Value::String(sa)), ExprIR::Constant(Value::String(sb))) => sa == sb,
+            (ExprIR::Constant(Value::Int(ia)), ExprIR::Constant(Value::Int(ib))) => ia == ib,
+            (ExprIR::Constant(Value::Float(fa)), ExprIR::Constant(Value::Float(fb))) => fa == fb,
+            (ExprIR::Constant(Value::Bool(ba)), ExprIR::Constant(Value::Bool(bb))) => ba == bb,
             (ExprIR::Property(pa), ExprIR::Property(pb)) => pa == pb,
             (ExprIR::Parameter(pa), ExprIR::Parameter(pb)) => pa == pb,
             _ => std::mem::discriminant(a) == std::mem::discriminant(b),

--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -40,6 +40,7 @@ use std::{
 };
 
 use crate::runtime::functions::Type;
+use crate::runtime::value::Value;
 use crate::tree;
 
 use orx_tree::{Bfs, DynNode, DynTree, NodeRef, Side, Traversal, Traverser};
@@ -588,8 +589,8 @@ pub(super) fn inline_attrs_to_filter(
     let mut filters: Vec<DynTree<ExprIR<Variable>>> = vec![];
 
     for attr in attrs.root().children() {
-        let ExprIR::String(attr_str) = attr.data() else {
-            unreachable!("inline attrs map children must be ExprIR::String keys");
+        let ExprIR::Constant(Value::String(attr_str)) = attr.data() else {
+            unreachable!("inline attrs map children must be ExprIR::Constant(Value::String) keys");
         };
         let eq = tree!(
             ExprIR::Eq,
@@ -770,7 +771,7 @@ impl Planner {
                 let where_tree = {
                     let t =
                         self.extract_pattern_comprehensions(&node.child(0), scope_id, extracted);
-                    if matches!(t.root().data(), ExprIR::Bool(true)) {
+                    if matches!(t.root().data(), ExprIR::Constant(Value::Bool(true))) {
                         None
                     } else {
                         Some(Arc::new(t))
@@ -837,7 +838,6 @@ impl Planner {
         paths: &[Arc<QueryPath<Variable>>],
     ) -> DynTree<IR> {
         use crate::runtime::functions::{FnType, get_functions};
-        use crate::runtime::value::Value;
 
         let saved = self.visited.clone();
         let mut sub_plan = self.plan_match(graph, None);
@@ -1053,7 +1053,7 @@ impl Planner {
                 non_scalar_trees.push(child_tree);
             } else {
                 // Skip trivial Bool(true) from extractable pattern replacement
-                if !matches!(child.data(), ExprIR::Bool(true)) {
+                if !matches!(child.data(), ExprIR::Constant(Value::Bool(true))) {
                     scalar_parts.push(child.clone_as_tree());
                 }
             }
@@ -1111,7 +1111,7 @@ impl Planner {
                 if can_extract {
                     // Top-level conjunct: extract for SemiApply, replace with true.
                     extractable.push((graph.clone(), false));
-                    DynTree::new(ExprIR::Bool(true))
+                    DynTree::new(ExprIR::Constant(Value::Bool(true)))
                 } else {
                     // Under OR/NOT: replace with a fresh boolean variable and
                     // record for inline handling via expr_to_plan.
@@ -1136,7 +1136,7 @@ impl Planner {
                     if can_extract {
                         // Extract for AntiSemiApply (is_anti = true).
                         extractable.push((graph.clone(), true));
-                        return DynTree::new(ExprIR::Bool(true));
+                        return DynTree::new(ExprIR::Constant(Value::Bool(true)));
                     }
                     // Inline: create NOT(synth_var) so expr_to_plan can
                     // recognize the negation and use AntiSemiApply.
@@ -1671,7 +1671,7 @@ impl Planner {
             // rebuilt expression into multiplexer / semi-apply / filter nodes.
             if !inline.is_empty() {
                 res = self.expr_to_plan(&rebuilt.root(), &inline, res);
-            } else if !matches!(rebuilt.root().data(), ExprIR::Bool(true)) {
+            } else if !matches!(rebuilt.root().data(), ExprIR::Constant(Value::Bool(true))) {
                 res = tree!(IR::Filter(Arc::new(rebuilt)), res);
             }
 
@@ -1891,7 +1891,7 @@ impl Planner {
                 true,
             );
 
-            if !matches!(rebuilt.root().data(), ExprIR::Bool(true)) {
+            if !matches!(rebuilt.root().data(), ExprIR::Constant(Value::Bool(true))) {
                 if inline.is_empty() {
                     res = tree!(IR::Filter(Arc::new(rebuilt)), res);
                 } else {
@@ -2144,7 +2144,7 @@ impl Planner {
                 explicit_yield: _yielded,
             } => {
                 if proc.name == "db.idx.fulltext.drop" {
-                    let ExprIR::String(label) = exprs[0].root().data() else {
+                    let ExprIR::Constant(Value::String(label)) = exprs[0].root().data() else {
                         unreachable!()
                     };
                     return tree!(IR::DropIndex {

--- a/graph/src/planner/optimizer/eliminate_true_filters.rs
+++ b/graph/src/planner/optimizer/eliminate_true_filters.rs
@@ -90,15 +90,7 @@ fn substitute_params(
         if let ExprIR::Parameter(name) = result.node(idx).data()
             && let Some(val) = params.get(name)
         {
-            let replacement = match val {
-                Value::Null => ExprIR::Null,
-                Value::Bool(b) => ExprIR::Bool(*b),
-                Value::Int(n) => ExprIR::Integer(*n),
-                Value::Float(f) => ExprIR::Float(*f),
-                Value::String(s) => ExprIR::String(s.clone()),
-                _ => continue,
-            };
-            *result.node_mut(idx).data_mut() = replacement;
+            *result.node_mut(idx).data_mut() = ExprIR::Constant(val.clone());
         }
     }
     result

--- a/graph/src/planner/optimizer/reduce_count.rs
+++ b/graph/src/planner/optimizer/reduce_count.rs
@@ -40,6 +40,7 @@ use orx_tree::{DynTree, NodeRef};
 use crate::{
     graph::graph::Graph,
     parser::ast::{ExprIR, Variable},
+    runtime::value::Value,
     tree,
 };
 
@@ -155,7 +156,7 @@ pub(super) fn reduce_count(
         // as a constant integer.
         let agg_var = agg_var.clone();
         let count_expr: Arc<DynTree<ExprIR<Variable>>> =
-            Arc::new(tree!(ExprIR::Integer(count_value)));
+            Arc::new(tree!(ExprIR::Constant(Value::Int(count_value))));
 
         // First prune all children.
         while optimized_plan.node(idx).num_children() > 0 {

--- a/graph/src/planner/optimizer/utilize_index.rs
+++ b/graph/src/planner/optimizer/utilize_index.rs
@@ -66,6 +66,7 @@ use super::super::IR;
 
 use crate::parser::ast::QueryRelationship;
 use crate::runtime::orderset::OrderSet;
+use crate::runtime::value::Value;
 
 /// Build a `hasLabels(variable, [label1, label2, ...])` filter expression.
 fn build_has_labels_filter(
@@ -78,7 +79,7 @@ fn build_has_labels_filter(
     Arc::new(tree!(
         ExprIR::FuncInvocation(has_labels_fn),
         tree!(ExprIR::Variable(var.clone())),
-        tree!(ExprIR::List; labels.map(|l| tree!(ExprIR::String(l))))
+        tree!(ExprIR::List; labels.map(|l| tree!(ExprIR::Constant(Value::String(l)))))
     ))
 }
 
@@ -726,7 +727,7 @@ fn get_inline_attr_index<T: IndexSubject>(
 ) -> Option<(T, Arc<String>, Arc<String>, DynTree<ExprIR<Variable>>)> {
     for label in subject.all_labels() {
         for attr in subject.inline_attrs().root().children() {
-            if let ExprIR::String(attr_str) = attr.data()
+            if let ExprIR::Constant(Value::String(attr_str)) = attr.data()
                 && T::is_indexed(graph, label, attr_str, &IndexType::Range)
             {
                 return Some((
@@ -865,12 +866,12 @@ fn needs_post_filter(
         && matches!(rhs.data(), ExprIR::List)
         && rhs.num_children() > 0
         && rhs.children().all(|child| match child.data() {
-            ExprIR::Bool(_) | ExprIR::Float(_) | ExprIR::String(_) => true,
+            ExprIR::Constant(Value::Bool(_) | Value::Float(_) | Value::String(_)) => true,
             // Large int64s can't round-trip through f64 exactly,
             // so the runtime will reject them and fall back to a
             // full scan — the Filter has to stay above to
             // re-establish correctness in that case.
-            ExprIR::Integer(v) => !Index::int_loses_f64_precision(*v),
+            ExprIR::Constant(Value::Int(v)) => !Index::int_loses_f64_precision(*v),
             // `Null` is intentionally *not* whitelisted: the runtime
             // drops `Null` from the IN list when building the index
             // query, which can collapse to an empty `Or([])` that the
@@ -916,7 +917,7 @@ fn is_non_indexable_subexpr(
     match expr {
         ExprIR::Variable(v) => scan_alias_id.is_none_or(|id| v.id != id),
         ExprIR::Parameter(_) => true,
-        ExprIR::Integer(v) => Index::int_loses_f64_precision(*v),
+        ExprIR::Constant(Value::Int(v)) => Index::int_loses_f64_precision(*v),
         // Compound / non-primitive literals: the index backing store
         // only handles numeric, string, bool, and point scalars.
         ExprIR::List | ExprIR::Map => true,

--- a/graph/src/runtime/eval.rs
+++ b/graph/src/runtime/eval.rs
@@ -178,11 +178,7 @@ impl<'a> ExprEval<'a> {
     ) -> Result<Value, String> {
         // Fast-path early returns for leaf / simple nodes.
         match ir.node(idx).data() {
-            ExprIR::Null => return Ok(Value::Null),
-            ExprIR::Bool(x) => return Ok(Value::Bool(*x)),
-            ExprIR::Integer(x) => return Ok(Value::Int(*x)),
-            ExprIR::Float(x) => return Ok(Value::Float(*x)),
-            ExprIR::String(x) => return Ok(Value::String(x.clone())),
+            ExprIR::Constant(v) => return Ok(v.clone()),
             ExprIR::Variable(x) => {
                 return Self::resolve_var(env, x);
             }
@@ -199,7 +195,7 @@ impl<'a> ExprEval<'a> {
                         .children()
                         .map(|child| {
                             Ok((
-                                if let ExprIR::String(key) = child.data() {
+                                if let ExprIR::Constant(Value::String(key)) = child.data() {
                                     key.clone()
                                 } else {
                                     return Err("Map key must be a string".into());
@@ -251,11 +247,7 @@ impl<'a> ExprEval<'a> {
         while let Some((idx, reenter)) = stack.pop() {
             let node = ir.node(idx);
             match node.data() {
-                ExprIR::Null => res.push(Value::Null),
-                ExprIR::Bool(x) => res.push(Value::Bool(*x)),
-                ExprIR::Integer(x) => res.push(Value::Int(*x)),
-                ExprIR::Float(x) => res.push(Value::Float(*x)),
-                ExprIR::String(x) => res.push(Value::String(x.clone())),
+                ExprIR::Constant(v) => res.push(v.clone()),
                 ExprIR::Variable(x) => res.push(Self::resolve_var(env, x)?),
                 ExprIR::Parameter(x) => res.push(self.rt()?.parameters.get(x).map_or_else(
                     || Err(format!("Parameter {x} not found")),
@@ -588,12 +580,42 @@ impl<'a> ExprEval<'a> {
                             None => Ok(acc),
                         };
                     }
-                    let mut args = node
-                        .children()
-                        .map(|child| self.eval(ir, child.idx(), env, agg_group_key))
-                        .collect::<Result<ThinVec<_>, _>>()?;
+                    // Fast path for struct-constructor functions (duration,
+                    // date, point, ...): when the binder rewrote a
+                    // `{key: value}` map call into positional children, write
+                    // child values into a stack array and dispatch the
+                    // slice-based struct_fn directly. Bypasses the per-row
+                    // ThinVec<Value> heap alloc, the validate_args_type walk,
+                    // and the Arc<RuntimeFn> dispatch hop. The
+                    // `num_children > 1` guard distinguishes the rewritten
+                    // positional form from the regular `duration({...})` call
+                    // with a single Map argument. Max 10 slots
+                    // (matches `localdatetime`).
+                    if let Some(struct_fn) = func.struct_fn
+                        && node.num_children() > 1
+                    {
+                        let n = node.num_children();
+                        debug_assert!(n <= 10);
+                        let mut slots: [Value; 10] = std::array::from_fn(|_| Value::Null);
+                        for (i, child) in node.children().enumerate() {
+                            if !matches!(child.data(), ExprIR::Constant(Value::Null)) {
+                                slots[i] = self.eval(ir, child.idx(), env, agg_group_key)?;
+                            }
+                        }
+                        res.push(struct_fn(&slots[..n])?);
+                        continue;
+                    }
+                    // Distinct-prefixed aggregate (e.g. `count(DISTINCT x, acc)`):
+                    // the first child carries the already-deduplicated list;
+                    // flatten it with the accumulator. Needs owned ownership of
+                    // the inner list to avoid a copy, so it stays on the
+                    // ThinVec path.
                     if node.num_children() == 2 && matches!(node.child(0).data(), ExprIR::Distinct)
                     {
+                        let mut args = node
+                            .children()
+                            .map(|child| self.eval(ir, child.idx(), env, agg_group_key))
+                            .collect::<Result<ThinVec<_>, _>>()?;
                         match args.remove(0) {
                             Value::List(values) => {
                                 let mut values = Arc::unwrap_or_clone(values);
@@ -602,22 +624,41 @@ impl<'a> ExprEval<'a> {
                             }
                             _ => unreachable!(),
                         }
+                        func.validate_args_type(&args)?;
+                        if !rt.write && func.write {
+                            return Err(String::from(
+                                "graph.RO_QUERY is to be executed only on read-only queries",
+                            ));
+                        }
+                        res.push(func.func.call(rt, &args)?);
+                        continue;
                     }
 
-                    func.validate_args_type(&args)?;
+                    // Common path: evaluate children directly onto the shared
+                    // `res` stack and pass a slice to the function. Eliminates
+                    // the per-call ThinVec<Value> heap allocation that an
+                    // intermediate `args` collection would do — same trick the
+                    // struct_fn fast path above uses with a stack array.
+                    let base = res.len();
+                    for child in node.children() {
+                        let v = self.eval(ir, child.idx(), env, agg_group_key)?;
+                        res.push(v);
+                    }
+                    func.validate_args_type(&res[base..])?;
                     if !rt.write && func.write {
                         return Err(String::from(
                             "graph.RO_QUERY is to be executed only on read-only queries",
                         ));
                     }
-
-                    res.push((func.func)(rt, args)?);
+                    let out = func.func.call(rt, &res[base..])?;
+                    res.truncate(base);
+                    res.push(out);
                 }
                 ExprIR::Map => res.push(Value::Map(Arc::new(
                     node.children()
                         .map(|child| {
                             Ok((
-                                if let ExprIR::String(key) = child.data() {
+                                if let ExprIR::Constant(Value::String(key)) = child.data() {
                                     key.clone()
                                 } else {
                                     return Err("Map key must be a string".into());
@@ -1188,8 +1229,8 @@ impl<'a> ExprEval<'a> {
                     };
                     result.insert(prop_name.clone(), value);
                 }
-                ExprIR::String(_) => {
-                    let key = if let ExprIR::String(k) = item.data() {
+                ExprIR::Constant(Value::String(_)) => {
+                    let key = if let ExprIR::Constant(Value::String(k)) = item.data() {
                         k.clone()
                     } else {
                         unreachable!();
@@ -1359,11 +1400,7 @@ pub(crate) const fn logical_xor(
 
 pub fn evaluate_param(expr: &DynNode<ExprIR<Arc<String>>>) -> Result<Value, String> {
     match expr.data() {
-        ExprIR::Null => Ok(Value::Null),
-        ExprIR::Bool(x) => Ok(Value::Bool(*x)),
-        ExprIR::Integer(x) => Ok(Value::Int(*x)),
-        ExprIR::Float(x) => Ok(Value::Float(*x)),
-        ExprIR::String(x) => Ok(Value::String(x.clone())),
+        ExprIR::Constant(v) => Ok(v.clone()),
         ExprIR::List => Ok(Value::List(Arc::new(
             expr.children()
                 .map(|c| evaluate_param(&c))
@@ -1372,7 +1409,7 @@ pub fn evaluate_param(expr: &DynNode<ExprIR<Arc<String>>>) -> Result<Value, Stri
         ExprIR::Map => Ok(Value::Map(Arc::new(
             expr.children()
                 .map(|ir| match ir.data() {
-                    ExprIR::String(key) => {
+                    ExprIR::Constant(Value::String(key)) => {
                         Ok::<_, String>((key.clone(), evaluate_param(&ir.child(0))?))
                     }
                     _ => Err("Map parameter key must be a string".into()),

--- a/graph/src/runtime/functions/aggregation.rs
+++ b/graph/src/runtime/functions/aggregation.rs
@@ -44,7 +44,7 @@ use crate::runtime::{
     value::{CompareValue, DisjointOrNull, Value},
 };
 use std::{cmp::Ordering, sync::Arc};
-use thin_vec::{ThinVec, thin_vec};
+use thin_vec::thin_vec;
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "collect",
@@ -53,7 +53,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::List(Arc::new(thin_vec![])),
         batch_agg: collect_batch,
         fn collect(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             match (iter.next(), iter.next()) {
                 (Some(a), Some(Value::Null)) => Ok(Value::List(Arc::new(thin_vec![a]))),
                 (Some(a), Some(Value::List(mut l))) => {
@@ -75,7 +75,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::Int(0),
         batch_agg: count_batch,
         fn count(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             let first = iter.next();
             let sec = iter.next();
             match (first, sec) {
@@ -93,7 +93,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::Float(0.0),
         batch_agg: sum_batch,
         fn sum(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             let first = iter.next();
             let second = iter.next();
 
@@ -117,7 +117,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::Null,
         batch_agg: max_batch,
         fn max(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             match (iter.next(), iter.next()) {
                 (Some(a), Some(b)) => {
                     if let (ord, cmp) = b.compare_value(&a) &&
@@ -138,7 +138,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::Null,
         batch_agg: min_batch,
         fn min(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             match (iter.next(), iter.next()) {
                 (Some(a), Some(b)) => {
                     if let (ord, cmp) = b.compare_value(&a) &&
@@ -159,7 +159,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::List(Arc::new(thin_vec![Value::Float(0.0), Value::Int(0), Value::Bool(false)])),
         finalizer: finalize_avg,
         fn avg(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             let val = iter.next().unwrap();
             let ctx = iter.next().unwrap();
             match (val, ctx) {
@@ -221,16 +221,16 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Float, Type::Null]),
         agg_init: Value::List(Arc::new(thin_vec![Value::Float(0.0), Value::List(Arc::new(thin_vec![]))])),
         finalizer: finalize_percentile_disc,
-        fn percentile(_, mut args) {
-            let val = args.remove(0);
-            let percentile_val = args.remove(0);
+        fn percentile(_, args) {
+            let val = args[0].clone();
+            let percentile_val = args[1].clone();
 
             // Domain validation is now done in PHASE 3.5, so these checks are removed
             // (Or kept as defensive programming - they should never fail)
 
             let percentile = percentile_val.get_numeric();
 
-            let ctx = args.remove(0);
+            let ctx = args[2].clone();
             if matches!(val, Value::Null) {
                 return Ok(ctx);
             }
@@ -281,7 +281,7 @@ pub fn register(funcs: &mut Functions) {
         agg_init: Value::List(Arc::new(thin_vec![Value::Float(0.0), Value::List(Arc::new(thin_vec![]))])),
         finalizer: finalize_stdev,
         fn stdev(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter().cloned();
             let val = iter.next().unwrap();
             let ctx = iter.next().unwrap();
             match (val, ctx) {

--- a/graph/src/runtime/functions/conversion.rs
+++ b/graph/src/runtime/functions/conversion.rs
@@ -42,7 +42,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Bool, Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Null]),
         fn value_to_integer(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => {
                     if s.is_empty() {
                         return Ok(Value::Null);
@@ -66,8 +66,8 @@ pub fn register(funcs: &mut Functions) {
                         _ => Ok(Value::Null),
                     }
                 }
-                Some(Value::Int(i)) => Ok(Value::Int(i)),
-                Some(Value::Float(f)) => {
+                Some(&Value::Int(i)) => Ok(Value::Int(i)),
+                Some(&Value::Float(f)) => {
                     if !f.is_finite() {
                         return Ok(Value::Null);
                     }
@@ -75,7 +75,7 @@ pub fn register(funcs: &mut Functions) {
                     #[allow(clippy::cast_possible_truncation)]
                     Ok(Value::Int(floored as i64))
                 }
-                Some(Value::Bool(b)) => Ok(Value::Int(i64::from(b))),
+                Some(&Value::Bool(b)) => Ok(Value::Int(i64::from(b))),
                 _ => Ok(Value::Null),
             }
         }
@@ -94,10 +94,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Float, Type::Int, Type::Null])],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn value_to_float(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => s.parse::<f64>().map(Value::Float).or(Ok(Value::Null)),
-                Some(Value::Float(f)) => Ok(Value::Float(f)),
-                Some(Value::Int(i)) => Ok(Value::Float(i as f64)),
+                Some(&Value::Float(f)) => Ok(Value::Float(f)),
+                Some(&Value::Int(i)) => Ok(Value::Float(i as f64)),
                 _ => Ok(Value::Null),
             }
         }
@@ -116,8 +116,8 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Datetime, Type::Date, Type::Time, Type::Duration, Type::String, Type::Bool, Type::Int, Type::Float, Type::Null, Type::Point])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn value_to_string(_runtime, args) {
-            match args.into_iter().next() {
-                Some(Value::String(s)) => Ok(Value::String(s)),
+            match args.first() {
+                Some(Value::String(s)) => Ok(Value::String(Arc::clone(s))),
                 Some(Value::Int(i)) => Ok(Value::String(Arc::new(i.to_string()))),
                 Some(Value::Float(f)) => {
                     // Format without trailing zeros; ensure at least one decimal
@@ -129,10 +129,10 @@ pub fn register(funcs: &mut Functions) {
                     "point({{latitude: {:.6}, longitude: {:.6}}})",
                     p.latitude, p.longitude
                 )))),
-                Some(Value::Datetime(ts)) => Ok(Value::String(Arc::new(Value::format_datetime(ts)))),
-                Some(Value::Date(ts)) => Ok(Value::String(Arc::new(Value::format_date(ts)))),
-                Some(Value::Time(ts)) => Ok(Value::String(Arc::new(Value::format_time(ts)))),
-                Some(Value::Duration(dur)) => Ok(Value::String(Arc::new(Value::format_duration(dur)))),
+                Some(&Value::Datetime(ts)) => Ok(Value::String(Arc::new(Value::format_datetime(ts)))),
+                Some(&Value::Date(ts)) => Ok(Value::String(Arc::new(Value::format_date(ts)))),
+                Some(&Value::Time(ts)) => Ok(Value::String(Arc::new(Value::format_time(ts)))),
+                Some(&Value::Duration(dur)) => Ok(Value::String(Arc::new(Value::format_duration(dur)))),
                 Some(_) => Ok(Value::Null),
                 None => unreachable!(),
             }
@@ -152,7 +152,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Any],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn to_json(runtime, args) {
-            args.into_iter().next().map_or_else(
+            args.first().map_or_else(
                 || unreachable!(),
                 |v| {
                     let json_string = v.to_json_string(runtime);
@@ -166,7 +166,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Map, Type::List(Box::new(Type::Any)), Type::String, Type::Null])],
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         fn is_empty(_, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::Null) => Ok(Value::Null),
                 Some(Value::String(s)) => Ok(Value::Bool(s.is_empty())),
                 Some(Value::List(v)) => Ok(Value::Bool(v.is_empty())),
@@ -180,8 +180,8 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Bool, Type::Int, Type::Null])],
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         fn to_boolean(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Bool(b)) => Ok(Value::Bool(b)),
+            match args.first() {
+                Some(&Value::Bool(b)) => Ok(Value::Bool(b)),
                 Some(Value::String(s)) => {
                     if s.eq_ignore_ascii_case("true") {
                         Ok(Value::Bool(true))
@@ -191,7 +191,7 @@ pub fn register(funcs: &mut Functions) {
                         Ok(Value::Null)
                     }
                 }
-                Some(Value::Int(n)) => Ok(Value::Bool(n != 0)),
+                Some(&Value::Int(n)) => Ok(Value::Bool(n != 0)),
                 _ => Ok(Value::Null),
             }
         }
@@ -210,7 +210,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn to_boolean_list(_, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::List(vs)) => {
                     let result: ThinVec<Value> = vs.iter().map(|v| match v {
                         Value::Bool(b) => Value::Bool(*b),
@@ -237,7 +237,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn to_float_list(_, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::List(vs)) => {
                     let result: ThinVec<Value> = vs.iter().map(|v| match v {
                         Value::Float(f) => Value::Float(*f),
@@ -256,11 +256,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn to_integer_list(runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::List(vs)) => {
                     let result: ThinVec<Value> = vs.iter().map(|v| {
-                        let elem_args = thin_vec::thin_vec![v.clone()];
-                        value_to_integer(runtime, elem_args).unwrap_or(Value::Null)
+                        value_to_integer(runtime, &[v.clone()]).unwrap_or(Value::Null)
                     }).collect();
                     Ok(Value::List(Arc::new(result)))
                 }
@@ -273,11 +272,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn to_string_list(runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::List(vs)) => {
                     let result: ThinVec<Value> = vs.iter().map(|v| {
-                        let elem_args = thin_vec::thin_vec![v.clone()];
-                        value_to_string(runtime, elem_args).unwrap_or(Value::Null)
+                        value_to_string(runtime, &[v.clone()]).unwrap_or(Value::Null)
                     }).collect();
                     Ok(Value::List(Arc::new(result)))
                 }

--- a/graph/src/runtime/functions/entity.rs
+++ b/graph/src/runtime/functions/entity.rs
@@ -38,8 +38,8 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Node, Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::String)), Type::Null]),
         fn labels(runtime, args) {
-            match args.into_iter().next() {
-                Some(Value::Node(id)) => {
+            match args.first() {
+                Some(&Value::Node(id)) => {
                     let labels = runtime.get_node_labels(id);
                     Ok(Value::List(Arc::new(labels.into_iter().map(Value::String).collect())))
                 }
@@ -54,7 +54,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Any],
         ret: Type::String,
         fn type_of(_runtime, args) {
-            let type_name = match args.into_iter().next() {
+            let type_name = match args.first() {
                 Some(Value::Null) => "Null",
                 Some(Value::Bool(_)) => "Boolean",
                 Some(Value::Int(_)) => "Integer",
@@ -84,9 +84,9 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         fn has_labels(runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
-                (Some(Value::Node(id)), Some(Value::List(required_labels))) => {
+                (Some(&Value::Node(id)), Some(Value::List(required_labels))) => {
                     // Validate that all items in the list are strings
                     for label_value in required_labels.iter() {
                         match label_value {
@@ -131,9 +131,8 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Union(vec![Type::Int, Type::Null]),
         fn id(_runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Node(id)) => Ok(Value::Int(u64::from(id) as i64)),
+            match args.first() {
+                Some(&Value::Node(id)) => Ok(Value::Int(u64::from(id) as i64)),
                 Some(Value::Relationship(rel)) => Ok(Value::Int(u64::from(rel.0) as i64)),
                 Some(Value::Null) => Ok(Value::Null),
 
@@ -151,10 +150,9 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Union(vec![Type::Map, Type::Null]),
         fn properties(runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Map(map)) => Ok(Value::Map(map)),
-                Some(Value::Node(id)) => Ok(Value::Map(Arc::new(runtime.get_node_attrs(id)))),
+            match args.first() {
+                Some(Value::Map(map)) => Ok(Value::Map(map.clone())),
+                Some(&Value::Node(id)) => Ok(Value::Map(Arc::new(runtime.get_node_attrs(id)))),
                 Some(Value::Relationship(rel)) => {
                     Ok(Value::Map(Arc::new(runtime.get_relationship_attrs(rel.0))))
                 }
@@ -169,8 +167,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Relationship],
         ret: Type::Union(vec![Type::Node, Type::Null]),
         fn start_node(_runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Relationship(rel)) => Ok(Value::Node(rel.1)),
 
                 _ => unreachable!(),
@@ -182,8 +179,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Relationship],
         ret: Type::Union(vec![Type::Node, Type::Null]),
         fn end_node(_runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Relationship(rel)) => Ok(Value::Node(rel.2)),
 
                 _ => unreachable!(),
@@ -195,8 +191,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Path, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Null]),
         fn length(_runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Path(path)) => Ok(Value::Int(path.len() as i64 / 2)),
                 Some(Value::Null) => Ok(Value::Null),
 
@@ -214,11 +209,11 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Union(vec![Type::List(Box::new(Type::String)), Type::Null]),
         fn keys(runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::Map(map)) => Ok(Value::List(Arc::new(
                     map.keys().cloned().map(Value::String).collect(),
                 ))),
-                Some(Value::Node(id)) => Ok(Value::List(Arc::new(
+                Some(&Value::Node(id)) => Ok(Value::List(Arc::new(
                     runtime
                         .get_node_attrs(id)
                         .into_iter()
@@ -243,8 +238,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Relationship, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn relationship_type(runtime, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Relationship(rel)) => runtime
                     .get_relationship_type(rel.0)
                     .map_or_else(|| Ok(Value::Null), |type_name| Ok(Value::String(type_name))),
@@ -258,8 +252,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Any],
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         fn exists(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Null) => Ok(Value::Bool(false)),
                 _ => Ok(Value::Bool(true)),
             }
@@ -307,7 +300,7 @@ pub fn register(funcs: &mut Functions) {
 ///   degree(node, [`type1`, `type2`])      → filter by list of strings
 fn parse_degree_args(
     fn_name: &str,
-    args: ThinVec<Value>,
+    args: &[Value],
 ) -> Result<(Option<NodeId>, Vec<Arc<String>>), String> {
     if args.is_empty() {
         return Err(format!(
@@ -315,11 +308,8 @@ fn parse_degree_args(
         ));
     }
 
-    let mut iter = args.into_iter();
-    let node = iter.next().unwrap();
-
-    let id = match node {
-        Value::Node(id) => Some(id),
+    let id = match &args[0] {
+        Value::Node(id) => Some(*id),
         Value::Null => None,
         other => {
             return Err(format!(
@@ -329,14 +319,14 @@ fn parse_degree_args(
         }
     };
 
-    let rest: ThinVec<Value> = iter.collect();
+    let rest = &args[1..];
     if rest.is_empty() {
         return Ok((id, Vec::new()));
     }
 
     // Single list argument: degree(node, ['type1', 'type2'])
     if rest.len() == 1 {
-        if let Value::List(ref list) = rest[0] {
+        if let Value::List(list) = &rest[0] {
             let mut types = Vec::with_capacity(list.len());
             for v in list.iter() {
                 match v {
@@ -365,11 +355,11 @@ fn parse_degree_args(
 
     // Varargs of strings: degree(node, 'type1', 'type2', ...)
     let mut types = Vec::with_capacity(rest.len());
-    for v in rest {
+    for v in rest.iter() {
         match v {
             Value::String(s) => {
-                if !types.contains(&s) {
-                    types.push(s);
+                if !types.contains(s) {
+                    types.push(s.clone());
                 }
             }
             other => {

--- a/graph/src/runtime/functions/internal.rs
+++ b/graph/src/runtime/functions/internal.rs
@@ -27,7 +27,6 @@
 
 use super::{FnType, Functions, Type};
 use crate::runtime::{runtime::Runtime, value::Value};
-use thin_vec::ThinVec;
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "starts_with",
@@ -38,7 +37,7 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         internal,
         fn internal_starts_with(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(prefix))) => {
                     Ok(Value::Bool(s.starts_with(prefix.as_str())))
@@ -56,7 +55,7 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         internal,
         fn internal_ends_with(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(suffix))) => {
                     Ok(Value::Bool(s.ends_with(suffix.as_str())))
@@ -74,7 +73,7 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         internal,
         fn internal_contains(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(substring))) => {
                     Ok(Value::Bool(s.contains(substring.as_str())))
@@ -89,10 +88,10 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         internal,
         fn internal_is_null(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
-                (Some(Value::Bool(is_not)), Some(Value::Null)) => Ok(Value::Bool(!is_not)),
-                (Some(Value::Bool(is_not)), Some(_)) => Ok(Value::Bool(is_not)),
+                (Some(&Value::Bool(is_not)), Some(Value::Null)) => Ok(Value::Bool(!is_not)),
+                (Some(&Value::Bool(is_not)), Some(_)) => Ok(Value::Bool(is_not)),
                 _ => unreachable!(),
             }
         }
@@ -106,7 +105,7 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Bool, Type::Null]),
         internal,
         fn internal_regex_matches(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(pattern))) => {
                     match regex::Regex::new(pattern.as_str()) {
@@ -125,7 +124,7 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Any,
         internal,
         fn internal_case(_, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next(), iter.next()) {
                 (Some(Value::List(alts)), Some(else_), None) => {
                     for pair in alts.chunks(2) {
@@ -134,7 +133,7 @@ pub fn register(funcs: &mut Functions) {
                             (_, result) => return Ok(result.clone()),
                         }
                     }
-                    Ok(else_)
+                    Ok(else_.clone())
                 }
                 (Some(value), Some(alt), Some(else_)) => {
                     let Value::List(alts) = alt else {
@@ -142,12 +141,12 @@ pub fn register(funcs: &mut Functions) {
                     };
                     for pair in alts.chunks(2) {
                         if let [condition, result] = pair
-                            && *condition == value
+                            && condition == value
                         {
                             return Ok(result.clone());
                         }
                     }
-                    Ok(else_)
+                    Ok(else_.clone())
                 }
                 _ => unreachable!(),
             }

--- a/graph/src/runtime/functions/list.rs
+++ b/graph/src/runtime/functions/list.rs
@@ -43,10 +43,10 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Union(vec![Type::Int, Type::Null]),
         fn size(_, args) {
-            match args.into_iter().next() {
-                Some(Value::String(s)) => Ok(Value::Int(s.chars().count() as i64)),
-                Some(Value::List(v)) => Ok(Value::Int(v.len() as i64)),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::String(s) => Ok(Value::Int(s.chars().count() as i64)),
+                Value::List(v) => Ok(Value::Int(v.len() as i64)),
+                Value::Null => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
@@ -59,15 +59,15 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Any,
         fn head(_, args) {
-            match args.into_iter().next() {
-                Some(Value::List(v)) => {
+            match &args[0] {
+                Value::List(v) => {
                     if v.is_empty() {
                         Ok(Value::Null)
                     } else {
                         Ok(v[0].clone())
                     }
                 }
-                Some(Value::Null) => Ok(Value::Null),
+                Value::Null => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
@@ -80,9 +80,9 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Any,
         fn last(_, args) {
-            match args.into_iter().next() {
-                Some(Value::List(v)) => Ok(v.last().cloned().unwrap_or(Value::Null)),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::List(v) => Ok(v.last().cloned().unwrap_or(Value::Null)),
+                Value::Null => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
@@ -95,15 +95,15 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Any,
         fn tail(_, args) {
-            match args.into_iter().next() {
-                Some(Value::List(v)) => {
+            match &args[0] {
+                Value::List(v) => {
                     if v.is_empty() {
                         Ok(Value::List(Arc::new(thin_vec![])))
                     } else {
                         Ok(Value::List(Arc::new(v[1..].iter().cloned().collect::<ThinVec<_>>())))
                     }
                 }
-                Some(Value::Null) => Ok(Value::Null),
+                Value::Null => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
@@ -121,13 +121,14 @@ pub fn register(funcs: &mut Functions) {
             Type::Null,
         ]),
         fn reverse(_, args) {
-            match args.into_iter().next() {
-                Some(Value::List(mut v)) => {
+            match &args[0] {
+                Value::List(v) => {
+                    let mut v = Arc::clone(v);
                     Arc::make_mut(&mut v).reverse();
                     Ok(Value::List(v))
                 }
-                Some(Value::String(s)) => Ok(Value::String(Arc::new(s.chars().rev().collect()))),
-                Some(Value::Null) => Ok(Value::Null),
+                Value::String(s) => Ok(Value::String(Arc::new(s.chars().rev().collect()))),
+                Value::Null => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
@@ -143,17 +144,16 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn list_remove(_, args) {
-            let mut it = args.into_iter();
-            let list = it.next();
-            let index = it.next();
-            let count = it.next();
+            let list = args.first();
+            let index = args.get(1);
+            let count = args.get(2);
 
             match list {
                 Some(Value::Null) => Ok(Value::Null),
                 Some(Value::List(vs)) => {
-                    let Some(Value::Int(idx)) = index else { return Ok(Value::Null) };
+                    let Some(&Value::Int(idx)) = index else { return Ok(Value::Null) };
                     let count = match count {
-                        Some(Value::Int(c)) => c,
+                        Some(&Value::Int(c)) => c,
                         None => 1,
                         _ => return Ok(Value::Null),
                     };
@@ -162,7 +162,7 @@ pub fn register(funcs: &mut Functions) {
                     let normalized = if idx < 0 { len + idx } else { idx };
                     // Out of range or non-positive count: return original
                     if normalized < 0 || normalized >= len || count <= 0 {
-                        return Ok(Value::List(vs));
+                        return Ok(Value::List(Arc::clone(vs)));
                     }
                     let start = normalized as usize;
                     let end = ((normalized + count) as usize).min(vs.len());
@@ -185,15 +185,14 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn list_sort(_, args) {
-            let mut it = args.into_iter();
-            let list = it.next();
-            let ascending = it.next();
+            let list = args.first();
+            let ascending = args.get(1);
 
             match list {
                 Some(Value::Null) => Ok(Value::Null),
                 Some(Value::List(vs)) => {
                     let asc = match ascending {
-                        Some(Value::Bool(b)) => b,
+                        Some(&Value::Bool(b)) => b,
                         None => true,
                         _ => return Ok(Value::Null),
                     };
@@ -220,22 +219,21 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn list_insert(_, args) {
-            let mut it = args.into_iter();
-            let list = it.next();
-            let index = it.next();
-            let value = it.next();
-            let allow_dup = it.next();
+            let list = args.first();
+            let index = args.get(1);
+            let value = args.get(2);
+            let allow_dup = args.get(3);
 
             match list {
                 Some(Value::Null) => Ok(Value::Null),
                 Some(Value::List(vs)) => {
-                    let Some(Value::Int(idx)) = index else { return Ok(Value::Null) };
+                    let Some(&Value::Int(idx)) = index else { return Ok(Value::Null) };
                     let val = match value {
-                        Some(Value::Null) | None => return Ok(Value::List(vs)),
-                        Some(v) => v,
+                        Some(Value::Null) | None => return Ok(Value::List(Arc::clone(vs))),
+                        Some(v) => v.clone(),
                     };
                     let allow_dup = match allow_dup {
-                        Some(Value::Bool(b)) => b,
+                        Some(&Value::Bool(b)) => b,
                         None => true,
                         _ => return Ok(Value::Null),
                     };
@@ -244,10 +242,10 @@ pub fn register(funcs: &mut Functions) {
                     let normalized = if idx < 0 { len + idx + 1 } else { idx };
                     // Out of range: return original
                     if normalized < 0 || normalized > len {
-                        return Ok(Value::List(vs));
+                        return Ok(Value::List(Arc::clone(vs)));
                     }
                     if !allow_dup && vs.contains(&val) {
-                        return Ok(Value::List(vs));
+                        return Ok(Value::List(Arc::clone(vs)));
                     }
                     let pos = normalized as usize;
                     let mut result = ThinVec::with_capacity(vs.len() + 1);
@@ -272,30 +270,29 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn list_insert_list_elements(_, args) {
-            let mut it = args.into_iter();
-            let list = it.next();
-            let list2 = it.next();
-            let index = it.next();
-            let allow_dup = it.next();
+            let list = args.first();
+            let list2 = args.get(1);
+            let index = args.get(2);
+            let allow_dup = args.get(3);
 
             match list {
                 Some(Value::Null) => Ok(Value::Null),
                 Some(Value::List(vs)) => {
                     let vals = match list2 {
-                        Some(Value::Null) | None => return Ok(Value::List(vs)),
+                        Some(Value::Null) | None => return Ok(Value::List(Arc::clone(vs))),
                         Some(Value::List(v)) => v,
                         _ => unreachable!(),
                     };
-                    let Some(Value::Int(idx)) = index else { return Ok(Value::Null) };
+                    let Some(&Value::Int(idx)) = index else { return Ok(Value::Null) };
                     let allow_dup = match allow_dup {
-                        Some(Value::Bool(b)) => b,
+                        Some(&Value::Bool(b)) => b,
                         None => true,
                         _ => return Ok(Value::Null),
                     };
                     let len = vs.len() as i64;
                     let normalized = if idx < 0 { len + idx + 1 } else { idx };
                     if normalized < 0 || normalized > len {
-                        return Ok(Value::List(vs));
+                        return Ok(Value::List(Arc::clone(vs)));
                     }
                     let pos = normalized as usize;
                     // Filter for duplicates if needed
@@ -329,9 +326,9 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn list_dedup(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Null) => Ok(Value::Null),
-                Some(Value::List(vs)) => {
+            match &args[0] {
+                Value::Null => Ok(Value::Null),
+                Value::List(vs) => {
                     let mut seen = ThinVec::<Value>::new();
                     for v in vs.iter() {
                         if !seen.contains(v) {

--- a/graph/src/runtime/functions/math.rs
+++ b/graph/src/runtime/functions/math.rs
@@ -37,20 +37,20 @@ use super::{FnType, Functions, Type};
 use crate::runtime::{runtime::Runtime, value::Value};
 use rand::RngExt;
 use std::sync::Arc;
-use thin_vec::{ThinVec, thin_vec};
+use thin_vec::thin_vec;
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "abs",
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Float, Type::Null]),
         fn abs(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => n
+            match &args[0] {
+                Value::Int(n) => n
                     .checked_abs()
                     .map(Value::Int)
                     .ok_or_else(|| String::from("ArgumentError: integer overflow in abs()")),
-                Some(Value::Float(f)) => Ok(Value::Float(f.abs())),
-                Some(Value::Null) => Ok(Value::Null),
+                Value::Float(f) => Ok(Value::Float(f.abs())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -61,10 +61,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Float, Type::Null]),
         fn ceil(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Int(n)),
-                Some(Value::Float(f)) => Ok(Value::Float(f.ceil())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Int(*n)),
+                Value::Float(f) => Ok(Value::Float(f.ceil())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -75,11 +75,8 @@ pub fn register(funcs: &mut Functions) {
         args: [],
         ret: Type::Float,
         fn e(_, args) {
-            match args.into_iter().next() {
-                None => Ok(Value::Float(std::f64::consts::E)),
-
-                _ => unreachable!(),
-            }
+            debug_assert!(args.is_empty());
+            Ok(Value::Float(std::f64::consts::E))
         }
     );
 
@@ -87,10 +84,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn exp(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Float((n as f64).exp())),
-                Some(Value::Float(f)) => Ok(Value::Float(f.exp())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Float((*n as f64).exp())),
+                Value::Float(f) => Ok(Value::Float(f.exp())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -101,10 +98,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Float, Type::Null]),
         fn floor(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Int(n)),
-                Some(Value::Float(f)) => Ok(Value::Float(f.floor())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Int(*n)),
+                Value::Float(f) => Ok(Value::Float(f.floor())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -115,10 +112,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn log(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Float((n as f64).ln())),
-                Some(Value::Float(f)) => Ok(Value::Float(f.ln())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Float((*n as f64).ln())),
+                Value::Float(f) => Ok(Value::Float(f.ln())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -129,10 +126,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn log10(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Float((n as f64).log10())),
-                Some(Value::Float(f)) => Ok(Value::Float(f.log10())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Float((*n as f64).log10())),
+                Value::Float(f) => Ok(Value::Float(f.log10())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -177,11 +174,7 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn pow(_, args) {
-            let mut iter = args.into_iter();
-            match (iter.next(), iter.next()) {
-                (Some(a), Some(b)) => Ok(apply_pow(a, b)),
-                _ => unreachable!(),
-            }
+            Ok(apply_pow(args[0].clone(), args[1].clone()))
         }
     );
 
@@ -201,10 +194,10 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Float, Type::Null]),
         fn round(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Int(n)),
-                Some(Value::Float(f)) => Ok(Value::Float(f.round())),
-                Some(Value::Null) => Ok(Value::Null),
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Int(*n)),
+                Value::Float(f) => Ok(Value::Float(f.round())),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -215,14 +208,14 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Int, Type::Null]),
         fn sign(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => Ok(Value::Int(n.signum())),
-                Some(Value::Float(f)) => Ok(if f == 0.0 {
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Int(n.signum())),
+                Value::Float(f) => Ok(if *f == 0.0 {
                     Value::Int(0)
                 } else {
                     Value::Float(f.signum().round())
                 }),
-                Some(Value::Null) => Ok(Value::Null),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -233,22 +226,22 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Int, Type::Float, Type::Null])],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn sqrt(_, args) {
-            match args.into_iter().next() {
-                Some(Value::Int(n)) => {
-                    if n < 0 {
+            match &args[0] {
+                Value::Int(n) => {
+                    if *n < 0 {
                         Ok(Value::Float(f64::NAN))
                     } else {
-                        Ok(Value::Float((n as f64).sqrt()))
+                        Ok(Value::Float((*n as f64).sqrt()))
                     }
                 }
-                Some(Value::Float(f)) => {
-                    if f >= 0f64 {
+                Value::Float(f) => {
+                    if *f >= 0f64 {
                         Ok(Value::Float(f.sqrt()))
                     } else {
                         Ok(Value::Float(f64::NAN))
                     }
                 }
-                Some(Value::Null) => Ok(Value::Null),
+                Value::Null => Ok(Value::Null),
 
                 _ => unreachable!(),
             }
@@ -259,12 +252,18 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Int, Type::Int, Type::Optional(Box::new(Type::Int))],
         ret: Type::Union(vec![Type::List(Box::new(Type::Int)), Type::Null]),
         fn range(_, args) {
-            let mut iter = args.into_iter();
-            let start = iter.next().ok_or("Missing start value")?;
-            let end = iter.next().ok_or("Missing end value")?;
-            let step = iter.next().unwrap_or_else(|| Value::Int(1));
+            let start = &args[0];
+            let end = &args[1];
+            let step_owned;
+            let step = if args.len() > 2 {
+                &args[2]
+            } else {
+                step_owned = Value::Int(1);
+                &step_owned
+            };
             match (start, end, step) {
                 (Value::Int(start), Value::Int(end), Value::Int(step)) => {
+                    let (start, end, step) = (*start, *end, *step);
                     if step == 0 {
                         return Err(String::from(
                             "ArgumentError: step argument to range() can't be 0",
@@ -316,12 +315,11 @@ pub fn register(funcs: &mut Functions) {
         var_arg: Type::Any,
         ret: Type::Any,
         fn coalesce(_, args) {
-            let iter = args.into_iter();
-            for arg in iter {
-                if arg == Value::Null {
+            for arg in args.iter() {
+                if *arg == Value::Null {
                     continue;
                 }
-                return Ok(arg);
+                return Ok(arg.clone());
             }
             Ok(Value::Null)
         }

--- a/graph/src/runtime/functions/mod.rs
+++ b/graph/src/runtime/functions/mod.rs
@@ -589,8 +589,15 @@ pub struct GraphFn {
     /// Optional pure form of the function: when set, the optimizer's
     /// constant-folding pass invokes this directly with concrete arguments
     /// without needing a [`Runtime`]. Used for Map/String constructor forms
-    /// (e.g. `date('2020-01-01')`).
+    /// (e.g. `date('2020-01-01')`). The binder only invokes `pure_fn` when
+    /// the arguments match `pure_args_type` — this matters because
+    /// constructor functions are registered with a loose `var_arg` signature
+    /// to accept zero-arg "now"-style invocations, while `pure_fn` only
+    /// handles the single-argument constructor shape.
     pub pure_fn: Option<fn(&[Value]) -> Result<Value, String>>,
+    /// Argument types `pure_fn` accepts (positional, one entry per arg).
+    /// Empty when `pure_fn` is `None`.
+    pub pure_args_type: Vec<Type>,
     /// Optional positional-slot form used by the binder's struct-constructor
     /// rewrite: a call like `duration({months: i})` is rewritten into 7
     /// positional children, which eval.rs evaluates into a stack-allocated
@@ -641,6 +648,7 @@ impl GraphFn {
             write,
             non_deterministic,
             pure_fn: None,
+            pure_args_type: Vec::new(),
             struct_fn: None,
             struct_slots: &[],
             args_type,
@@ -658,6 +666,7 @@ impl GraphFn {
             write: false,
             non_deterministic: false,
             pure_fn: None,
+            pure_args_type: Vec::new(),
             struct_fn: None,
             struct_slots: &[],
             args_type: FnArguments::VarLength(Type::Any),
@@ -833,11 +842,13 @@ impl Functions {
     }
 
     /// Attach a pure form of a previously registered function. The binder's
-    /// constant-folding pass invokes `pure_fn` when all arguments are constants.
+    /// constant-folding pass invokes `pure_fn` when all arguments are
+    /// constants and match `args_type` positionally.
     pub fn set_pure_fn(
         &mut self,
         name: &str,
         pure_fn: fn(&[Value]) -> Result<Value, String>,
+        args_type: Vec<Type>,
     ) {
         let lower = name.to_lowercase();
         let existing = self
@@ -847,6 +858,7 @@ impl Functions {
         let inner =
             Arc::get_mut(existing).expect("function Arc must be unique at registration time");
         inner.pure_fn = Some(pure_fn);
+        inner.pure_args_type = args_type;
     }
 
     /// Attach a positional-slot constructor to a previously registered

--- a/graph/src/runtime/functions/mod.rs
+++ b/graph/src/runtime/functions/mod.rs
@@ -83,7 +83,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -109,7 +109,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -134,7 +134,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -159,7 +159,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -186,7 +186,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -218,7 +218,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -248,7 +248,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -274,7 +274,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -300,7 +300,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -326,7 +326,7 @@ macro_rules! cypher_fn {
         $(#[$attr])*
         fn $fn_name(
             $rt: &Runtime,
-            $args: ThinVec<Value>,
+            $args: &[Value],
         ) -> Result<Value, String>
         $body
 
@@ -351,7 +351,7 @@ mod list;
 mod math;
 mod path;
 mod procedures;
-mod spatial;
+pub mod spatial;
 mod string;
 pub mod temporal;
 mod trig;
@@ -372,10 +372,30 @@ use std::{
         atomic::{AtomicU64, Ordering},
     },
 };
-use thin_vec::ThinVec;
 
 /// Function type for runtime function implementations.
-type RuntimeFn = Arc<dyn Fn(&Runtime, ThinVec<Value>) -> Result<Value, String> + Send + Sync>;
+///
+/// Two variants because UDFs need a captured name (closure-shaped) while
+/// native functions are plain `fn` pointers. An enum avoids the
+/// `Arc<dyn Fn>` indirection and vtable dispatch on the hot path.
+pub enum RuntimeFn {
+    Native(fn(&Runtime, &[Value]) -> Result<Value, String>),
+    Udf(String),
+}
+
+impl RuntimeFn {
+    #[inline]
+    pub fn call(
+        &self,
+        rt: &Runtime,
+        args: &[Value],
+    ) -> Result<Value, String> {
+        match self {
+            Self::Native(f) => f(rt, args),
+            Self::Udf(name) => crate::udf::js_context::call_udf_bridge(name, rt, args),
+        }
+    }
+}
 
 /// Optional bulk-aggregation entry point. Receives the column of input
 /// values for one batch (`inputs`), the number of rows being aggregated
@@ -566,6 +586,23 @@ pub struct GraphFn {
     pub func: RuntimeFn,
     pub write: bool,
     pub non_deterministic: bool,
+    /// Optional pure form of the function: when set, the optimizer's
+    /// constant-folding pass invokes this directly with concrete arguments
+    /// without needing a [`Runtime`]. Used for Map/String constructor forms
+    /// (e.g. `date('2020-01-01')`).
+    pub pure_fn: Option<fn(&[Value]) -> Result<Value, String>>,
+    /// Optional positional-slot form used by the binder's struct-constructor
+    /// rewrite: a call like `duration({months: i})` is rewritten into 7
+    /// positional children, which eval.rs evaluates into a stack-allocated
+    /// `[Value; 10]` array and dispatches here — bypassing the
+    /// `ThinVec<Value>` heap alloc, `validate_args_type` walk, and the
+    /// `RuntimeFn` dispatch hop used by the general `func` path. Only
+    /// invoked when `num_children > 1`.
+    pub struct_fn: Option<fn(&[Value]) -> Result<Value, String>>,
+    /// Slot names that drive the binder rewrite — the order matches the
+    /// positional children produced for `struct_fn`. Set in lockstep with
+    /// `struct_fn`; both `Some` or both `None`.
+    pub struct_slots: &'static [&'static str],
     pub args_type: FnArguments,
     pub fn_type: FnType,
     pub ret_type: Type,
@@ -591,7 +628,7 @@ impl GraphFn {
     #[must_use]
     pub fn new(
         name: &str,
-        func: fn(&Runtime, ThinVec<Value>) -> Result<Value, String>,
+        func: fn(&Runtime, &[Value]) -> Result<Value, String>,
         write: bool,
         non_deterministic: bool,
         args_type: FnArguments,
@@ -600,9 +637,12 @@ impl GraphFn {
     ) -> Self {
         Self {
             name: String::from(name),
-            func: Arc::new(func),
+            func: RuntimeFn::Native(func),
             write,
             non_deterministic,
+            pure_fn: None,
+            struct_fn: None,
+            struct_slots: &[],
             args_type,
             fn_type,
             ret_type,
@@ -614,11 +654,12 @@ impl GraphFn {
         let udf_name = name.to_string();
         Self {
             name: String::from(name),
-            func: Arc::new(move |rt, args| {
-                crate::udf::js_context::call_udf_bridge(&udf_name, rt, &args)
-            }),
+            func: RuntimeFn::Udf(udf_name),
             write: false,
             non_deterministic: false,
+            pure_fn: None,
+            struct_fn: None,
+            struct_slots: &[],
             args_type: FnArguments::VarLength(Type::Any),
             fn_type: FnType::Udf,
             ret_type: Type::Any,
@@ -739,7 +780,7 @@ impl Functions {
     pub fn add(
         &mut self,
         name: &str,
-        func: fn(&Runtime, ThinVec<Value>) -> Result<Value, String>,
+        func: fn(&Runtime, &[Value]) -> Result<Value, String>,
         write: bool,
         non_deterministic: bool,
         args_type: Vec<Type>,
@@ -767,7 +808,7 @@ impl Functions {
     pub fn add_var_len(
         &mut self,
         name: &str,
-        func: fn(&Runtime, ThinVec<Value>) -> Result<Value, String>,
+        func: fn(&Runtime, &[Value]) -> Result<Value, String>,
         write: bool,
         non_deterministic: bool,
         arg_type: Type,
@@ -789,6 +830,45 @@ impl Functions {
             ret_type,
         ));
         self.functions.insert(name, graph_fn);
+    }
+
+    /// Attach a pure form of a previously registered function. The binder's
+    /// constant-folding pass invokes `pure_fn` when all arguments are constants.
+    pub fn set_pure_fn(
+        &mut self,
+        name: &str,
+        pure_fn: fn(&[Value]) -> Result<Value, String>,
+    ) {
+        let lower = name.to_lowercase();
+        let existing = self
+            .functions
+            .get_mut(&lower)
+            .unwrap_or_else(|| panic!("Function '{name}' not registered"));
+        let inner =
+            Arc::get_mut(existing).expect("function Arc must be unique at registration time");
+        inner.pure_fn = Some(pure_fn);
+    }
+
+    /// Attach a positional-slot constructor to a previously registered
+    /// function. The binder rewrites Map-keyed constructor calls like
+    /// `duration({months: i})` into positional children using `slots` for
+    /// the slot order, and eval.rs dispatches them through `struct_fn` via
+    /// a stack `[Value; 10]` array.
+    pub fn set_struct_fn(
+        &mut self,
+        name: &str,
+        struct_fn: fn(&[Value]) -> Result<Value, String>,
+        slots: &'static [&'static str],
+    ) {
+        let lower = name.to_lowercase();
+        let existing = self
+            .functions
+            .get_mut(&lower)
+            .unwrap_or_else(|| panic!("Function '{name}' not registered"));
+        let inner =
+            Arc::get_mut(existing).expect("function Arc must be unique at registration time");
+        inner.struct_fn = Some(struct_fn);
+        inner.struct_slots = slots;
     }
 
     pub fn get(

--- a/graph/src/runtime/functions/path.rs
+++ b/graph/src/runtime/functions/path.rs
@@ -21,15 +21,13 @@
 use super::{FnType, Functions, Type};
 use crate::runtime::{runtime::Runtime, value::Value};
 use std::sync::Arc;
-use thin_vec::ThinVec;
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "nodes",
         args: [Type::Union(vec![Type::Path, Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Node)), Type::Null]),
         fn nodes(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Path(values)) => Ok(Value::List(Arc::new(
                     values
                         .iter()
@@ -52,8 +50,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Path, Type::Null])],
         ret: Type::Union(vec![Type::List(Box::new(Type::Relationship)), Type::Null]),
         fn relationships(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::Path(values)) => Ok(Value::List(Arc::new(
                     values
                         .iter()

--- a/graph/src/runtime/functions/spatial.rs
+++ b/graph/src/runtime/functions/spatial.rs
@@ -31,7 +31,38 @@ use crate::runtime::{
     vec_distance,
 };
 use std::sync::Arc;
-use thin_vec::ThinVec;
+
+/// Slot order: [latitude, longitude]
+const POINT_SLOTS: &[&str] = &["latitude", "longitude"];
+
+pub fn point_struct_pure(args: &[Value]) -> Result<Value, String> {
+    debug_assert_eq!(args.len(), 2);
+    let latitude = match &args[0] {
+        Value::Float(f) => *f as f32,
+        Value::Int(i) => *i as f32,
+        Value::Null => return Err(String::from("point() requires 'latitude' field")),
+        other => {
+            return Err(format!(
+                "Type mismatch: 'latitude' must be a number, got {}",
+                other.name()
+            ));
+        }
+    };
+    let longitude = match &args[1] {
+        Value::Float(f) => *f as f32,
+        Value::Int(i) => *i as f32,
+        Value::Null => return Err(String::from("point() requires 'longitude' field")),
+        other => {
+            return Err(format!(
+                "Type mismatch: 'longitude' must be a number, got {}",
+                other.name()
+            ));
+        }
+    };
+    let point = Point::new(latitude, longitude);
+    point.validate()?;
+    Ok(Value::Point(point))
+}
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "vecf32",
@@ -41,8 +72,7 @@ pub fn register(funcs: &mut Functions) {
         ])],
         ret: Type::Union(vec![Type::VecF32, Type::Null]),
         fn vecf32(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
+            match args.first() {
                 Some(Value::List(vec)) => {
                     for v in vec.iter() {
                         if !matches!(v, Value::Int(_) | Value::Float(_)) {
@@ -137,7 +167,7 @@ pub fn register(funcs: &mut Functions) {
                     // SIMD path delegates to `simsimd` (AVX-512 / AVX2 /
                     // NEON / scalar runtime dispatch). `None` only on
                     // length mismatch, ruled out above.
-                    Ok(Value::Float(vec_distance::euclidean(&a, &b).unwrap_or(0.0)))
+                    Ok(Value::Float(vec_distance::euclidean(a.as_slice(), b.as_slice()).unwrap_or(0.0)))
                 }
                 (Some(Value::Null), _) | (_, Some(Value::Null)) => Ok(Value::Null),
                 _ => unreachable!(),
@@ -164,11 +194,13 @@ pub fn register(funcs: &mut Functions) {
                             a.len(), b.len()
                         ));
                     }
-                    Ok(Value::Float(vec_distance::cosine(&a, &b).unwrap_or(1.0)))
+                    Ok(Value::Float(vec_distance::cosine(a.as_slice(), b.as_slice()).unwrap_or(1.0)))
                 }
                 (Some(Value::Null), _) | (_, Some(Value::Null)) => Ok(Value::Null),
                 _ => unreachable!(),
             }
         }
     );
+
+    funcs.set_struct_fn("point", point_struct_pure, POINT_SLOTS);
 }

--- a/graph/src/runtime/functions/string.rs
+++ b/graph/src/runtime/functions/string.rs
@@ -30,7 +30,7 @@
 use super::{FnType, Functions, Type};
 use crate::runtime::{runtime::Runtime, string_pool, value::Value};
 use std::sync::Arc;
-use thin_vec::{ThinVec, thin_vec};
+use thin_vec::thin_vec;
 
 pub fn register(funcs: &mut Functions) {
     cypher_fn!(funcs, "intern",
@@ -38,9 +38,9 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::String, Type::Null]),
         non_deterministic,
         fn intern(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => {
-                    Ok(Value::String(string_pool::global().intern(s)))
+                    Ok(Value::String(string_pool::global().intern(Arc::clone(s))))
                 }
                 Some(Value::Null) => Ok(Value::Null),
                 _ => unreachable!(),
@@ -56,12 +56,12 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn substring(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next(), iter.next()) {
                 // Handle NULL input case
                 (Some(Value::Null), _, _) => Ok(Value::Null),
                 // Two-argument version: (string, start)
-                (Some(Value::String(s)), Some(Value::Int(start)), None) => {
+                (Some(Value::String(s)), Some(&Value::Int(start)), None) => {
                     if start < 0 {
                         return Err("start must be a non-negative integer".into());
                     }
@@ -74,7 +74,7 @@ pub fn register(funcs: &mut Functions) {
                 }
 
                 // Three-argument version: (string, start, length)
-                (Some(Value::String(s)), Some(Value::Int(start)), Some(Value::Int(length))) => {
+                (Some(Value::String(s)), Some(&Value::Int(start)), Some(&Value::Int(length))) => {
                     if start < 0 {
                         return Err("start must be a non-negative integer".into());
                     }
@@ -107,7 +107,7 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::String)), Type::Null]),
         fn split(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(string)), Some(Value::String(delimiter))) => {
                     if string.is_empty() {
@@ -140,7 +140,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_to_lower(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => {
                     // Match C behavior: detect replacement character which indicates invalid UTF-8
                     // In the C version, str_tolower returns NULL on invalid UTF-8 (c == -1)
@@ -162,7 +162,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_to_upper(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => {
                     // Match C behavior: detect replacement character which indicates invalid UTF-8
                     // In the C version, str_toupper returns NULL on invalid UTF-8 (c == -1)
@@ -188,7 +188,7 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_replace(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next(), iter.next()) {
                 (Some(Value::String(s)), Some(Value::String(search)), Some(Value::String(replacement))) => {
                     Ok(Value::String(Arc::new(
@@ -211,9 +211,9 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_left(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
-                (Some(Value::String(s)), Some(Value::Int(n))) => {
+                (Some(Value::String(s)), Some(&Value::Int(n))) => {
                     if n < 0 {
                         Err(String::from("length must be a non-negative integer"))
                     } else {
@@ -234,7 +234,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_ltrim(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => Ok(Value::String(Arc::new(String::from(
                     s.trim_start_matches(' '),
                 )))),
@@ -249,7 +249,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_rtrim(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => Ok(Value::String(Arc::new(String::from(
                     s.trim_end_matches(' '),
                 )))),
@@ -264,7 +264,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::String, Type::Null])],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_trim(_runtime, args) {
-            match args.into_iter().next() {
+            match args.first() {
                 Some(Value::String(s)) => Ok(Value::String(Arc::new(String::from(s.trim_matches(' '))))),
                 Some(Value::Null) => Ok(Value::Null),
 
@@ -280,9 +280,9 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_right(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
-                (Some(Value::String(s)), Some(Value::Int(n))) => {
+                (Some(Value::String(s)), Some(&Value::Int(n))) => {
                     if n < 0 {
                         Err(String::from("length must be a non-negative integer"))
                     } else {
@@ -385,19 +385,19 @@ pub fn register(funcs: &mut Functions) {
                 result
             }
 
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
 
             let first = iter.next().unwrap();
 
             match (first, iter.next()) {
                 (Value::List(vec), Some(Value::String(s))) => {
-                    let strings = to_string_vec(&vec)?;
+                    let strings = to_string_vec(vec)?;
                     let size = compute_join_length(&strings, s.as_str())?;
                     let joined = join_with_preallocate(&strings, s.as_str(), size);
                     Ok(Value::String(Arc::new(joined)))
                 }
                 (Value::List(vec), None) => {
-                    let strings = to_string_vec(&vec)?;
+                    let strings = to_string_vec(vec)?;
                     let size = compute_join_length(&strings, "")?;
                     let joined = join_with_preallocate(&strings, "", size);
                     Ok(Value::String(Arc::new(joined)))
@@ -415,7 +415,7 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::List(Box::new(Type::Any)), Type::Null]),
         fn string_match_reg_ex(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             match (iter.next(), iter.next()) {
                 (Some(Value::String(text)), Some(Value::String(pattern))) => {
                     match regex::Regex::new(pattern.as_str()) {
@@ -457,7 +457,7 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::String, Type::Null]),
         fn string_replace_reg_ex(_runtime, args) {
-            let mut iter = args.into_iter();
+            let mut iter = args.iter();
             let text = iter.next();
             let pattern = iter.next();
             let replacement = iter.next(); // May be None (optional third argument)

--- a/graph/src/runtime/functions/temporal.rs
+++ b/graph/src/runtime/functions/temporal.rs
@@ -44,9 +44,8 @@
 
 use super::{FnType, Functions, Type};
 use crate::runtime::{ordermap::OrderMap, runtime::Runtime, value::Value};
-use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::sync::Arc;
-use thin_vec::ThinVec;
 
 fn get_int_field(
     map: &OrderMap<Arc<String>, Value>,
@@ -59,32 +58,36 @@ fn get_int_field(
     })
 }
 
-// Build a NaiveDate from map components: supports year/month/day, week, quarter modes.
-fn date_from_map(map: &OrderMap<Arc<String>, Value>) -> Result<NaiveDate, String> {
-    let year = get_int_field(map, "year").unwrap_or(1970) as i32;
+/// Build a NaiveDate from optional components. Supports ymd, week, and quarter modes.
+fn date_from_components(
+    year: Option<i64>,
+    month: Option<i64>,
+    day: Option<i64>,
+    week: Option<i64>,
+    day_of_week: Option<i64>,
+    quarter: Option<i64>,
+    day_of_quarter: Option<i64>,
+) -> Result<NaiveDate, String> {
+    let year = year.unwrap_or(1970) as i32;
 
-    if let Some(week) = get_int_field(map, "week") {
-        let dow_raw = get_int_field(map, "dayOfWeek").unwrap_or(1);
+    if let Some(week) = week {
+        let dow_raw = day_of_week.unwrap_or(1);
         if !(0..=6).contains(&dow_raw) {
             return Err(format!("Invalid dayOfWeek: {dow_raw}, expected 0..6"));
         }
         let dow = dow_raw as u32;
-        // Find Monday of ISO week 1 for the given year
         let jan4 =
             NaiveDate::from_ymd_opt(year, 1, 4).ok_or_else(|| format!("Invalid year: {year}"))?;
-        let weekday_of_jan4 = jan4.weekday().num_days_from_monday(); // Mon=0..Sun=6
+        let weekday_of_jan4 = jan4.weekday().num_days_from_monday();
         let iso_week1_monday = jan4 - chrono::Duration::days(i64::from(weekday_of_jan4));
-        // Add (week-1)*7 days to get to target week Monday
         let target_monday = iso_week1_monday + chrono::Duration::days((week - 1) * 7);
-        // Add dayOfWeek offset: dow 0=Sun,1=Mon,...,6=Sat
-        // Monday is already our base, so offset from Monday
         let day_offset = if dow == 0 { 6 } else { i64::from(dow) - 1 };
         let result = target_monday + chrono::Duration::days(day_offset);
         return Ok(result);
     }
 
-    if let Some(quarter) = get_int_field(map, "quarter") {
-        let doq = get_int_field(map, "dayOfQuarter").unwrap_or(1);
+    if let Some(quarter) = quarter {
+        let doq = day_of_quarter.unwrap_or(1);
         let quarter_start_month = ((quarter - 1) * 3 + 1) as u32;
         let base = NaiveDate::from_ymd_opt(year, quarter_start_month, 1)
             .ok_or_else(|| format!("Invalid quarter: year={year}, quarter={quarter}"))?;
@@ -93,18 +96,52 @@ fn date_from_map(map: &OrderMap<Arc<String>, Value>) -> Result<NaiveDate, String
             .ok_or_else(|| format!("Invalid dayOfQuarter: {doq}"));
     }
 
-    let month = get_int_field(map, "month").unwrap_or(1) as u32;
-    let day = get_int_field(map, "day").unwrap_or(1) as u32;
+    let month = month.unwrap_or(1) as u32;
+    let day = day.unwrap_or(1) as u32;
     NaiveDate::from_ymd_opt(year, month, day)
         .ok_or_else(|| format!("Invalid date: year={year}, month={month}, day={day}"))
 }
 
-fn time_from_map(map: &OrderMap<Arc<String>, Value>) -> Result<NaiveTime, String> {
-    let hour = get_int_field(map, "hour").unwrap_or(0) as u32;
-    let minute = get_int_field(map, "minute").unwrap_or(0) as u32;
-    let second = get_int_field(map, "second").unwrap_or(0) as u32;
+fn date_from_map(map: &OrderMap<Arc<String>, Value>) -> Result<NaiveDate, String> {
+    date_from_components(
+        get_int_field(map, "year"),
+        get_int_field(map, "month"),
+        get_int_field(map, "day"),
+        get_int_field(map, "week"),
+        get_int_field(map, "dayOfWeek"),
+        get_int_field(map, "quarter"),
+        get_int_field(map, "dayOfQuarter"),
+    )
+}
+
+fn time_from_components(
+    hour: Option<i64>,
+    minute: Option<i64>,
+    second: Option<i64>,
+) -> Result<NaiveTime, String> {
+    let hour = hour.unwrap_or(0) as u32;
+    let minute = minute.unwrap_or(0) as u32;
+    let second = second.unwrap_or(0) as u32;
     NaiveTime::from_hms_opt(hour, minute, second)
         .ok_or_else(|| format!("Invalid time: hour={hour}, minute={minute}, second={second}"))
+}
+
+fn time_from_map(map: &OrderMap<Arc<String>, Value>) -> Result<NaiveTime, String> {
+    time_from_components(
+        get_int_field(map, "hour"),
+        get_int_field(map, "minute"),
+        get_int_field(map, "second"),
+    )
+}
+
+/// Extract i64 from positional slot arg (Int/Float/Null).
+#[inline]
+fn slot_to_int(v: &Value) -> Option<i64> {
+    match v {
+        Value::Int(i) => Some(*i),
+        Value::Float(f) => Some(*f as i64),
+        _ => None,
+    }
 }
 
 // Parse date from ISO string formats.
@@ -370,6 +407,23 @@ fn parse_duration_string(s: &str) -> Result<(i64, i64, i64, i64, i64, i64, i64),
     Ok((years, months, 0, days, hours, minutes, seconds))
 }
 
+/// Days from 1970-01-01 to the given (year, month, day) — Howard Hinnant's civil-from-days.
+/// Avoids chrono allocation/validation on the duration hot path.
+#[inline]
+fn days_from_civil(
+    y: i32,
+    m: u32,
+    d: u32,
+) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u32; // [0, 399]
+    let mp = if m > 2 { m - 3 } else { m + 9 }; // [0, 11]
+    let doy = (153 * mp + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era as i64 * 146097 + doe as i64 - 719468
+}
+
 /// Construct a duration i64 (seconds from epoch) from components.
 /// The encoding stores the target datetime = epoch + years/months + days + time.
 pub fn construct_duration_secs(
@@ -393,12 +447,8 @@ pub fn construct_duration_secs(
         .ok_or_else(|| format!("Duration out of range: years={years}, months={months}"))?;
     let base_month = (total_month_offset_i32.rem_euclid(12) + 1) as u32;
 
-    let anchor = NaiveDate::from_ymd_opt(base_year, base_month, 1)
-        .ok_or_else(|| format!("Invalid duration: years={years}, months={months}"))?
-        .and_hms_opt(0, 0, 0)
-        .ok_or("Invalid anchor time")?;
+    let anchor_ts = days_from_civil(base_year, base_month, 1) * 86400;
 
-    let anchor_ts = anchor.and_utc().timestamp();
     let extra = weeks
         .checked_mul(7)
         .and_then(|w| w.checked_add(days))
@@ -418,21 +468,214 @@ pub fn construct_duration_secs(
 
 /// Decompose a duration (seconds from epoch) into (years, months, remaining_seconds).
 pub fn decompose_duration(dur_secs: i64) -> Result<(i32, i32, i64), String> {
-    let dt = Utc
-        .timestamp_opt(dur_secs, 0)
-        .single()
-        .ok_or("Invalid duration timestamp")?;
+    let days = dur_secs.div_euclid(86400);
+    let time_of_day = dur_secs.rem_euclid(86400);
+    let (y, m, d) = crate::runtime::value::civil_from_days(days);
 
-    let year_diff = dt.year() - 1970;
-    let month_diff = dt.month() as i32 - 1;
+    let year_diff = y - 1970;
+    let month_diff = m as i32 - 1;
+    let remaining_secs = (d as i64 - 1) * 86400 + time_of_day;
 
-    let anchor = Utc
-        .with_ymd_and_hms(1970 + year_diff, (1 + month_diff) as u32, 1, 0, 0, 0)
-        .single()
-        .ok_or("Invalid duration anchor")?;
-
-    let remaining_secs = dur_secs - anchor.timestamp();
     Ok((year_diff, month_diff, remaining_secs))
+}
+
+// ---------------------------------------------------------------------------
+// Pure (Runtime-free) constructors used by the optimizer's constant-folding
+// pass. The Runtime-bound versions registered below delegate to these for the
+// non-zero-arg branch.
+// ---------------------------------------------------------------------------
+
+pub fn date_pure(args: &[Value]) -> Result<Value, String> {
+    match args.first() {
+        Some(Value::Map(map)) => {
+            let d = date_from_map(map)?;
+            let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+            Ok(Value::Date(ts))
+        }
+        Some(Value::String(s)) => {
+            let d = parse_date_string(s)?;
+            let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+            Ok(Value::Date(ts))
+        }
+        Some(Value::Null) => Ok(Value::Null),
+        _ => unreachable!(),
+    }
+}
+
+pub fn localtime_pure(args: &[Value]) -> Result<Value, String> {
+    match args.first() {
+        Some(Value::Map(map)) => {
+            let t = time_from_map(map)?;
+            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+            let dt = NaiveDateTime::new(epoch, t);
+            Ok(Value::Time(dt.and_utc().timestamp()))
+        }
+        Some(Value::String(s)) => {
+            let t = parse_time_string(s)?;
+            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+            let dt = NaiveDateTime::new(epoch, t);
+            Ok(Value::Time(dt.and_utc().timestamp()))
+        }
+        Some(Value::Null) => Ok(Value::Null),
+        _ => unreachable!(),
+    }
+}
+
+pub fn localdatetime_pure(args: &[Value]) -> Result<Value, String> {
+    match args.first() {
+        Some(Value::Map(map)) => {
+            let d = date_from_map(map)?;
+            let t = time_from_map(map)?;
+            let dt = NaiveDateTime::new(d, t);
+            Ok(Value::Datetime(dt.and_utc().timestamp()))
+        }
+        Some(Value::String(s)) => {
+            let dt = parse_datetime_string(s)?;
+            Ok(Value::Datetime(dt.and_utc().timestamp()))
+        }
+        Some(Value::Null) => Ok(Value::Null),
+        _ => unreachable!(),
+    }
+}
+
+pub fn duration_pure(args: &[Value]) -> Result<Value, String> {
+    match args.first() {
+        Some(Value::Map(map)) => {
+            let mut years = 0i64;
+            let mut months = 0i64;
+            let mut weeks = 0i64;
+            let mut days = 0i64;
+            let mut hours = 0i64;
+            let mut minutes = 0i64;
+            let mut seconds = 0i64;
+            for (k, v) in map.iter() {
+                let n = match v {
+                    Value::Int(i) => *i,
+                    Value::Float(f) => *f as i64,
+                    _ => continue,
+                };
+                match k.as_str() {
+                    "years" => years = n,
+                    "months" => months = n,
+                    "weeks" => weeks = n,
+                    "days" => days = n,
+                    "hours" => hours = n,
+                    "minutes" => minutes = n,
+                    "seconds" => seconds = n,
+                    _ => {}
+                }
+            }
+            let ts = construct_duration_secs(years, months, weeks, days, hours, minutes, seconds)?;
+            Ok(Value::Duration(ts))
+        }
+        Some(Value::String(s)) => {
+            let (years, months, weeks, days, hours, minutes, seconds) = parse_duration_string(s)?;
+            let ts = construct_duration_secs(years, months, weeks, days, hours, minutes, seconds)?;
+            Ok(Value::Duration(ts))
+        }
+        Some(Value::Null) => Ok(Value::Null),
+        _ => unreachable!(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Positional-slot constructors. The binder rewrites Map-literal calls with
+// constant string keys (e.g. `duration({months: i})`) into invocations of these
+// internal functions, avoiding per-row Map+Arc allocation. Slot order is
+// fixed per constructor; missing fields are passed as Value::Null.
+// ---------------------------------------------------------------------------
+
+/// Slot order: [years, months, weeks, days, hours, minutes, seconds]
+const DURATION_SLOTS: &[&str] = &[
+    "years", "months", "weeks", "days", "hours", "minutes", "seconds",
+];
+
+/// Slot order: [year, month, day, week, dayOfWeek, quarter, dayOfQuarter]
+const DATE_SLOTS: &[&str] = &[
+    "year",
+    "month",
+    "day",
+    "week",
+    "dayOfWeek",
+    "quarter",
+    "dayOfQuarter",
+];
+
+/// Slot order: [hour, minute, second]
+const LOCALTIME_SLOTS: &[&str] = &["hour", "minute", "second"];
+
+/// Slot order: [year, month, day, week, dayOfWeek, quarter, dayOfQuarter, hour, minute, second]
+const LOCALDATETIME_SLOTS: &[&str] = &[
+    "year",
+    "month",
+    "day",
+    "week",
+    "dayOfWeek",
+    "quarter",
+    "dayOfQuarter",
+    "hour",
+    "minute",
+    "second",
+];
+
+pub fn duration_struct_pure(args: &[Value]) -> Result<Value, String> {
+    debug_assert_eq!(args.len(), 7);
+    let years = slot_to_int(&args[0]).unwrap_or(0);
+    let months = slot_to_int(&args[1]).unwrap_or(0);
+    let weeks = slot_to_int(&args[2]).unwrap_or(0);
+    let days = slot_to_int(&args[3]).unwrap_or(0);
+    let hours = slot_to_int(&args[4]).unwrap_or(0);
+    let minutes = slot_to_int(&args[5]).unwrap_or(0);
+    let seconds = slot_to_int(&args[6]).unwrap_or(0);
+    let ts = construct_duration_secs(years, months, weeks, days, hours, minutes, seconds)?;
+    Ok(Value::Duration(ts))
+}
+
+pub fn date_struct_pure(args: &[Value]) -> Result<Value, String> {
+    debug_assert_eq!(args.len(), 7);
+    let d = date_from_components(
+        slot_to_int(&args[0]),
+        slot_to_int(&args[1]),
+        slot_to_int(&args[2]),
+        slot_to_int(&args[3]),
+        slot_to_int(&args[4]),
+        slot_to_int(&args[5]),
+        slot_to_int(&args[6]),
+    )?;
+    let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+    Ok(Value::Date(ts))
+}
+
+pub fn localtime_struct_pure(args: &[Value]) -> Result<Value, String> {
+    debug_assert_eq!(args.len(), 3);
+    let t = time_from_components(
+        slot_to_int(&args[0]),
+        slot_to_int(&args[1]),
+        slot_to_int(&args[2]),
+    )?;
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+    let dt = NaiveDateTime::new(epoch, t);
+    Ok(Value::Time(dt.and_utc().timestamp()))
+}
+
+pub fn localdatetime_struct_pure(args: &[Value]) -> Result<Value, String> {
+    debug_assert_eq!(args.len(), 10);
+    let d = date_from_components(
+        slot_to_int(&args[0]),
+        slot_to_int(&args[1]),
+        slot_to_int(&args[2]),
+        slot_to_int(&args[3]),
+        slot_to_int(&args[4]),
+        slot_to_int(&args[5]),
+        slot_to_int(&args[6]),
+    )?;
+    let t = time_from_components(
+        slot_to_int(&args[7]),
+        slot_to_int(&args[8]),
+        slot_to_int(&args[9]),
+    )?;
+    let dt = NaiveDateTime::new(d, t);
+    Ok(Value::Datetime(dt.and_utc().timestamp()))
 }
 
 pub fn register(funcs: &mut Functions) {
@@ -454,26 +697,13 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Date, Type::Null]),
         non_deterministic,
         fn date_fn(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Map(map)) => {
-                    let d = date_from_map(&map)?;
-                    let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
-                    Ok(Value::Date(ts))
-                }
-                Some(Value::String(s)) => {
-                    let d = parse_date_string(&s)?;
-                    let ts = d.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
-                    Ok(Value::Date(ts))
-                }
-                Some(Value::Null) => Ok(Value::Null),
-                None => {
-                    // Zero args: return current date
-                    let now = Utc::now().date_naive();
-                    let ts = now.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
-                    Ok(Value::Date(ts))
-                }
-                _ => unreachable!(),
+            if args.is_empty() {
+                // Zero args: return current date
+                let now = Utc::now().date_naive();
+                let ts = now.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp();
+                Ok(Value::Date(ts))
+            } else {
+                date_pure(args)
             }
         }
     );
@@ -484,33 +714,15 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Time, Type::Null]),
         non_deterministic,
         fn localtime_fn(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Map(map)) => {
-                    let t = time_from_map(&map)?;
-                    // Store as seconds from epoch (base date 1970-01-01)
-                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                    let dt = NaiveDateTime::new(epoch, t);
-                    let ts = dt.and_utc().timestamp();
-                    Ok(Value::Time(ts))
-                }
-                Some(Value::String(s)) => {
-                    let t = parse_time_string(&s)?;
-                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                    let dt = NaiveDateTime::new(epoch, t);
-                    let ts = dt.and_utc().timestamp();
-                    Ok(Value::Time(ts))
-                }
-                Some(Value::Null) => Ok(Value::Null),
-                None => {
-                    // Zero args: return current local time
-                    let now = Utc::now().time();
-                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-                    let dt = NaiveDateTime::new(epoch, now);
-                    let ts = dt.and_utc().timestamp();
-                    Ok(Value::Time(ts))
-                }
-                _ => unreachable!(),
+            if args.is_empty() {
+                // Zero args: return current local time
+                let now = Utc::now().time();
+                let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+                let dt = NaiveDateTime::new(epoch, now);
+                let ts = dt.and_utc().timestamp();
+                Ok(Value::Time(ts))
+            } else {
+                localtime_pure(args)
             }
         }
     );
@@ -521,28 +733,13 @@ pub fn register(funcs: &mut Functions) {
         ret: Type::Union(vec![Type::Datetime, Type::Null]),
         non_deterministic,
         fn localdatetime_fn(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Map(map)) => {
-                    let d = date_from_map(&map)?;
-                    let t = time_from_map(&map)?;
-                    let dt = NaiveDateTime::new(d, t);
-                    let ts = dt.and_utc().timestamp();
-                    Ok(Value::Datetime(ts))
-                }
-                Some(Value::String(s)) => {
-                    let dt = parse_datetime_string(&s)?;
-                    let ts = dt.and_utc().timestamp();
-                    Ok(Value::Datetime(ts))
-                }
-                Some(Value::Null) => Ok(Value::Null),
-                None => {
-                    // Zero args: return current local datetime
-                    let now = Utc::now().naive_utc();
-                    let ts = now.and_utc().timestamp();
-                    Ok(Value::Datetime(ts))
-                }
-                _ => unreachable!(),
+            if args.is_empty() {
+                // Zero args: return current local datetime
+                let now = Utc::now().naive_utc();
+                let ts = now.and_utc().timestamp();
+                Ok(Value::Datetime(ts))
+            } else {
+                localdatetime_pure(args)
             }
         }
     );
@@ -552,27 +749,7 @@ pub fn register(funcs: &mut Functions) {
         args: [Type::Union(vec![Type::Map, Type::String, Type::Null])],
         ret: Type::Union(vec![Type::Duration, Type::Null]),
         fn duration_fn(_, args) {
-            let mut iter = args.into_iter();
-            match iter.next() {
-                Some(Value::Map(map)) => {
-                    let years = get_int_field(&map, "years").unwrap_or(0);
-                    let months = get_int_field(&map, "months").unwrap_or(0);
-                    let weeks = get_int_field(&map, "weeks").unwrap_or(0);
-                    let days = get_int_field(&map, "days").unwrap_or(0);
-                    let hours = get_int_field(&map, "hours").unwrap_or(0);
-                    let minutes = get_int_field(&map, "minutes").unwrap_or(0);
-                    let seconds = get_int_field(&map, "seconds").unwrap_or(0);
-                    let ts = construct_duration_secs(years, months, weeks, days, hours, minutes, seconds)?;
-                    Ok(Value::Duration(ts))
-                }
-                Some(Value::String(s)) => {
-                    let (years, months, weeks, days, hours, minutes, seconds) = parse_duration_string(&s)?;
-                    let ts = construct_duration_secs(years, months, weeks, days, hours, minutes, seconds)?;
-                    Ok(Value::Duration(ts))
-                }
-                Some(Value::Null) => Ok(Value::Null),
-                _ => unreachable!(),
-            }
+            duration_pure(args)
         }
     );
 
@@ -613,4 +790,17 @@ pub fn register(funcs: &mut Functions) {
             Ok(Value::Datetime(ts))
         }
     );
+
+    // Mark temporal constructors as safe to constant-fold when called with
+    // concrete arguments, and attach the positional-slot form invoked by
+    // eval.rs after the binder rewrites `duration({months: i})` into
+    // positional children.
+    funcs.set_pure_fn("date", date_pure);
+    funcs.set_pure_fn("localtime", localtime_pure);
+    funcs.set_pure_fn("localdatetime", localdatetime_pure);
+    funcs.set_pure_fn("duration", duration_pure);
+    funcs.set_struct_fn("date", date_struct_pure, DATE_SLOTS);
+    funcs.set_struct_fn("localtime", localtime_struct_pure, LOCALTIME_SLOTS);
+    funcs.set_struct_fn("localdatetime", localdatetime_struct_pure, LOCALDATETIME_SLOTS);
+    funcs.set_struct_fn("duration", duration_struct_pure, DURATION_SLOTS);
 }

--- a/graph/src/runtime/functions/temporal.rs
+++ b/graph/src/runtime/functions/temporal.rs
@@ -795,12 +795,17 @@ pub fn register(funcs: &mut Functions) {
     // concrete arguments, and attach the positional-slot form invoked by
     // eval.rs after the binder rewrites `duration({months: i})` into
     // positional children.
-    funcs.set_pure_fn("date", date_pure);
-    funcs.set_pure_fn("localtime", localtime_pure);
-    funcs.set_pure_fn("localdatetime", localdatetime_pure);
-    funcs.set_pure_fn("duration", duration_pure);
+    let constructor_args = || vec![Type::Union(vec![Type::Map, Type::String, Type::Null])];
+    funcs.set_pure_fn("date", date_pure, constructor_args());
+    funcs.set_pure_fn("localtime", localtime_pure, constructor_args());
+    funcs.set_pure_fn("localdatetime", localdatetime_pure, constructor_args());
+    funcs.set_pure_fn("duration", duration_pure, constructor_args());
     funcs.set_struct_fn("date", date_struct_pure, DATE_SLOTS);
     funcs.set_struct_fn("localtime", localtime_struct_pure, LOCALTIME_SLOTS);
-    funcs.set_struct_fn("localdatetime", localdatetime_struct_pure, LOCALDATETIME_SLOTS);
+    funcs.set_struct_fn(
+        "localdatetime",
+        localdatetime_struct_pure,
+        LOCALDATETIME_SLOTS,
+    );
     funcs.set_struct_fn("duration", duration_struct_pure, DURATION_SLOTS);
 }

--- a/graph/src/runtime/functions/trig.rs
+++ b/graph/src/runtime/functions/trig.rs
@@ -26,17 +26,16 @@
 
 use super::{FnType, Functions, Type};
 use crate::runtime::{runtime::Runtime, value::Value};
-use thin_vec::ThinVec;
 
 /// Apply a unary `f64 -> f64` function to a single numeric-or-null argument.
 fn apply_unary_float(
-    args: ThinVec<Value>,
+    args: &[Value],
     f: fn(f64) -> f64,
 ) -> Result<Value, String> {
-    match args.into_iter().next() {
-        Some(Value::Int(n)) => Ok(Value::Float(f(n as f64))),
-        Some(Value::Float(v)) => Ok(Value::Float(f(v))),
-        Some(Value::Null) => Ok(Value::Null),
+    match &args[0] {
+        Value::Int(n) => Ok(Value::Float(f(*n as f64))),
+        Value::Float(v) => Ok(Value::Float(f(*v))),
+        Value::Null => Ok(Value::Null),
         _ => unreachable!("trig functions expect Int, Float, or Null"),
     }
 }
@@ -93,13 +92,12 @@ pub fn register(funcs: &mut Functions) {
         ],
         ret: Type::Union(vec![Type::Float, Type::Null]),
         fn atan2(_, args) {
-            let mut iter = args.into_iter();
-            match (iter.next(), iter.next()) {
-                (Some(Value::Int(y)), Some(Value::Int(x))) => Ok(Value::Float((y as f64).atan2(x as f64))),
-                (Some(Value::Float(y)), Some(Value::Float(x))) => Ok(Value::Float(y.atan2(x))),
-                (Some(Value::Int(y)), Some(Value::Float(x))) => Ok(Value::Float((y as f64).atan2(x))),
-                (Some(Value::Float(y)), Some(Value::Int(x))) => Ok(Value::Float(y.atan2(x as f64))),
-                (Some(Value::Null), Some(_)) | (Some(_), Some(Value::Null)) => Ok(Value::Null),
+            match (&args[0], &args[1]) {
+                (Value::Int(y), Value::Int(x)) => Ok(Value::Float((*y as f64).atan2(*x as f64))),
+                (Value::Float(y), Value::Float(x)) => Ok(Value::Float(y.atan2(*x))),
+                (Value::Int(y), Value::Float(x)) => Ok(Value::Float((*y as f64).atan2(*x))),
+                (Value::Float(y), Value::Int(x)) => Ok(Value::Float(y.atan2(*x as f64))),
+                (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
                 _ => unreachable!("atan2 expects two numeric-or-null arguments"),
             }
         }

--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -721,9 +721,22 @@ impl<'a> AggregateOp<'a> {
                     return Err(e);
                 }
 
-                args.push(prev_value);
-
-                let new_value = func.func.call(runtime, &args)?;
+                // Prefer batch_agg when registered: it takes the accumulator
+                // by owned `Value`, so functions like `collect` get a unique
+                // `Arc` and avoid an O(n^2) deep clone per row caused by the
+                // shared ref `args` would hold if we pushed `prev_value` and
+                // called `func.func.call(&args)`.
+                let new_value = if let FnType::Aggregation {
+                    batch_agg: Some(batch_fn),
+                    ..
+                } = &func.fn_type
+                {
+                    let inputs: &[Value] = if args.is_empty() { &[] } else { &args[..] };
+                    batch_fn(runtime, inputs, 1, prev_value)?
+                } else {
+                    args.push(prev_value);
+                    func.func.call(runtime, &args)?
+                };
                 acc.insert(key, new_value);
             }
             _ => {

--- a/graph/src/runtime/ops/aggregate.rs
+++ b/graph/src/runtime/ops/aggregate.rs
@@ -258,9 +258,12 @@ impl<'a> AggregateOp<'a> {
                         return None;
                     }
                 }
-                ExprIR::Bool(true) | ExprIR::Integer(_) | ExprIR::Float(_) | ExprIR::String(_)
-                    if func.name.eq_ignore_ascii_case("count") =>
-                {
+                ExprIR::Constant(
+                    Value::Bool(true)
+                    | Value::Int(_ | _)
+                    | Value::Float(_ | _)
+                    | Value::String(_ | _),
+                ) if func.name.eq_ignore_ascii_case("count") => {
                     // count(*) is represented as count(1) (or other non-null literal).
                     None
                 }
@@ -452,7 +455,7 @@ impl<'a> AggregateOp<'a> {
                         break;
                     }
 
-                    match (agg.func.func)(self.runtime, args) {
+                    match agg.func.func.call(self.runtime, &args) {
                         Ok(new_val) => acc.insert(&agg.acc_var, new_val),
                         Err(e) => {
                             errors.push(e);
@@ -624,13 +627,12 @@ impl<'a> AggregateOp<'a> {
             // Compute group hash for DISTINCT tracking.
             let agg_group_key = entry.0.hash_u64();
 
-            let mut curr = vars.clone_pooled(runtime.env_pool);
             for (_, tree) in agg {
                 if let Err(e) = Self::run_agg_expr(
                     runtime,
                     tree,
                     tree.root().idx(),
-                    &mut curr,
+                    vars,
                     &mut entry.1,
                     agg_group_key,
                 ) {
@@ -649,7 +651,7 @@ impl<'a> AggregateOp<'a> {
         runtime: &Runtime,
         ir: &DynTree<ExprIR<Variable>>,
         idx: NodeIdx<Dyn<ExprIR<Variable>>>,
-        curr: &mut Env<'a>,
+        curr: &Env<'a>,
         acc: &mut Env<'a>,
         agg_group_key: u64,
     ) -> Result<(), String> {
@@ -721,7 +723,7 @@ impl<'a> AggregateOp<'a> {
 
                 args.push(prev_value);
 
-                let new_value = (func.func)(runtime, args)?;
+                let new_value = func.func.call(runtime, &args)?;
                 acc.insert(key, new_value);
             }
             _ => {

--- a/graph/src/runtime/ops/procedure_call.rs
+++ b/graph/src/runtime/ops/procedure_call.rs
@@ -97,7 +97,7 @@ impl<'a> ProcedureCallOp<'a> {
                             })
                             .collect::<Result<ThinVec<_>, _>>()?;
                         self.func.validate_args_type(&args)?;
-                        let res = (self.func.func)(self.runtime, args)?;
+                        let res = self.func.func.call(self.runtime, &args)?;
                         match res {
                             Value::List(arr) => {
                                 for v in arr.iter() {

--- a/graph/src/runtime/ops/project.rs
+++ b/graph/src/runtime/ops/project.rs
@@ -198,14 +198,15 @@ impl<'a> ProjectOp<'a> {
                 );
                 return_vars.insert(name, res?);
             }
-            let mut vars = env.clone_pooled(self.runtime.env_pool);
             for (old_var, new_var) in self.copy_from_parent {
-                match vars.take(old_var) {
-                    Some(value) => return_vars.insert(new_var, value),
-                    None if vars.is_bound(old_var) => {
+                match env.get(old_var) {
+                    Some(value) if !matches!(value, Value::Null) => {
+                        return_vars.insert(new_var, value.clone());
+                    }
+                    _ if env.is_bound(old_var) => {
                         return_vars.insert(new_var, Value::Null);
                     }
-                    None => {}
+                    _ => {}
                 }
             }
             result_envs.push(return_vars);

--- a/graph/src/runtime/ops/remove.rs
+++ b/graph/src/runtime/ops/remove.rs
@@ -94,7 +94,7 @@ impl Runtime<'_> {
                         .child(1)
                         .children()
                         .filter_map(|c| match c.data() {
-                            ExprIR::String(label) => Some(label.clone()),
+                            ExprIR::Constant(Value::String(label)) => Some(label.clone()),
                             _ => None,
                         })
                         .collect::<OrderSet<_>>();

--- a/graph/src/runtime/pool.rs
+++ b/graph/src/runtime/pool.rs
@@ -17,11 +17,12 @@
 //!  Next acquire() pops from free_vecs instead of allocating.
 //! ```
 //!
-//! The pool uses `RefCell` for interior mutability, which is safe because
-//! each query runs on a single thread. A fresh pool is created per query
-//! in `graph_core.rs` / `record.rs`.
+//! The pool uses `UnsafeCell` for interior mutability. Each query runs on a
+//! single thread and `Pool` is `!Sync`, so there are no concurrent borrows;
+//! the `RefCell` runtime flag would just be dead overhead on a per-row hot
+//! path.
 
-use std::cell::RefCell;
+use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 
 /// Per-query object pool for `Vec<T>` buffers.
@@ -29,7 +30,11 @@ use std::ops::{Deref, DerefMut};
 /// Reuses previously allocated `Vec`s to amortise allocation cost
 /// across millions of clones in scan/traversal loops.
 pub struct Pool<T> {
-    free_vecs: RefCell<Vec<Vec<T>>>,
+    // SAFETY invariant: only one mutable reference exists at a time. Enforced
+    // by Pool being !Sync (UnsafeCell), each query owning its own Pool, and
+    // all access being scoped inside `acquire_raw` / `release` — neither
+    // re-enters the other.
+    free_vecs: UnsafeCell<Vec<Vec<T>>>,
 }
 
 impl<T> Default for Pool<T> {
@@ -42,30 +47,33 @@ impl<T> Pool<T> {
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            free_vecs: RefCell::new(Vec::new()),
+            free_vecs: UnsafeCell::new(Vec::new()),
         }
     }
 
     /// Acquire a raw `Vec<T>` from the pool (or allocate if empty).
     /// Prefer [`acquire`](Self::acquire) which returns a [`Pooled`] handle.
+    #[inline]
     pub(crate) fn acquire_raw(
         &self,
         capacity: usize,
     ) -> Vec<T> {
-        let mut free = self.free_vecs.borrow_mut();
-        free.pop().map_or_else(
-            || Vec::with_capacity(capacity),
-            |mut v| {
+        // SAFETY: see struct-level invariant.
+        let free = unsafe { &mut *self.free_vecs.get() };
+        match free.pop() {
+            Some(mut v) => {
                 v.clear();
                 if v.capacity() < capacity {
                     v.reserve(capacity - v.capacity());
                 }
                 v
-            },
-        )
+            }
+            None => Vec::with_capacity(capacity),
+        }
     }
 
     /// Acquire a [`Pooled`] handle that automatically returns the buffer on drop.
+    #[inline]
     pub fn acquire(
         &self,
         capacity: usize,
@@ -77,11 +85,14 @@ impl<T> Pool<T> {
     }
 
     /// Return a `Vec<T>` to the pool for later reuse.
+    #[inline]
     pub fn release(
         &self,
         v: Vec<T>,
     ) {
-        self.free_vecs.borrow_mut().push(v);
+        // SAFETY: see struct-level invariant.
+        let free = unsafe { &mut *self.free_vecs.get() };
+        free.push(v);
     }
 }
 
@@ -95,6 +106,7 @@ pub struct Pooled<'a, T> {
 }
 
 impl<T> Drop for Pooled<'_, T> {
+    #[inline]
     fn drop(&mut self) {
         let v = std::mem::take(&mut self.value);
         self.pool.release(v);

--- a/graph/src/runtime/value.rs
+++ b/graph/src/runtime/value.rs
@@ -31,7 +31,7 @@ use std::{
     cmp::Ordering,
     collections::HashSet,
     fmt::{self},
-    hash::{DefaultHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
     ops::{Add, Div, Mul, Rem, Sub},
     sync::Arc,
 };
@@ -219,9 +219,17 @@ impl Value {
 
     #[must_use]
     pub fn format_datetime(timestamp_secs: i64) -> String {
-        use chrono::{TimeZone, Utc};
+        use chrono::{Datelike, TimeZone, Timelike, Utc};
         match Utc.timestamp_opt(timestamp_secs, 0) {
-            chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
+            chrono::LocalResult::Single(dt) => format!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+                dt.year(),
+                dt.month(),
+                dt.day(),
+                dt.hour(),
+                dt.minute(),
+                dt.second()
+            ),
             _ => format!("<invalid timestamp: {timestamp_secs}>"),
         }
     }
@@ -229,19 +237,22 @@ impl Value {
     // Format date as ISO-8601: "2025-04-14"
     #[must_use]
     pub fn format_date(timestamp_secs: i64) -> String {
-        use chrono::{TimeZone, Utc};
-        match Utc.timestamp_opt(timestamp_secs, 0) {
-            chrono::LocalResult::Single(dt) => dt.format("%Y-%m-%d").to_string(),
-            _ => format!("<invalid timestamp: {timestamp_secs}>"),
-        }
+        let days = timestamp_secs.div_euclid(86400);
+        let (y, m, d) = civil_from_days(days);
+        let mut buf = [0u8; 10];
+        write_date_into(&mut buf, y, m, d);
+        // Safe: ASCII digits and '-'
+        unsafe { String::from_utf8_unchecked(buf.to_vec()) }
     }
 
     // Format time as ISO-8601: "06:08:21"
     #[must_use]
     pub fn format_time(timestamp_secs: i64) -> String {
-        use chrono::{TimeZone, Utc};
+        use chrono::{TimeZone, Timelike, Utc};
         match Utc.timestamp_opt(timestamp_secs, 0) {
-            chrono::LocalResult::Single(dt) => dt.format("%H:%M:%S").to_string(),
+            chrono::LocalResult::Single(dt) => {
+                format!("{:02}:{:02}:{:02}", dt.hour(), dt.minute(), dt.second())
+            }
             _ => format!("<invalid timestamp: {timestamp_secs}>"),
         }
     }
@@ -592,21 +603,19 @@ fn add_duration_to_timestamp(
     dur_secs: i64,
 ) -> Result<i64, String> {
     use crate::runtime::functions::temporal::decompose_duration;
-    use chrono::{Datelike, NaiveDate, TimeZone, Timelike, Utc};
 
     let (years, months, remaining_secs) = decompose_duration(dur_secs)?;
-    let dt = Utc
-        .timestamp_opt(ts, 0)
-        .single()
-        .ok_or("Invalid timestamp")?;
+    let days = ts.div_euclid(86400);
+    let time_of_day = ts.rem_euclid(86400);
+    let (y, m, d) = civil_from_days(days);
 
-    let new_year = dt.year() + years;
-    let new_month_raw = dt.month() as i32 + months;
+    let new_year = y + years;
+    let new_month_raw = m as i32 + months;
     let adj_year = new_year + (new_month_raw - 1).div_euclid(12);
     let adj_month = ((new_month_raw - 1).rem_euclid(12) + 1) as u32;
     let max_day = days_in_month(adj_year, adj_month);
-    let (final_year, final_month, final_day) = if dt.day() > max_day {
-        let overflow = dt.day() - max_day;
+    let (final_year, final_month, final_day) = if d > max_day {
+        let overflow = d - max_day;
         let nm = adj_month + 1;
         let (ny, nm) = if nm > 12 {
             (adj_year + 1, 1)
@@ -615,24 +624,11 @@ fn add_duration_to_timestamp(
         };
         (ny, nm, overflow)
     } else {
-        (adj_year, adj_month, dt.day())
+        (adj_year, adj_month, d)
     };
-    let _ = NaiveDate::from_ymd_opt(final_year, final_month, final_day)
-        .ok_or("Invalid resulting date")?;
 
-    let new_dt = Utc
-        .with_ymd_and_hms(
-            final_year,
-            final_month,
-            final_day,
-            dt.hour(),
-            dt.minute(),
-            dt.second(),
-        )
-        .single()
-        .ok_or("Invalid resulting date")?;
-
-    Ok(new_dt.timestamp() + remaining_secs)
+    let new_days = days_from_civil(final_year, final_month, final_day);
+    Ok(new_days * 86400 + time_of_day + remaining_secs)
 }
 
 /// Subtract a duration from a timestamp.
@@ -641,47 +637,91 @@ fn sub_duration_from_timestamp(
     dur_secs: i64,
 ) -> Result<i64, String> {
     use crate::runtime::functions::temporal::decompose_duration;
-    use chrono::{Datelike, TimeZone, Timelike, Utc};
 
     let (years, months, remaining_secs) = decompose_duration(dur_secs)?;
-    let dt = Utc
-        .timestamp_opt(ts, 0)
-        .single()
-        .ok_or("Invalid timestamp")?;
+    let days = ts.div_euclid(86400);
+    let time_of_day = ts.rem_euclid(86400);
+    let (y, m, d) = civil_from_days(days);
 
-    let new_year = dt.year() - years;
-    let new_month_raw = dt.month() as i32 - months;
+    let new_year = y - years;
+    let new_month_raw = m as i32 - months;
     let adj_year = new_year + (new_month_raw - 1).div_euclid(12);
     let adj_month = ((new_month_raw - 1).rem_euclid(12) + 1) as u32;
     let max_day = days_in_month(adj_year, adj_month);
-    let day = dt.day().min(max_day);
+    let day = d.min(max_day);
 
-    let new_dt = Utc
-        .with_ymd_and_hms(
-            adj_year,
-            adj_month,
-            day,
-            dt.hour(),
-            dt.minute(),
-            dt.second(),
-        )
-        .single()
-        .ok_or("Invalid resulting date")?;
-
-    Ok(new_dt.timestamp() - remaining_secs)
+    let new_days = days_from_civil(adj_year, adj_month, day);
+    Ok(new_days * 86400 + time_of_day - remaining_secs)
 }
 
 fn days_in_month(
     year: i32,
     month: u32,
 ) -> u32 {
-    use chrono::{Datelike, NaiveDate};
-    if month == 12 {
-        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    const DAYS: [u32; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    if month == 2 && is_leap(year) {
+        29
     } else {
-        NaiveDate::from_ymd_opt(year, month + 1, 1)
+        DAYS[(month - 1) as usize]
     }
-    .map_or(30, |d| d.pred_opt().unwrap().day())
+}
+
+const fn is_leap(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// Howard Hinnant's `days_from_civil`: civil (y/m/d) -> days since 1970-01-01.
+/// Works for any proleptic Gregorian date.
+#[must_use]
+pub const fn days_from_civil(
+    y: i32,
+    m: u32,
+    d: u32,
+) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400) as i64;
+    let yoe = y.rem_euclid(400) as i64; // [0, 399]
+    let m = m as i64;
+    let d = d as i64;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146097 + doe - 719468
+}
+
+/// Howard Hinnant's `civil_from_days`: days since 1970-01-01 -> (y, m, d).
+#[must_use]
+pub const fn civil_from_days(z: i64) -> (i32, u32, u32) {
+    let z = z + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097); // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+/// Write "YYYY-MM-DD" into buf[0..10]. buf must be at least 10 bytes.
+fn write_date_into(
+    buf: &mut [u8],
+    y: i32,
+    m: u32,
+    d: u32,
+) {
+    let yr = y.unsigned_abs();
+    buf[0] = b'0' + ((yr / 1000) % 10) as u8;
+    buf[1] = b'0' + ((yr / 100) % 10) as u8;
+    buf[2] = b'0' + ((yr / 10) % 10) as u8;
+    buf[3] = b'0' + (yr % 10) as u8;
+    buf[4] = b'-';
+    buf[5] = b'0' + ((m / 10) % 10) as u8;
+    buf[6] = b'0' + (m % 10) as u8;
+    buf[7] = b'-';
+    buf[8] = b'0' + ((d / 10) % 10) as u8;
+    buf[9] = b'0' + (d % 10) as u8;
 }
 
 impl Hash for Value {

--- a/graph/src/runtime/vectorized.rs
+++ b/graph/src/runtime/vectorized.rs
@@ -344,11 +344,7 @@ fn try_property_vs_constant(
     // const_side must be a leaf literal
     let const_node = tree.node(const_idx);
     let constant = match const_node.data() {
-        ExprIR::Integer(i) => Value::Int(*i),
-        ExprIR::Float(f) => Value::Float(*f),
-        ExprIR::String(s) => Value::String(s.clone()),
-        ExprIR::Bool(b) => Value::Bool(*b),
-        ExprIR::Null => Value::Null,
+        ExprIR::Constant(v) => v.clone(),
         _ => return None,
     };
     if const_node.num_children() != 0 {

--- a/graph/src/udf/js_context.rs
+++ b/graph/src/udf/js_context.rs
@@ -57,7 +57,6 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, Instant};
 
 use rquickjs::{CatchResultExt, CaughtError, Context, Function, Persistent, Runtime as JsRuntime};
-use thin_vec::ThinVec;
 
 use crate::runtime::runtime::Runtime;
 use crate::runtime::value::Value;
@@ -282,7 +281,7 @@ fn rebuild_context(
 pub fn call_udf_bridge(
     name: &str,
     rt: &Runtime,
-    args: &ThinVec<Value>,
+    args: &[Value],
 ) -> Result<Value, String> {
     ensure_context_current()?;
 


### PR DESCRIPTION
…d clarity

- Updated `apply_unary_float` to accept a slice of `Value` instead of `ThinVec`, simplifying argument handling.
- Refactored `atan2` function to use slice indexing for better readability and performance.
- Changed various aggregate operations to utilize method calls instead of direct function calls, enhancing consistency.
- Modified `project` operation to directly access environment variables, improving efficiency.
- Updated `remove` operation to handle string labels using `ExprIR::Constant`.
- Replaced `RefCell` with `UnsafeCell` in `Pool` for better performance and safety in single-threaded contexts.
- Enhanced date formatting functions in `Value` to use optimized logic for constructing date strings.
- Implemented civil date conversion functions for better date handling without relying on external libraries.
- Adjusted vectorized operations to handle constants more efficiently.
- Updated JavaScript context to accept slices of `Value` for argument passing, improving interoperability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Optimization**
  * Faster query execution via improved constant folding and optimizer handling
  * Reduced runtime overhead from more efficient function dispatch and argument evaluation

* **Improvements**
  * More robust and consistent date/time formatting and temporal arithmetic
  * Better handling of literal/constants across queries and planners

* **New Features**
  * Added pure/positional constructor support for temporal and spatial types (enables more optimizer-driven simplifications)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/falkordb-rs-next-gen/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->