### PR TITLE
Optimize multi-hop queries with columnar-native traversal

### DIFF
--- a/graph/src/runtime/batch.rs
+++ b/graph/src/runtime/batch.rs
@@ -274,6 +274,22 @@ impl Column {
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Creates a new column by gathering values from this column at the given
+    /// indices.
+    pub fn gather(
+        &self,
+        indices: impl Iterator<Item = usize>,
+    ) -> Self {
+        match self {
+            Self::NodeIds(v) => Self::NodeIds(indices.map(|i| v[i]).collect()),
+            Self::RelTriples(v) => Self::RelTriples(indices.map(|i| v[i]).collect()),
+            Self::Ints(v) => Self::Ints(indices.map(|i| v[i]).collect()),
+            Self::Floats(v) => Self::Floats(indices.map(|i| v[i]).collect()),
+            Self::Values(v) => Self::Values(indices.map(|i| v[i].clone()).collect()),
+            Self::Unbound => Self::Unbound,
+        }
+    }
 }
 
 /// In-progress column accumulator for a single variable slot.
@@ -663,32 +679,34 @@ impl<'a> Batch<'a> {
         let Some(sel) = self.selection.as_ref() else {
             return self;
         };
+        let indices: Vec<usize> = sel.iter().map(|&i| i as usize).collect();
+        let mut batch = self.gather(&indices);
+        batch.selection = None;
+        batch
+    }
+
+    /// Creates a new batch by gathering rows from this batch at the given
+    /// indices. Indices may be repeated or out of order.
+    #[must_use]
+    pub fn gather(
+        &self,
+        indices: &[usize],
+    ) -> Self {
         let columns = self
             .columns
             .iter()
-            .map(|col| match col {
-                Column::Unbound => Column::Unbound,
-                Column::NodeIds(v) => Column::NodeIds(sel.iter().map(|&r| v[r as usize]).collect()),
-                Column::RelTriples(v) => {
-                    Column::RelTriples(sel.iter().map(|&r| v[r as usize]).collect())
-                }
-                Column::Ints(v) => Column::Ints(sel.iter().map(|&r| v[r as usize]).collect()),
-                Column::Floats(v) => Column::Floats(sel.iter().map(|&r| v[r as usize]).collect()),
-                Column::Values(v) => {
-                    Column::Values(sel.iter().map(|&r| v[r as usize].clone()).collect())
-                }
-            })
+            .map(|c| c.gather(indices.iter().copied()))
             .collect();
         let origin_rows = self.origin_rows.as_ref().and_then(|o| {
-            let origins: Vec<u32> = sel.iter().map(|&r| o[r as usize]).collect();
+            let origins: Vec<u32> = indices.iter().map(|&i| o[i]).collect();
             origins.iter().any(|&x| x != 0).then_some(origins)
         });
         Batch {
-            len: sel.len(),
+            len: indices.len(),
             selection: None,
             columns,
             origin_rows,
-            value_only: self.value_only,
+            value_only: self.value_only.clone(),
             _marker: PhantomData,
         }
     }

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -74,6 +74,8 @@ pub struct CondTraverseOp<'a> {
     relationship_pattern: &'a QueryRelationship<Arc<String>, Arc<String>, Variable>,
     /// Buffered output rows from a partial expansion.
     pending: VecDeque<Row>,
+    /// Buffered output batches from a partial expansion (vectorized path).
+    pending_batches: VecDeque<Batch<'a>>,
     /// Current input batch being expanded (may span multiple output batches).
     current_batch: Option<Batch<'a>>,
     /// Index into active rows of the current batch.
@@ -230,6 +232,7 @@ impl<'a> CondTraverseOp<'a> {
             child,
             relationship_pattern,
             pending: VecDeque::new(),
+            pending_batches: VecDeque::new(),
             current_batch: None,
             current_pos: 0,
             emit_relationship,
@@ -340,8 +343,9 @@ impl<'a> CondTraverseOp<'a> {
     /// returns `false` to signal "fall back to slow path for this batch".
     fn expand_batch(
         &self,
-        rows: &[Row],
-        out: &mut Vec<Row>,
+        batch: &Batch<'a>,
+        active_subset: &[usize],
+        out_pending: &mut VecDeque<Batch<'a>>,
     ) -> Result<bool, String> {
         let runtime = self.runtime;
         let rp = self.relationship_pattern;
@@ -414,29 +418,29 @@ impl<'a> CondTraverseOp<'a> {
         let ncols = m_merged.ncols();
 
         let transposed = self.transposed;
-        let nrows = rows.len() as u64;
+        let nrows = active_subset.len() as u64;
 
         // Collect (row_i, src_id) for rows where the from-alias is bound to
         // a Node and (post-label-filter) the src has all required labels.
         // Rows where from is bound to a non-Node are dropped (mirror line
         // 311 early return). Rows where from is unbound trigger fall-back.
-        let mut row_idx_buf: Vec<u64> = Vec::with_capacity(rows.len());
-        let mut col_idx_buf: Vec<u64> = Vec::with_capacity(rows.len());
-        for (i, env) in rows.iter().enumerate() {
-            let from_alias = if transposed {
-                &rp.to.alias
-            } else {
-                &rp.from.alias
-            };
+        let mut row_idx_buf: Vec<u64> = Vec::with_capacity(active_subset.len());
+        let mut col_idx_buf: Vec<u64> = Vec::with_capacity(active_subset.len());
+        let from_alias = if transposed {
+            &rp.to.alias
+        } else {
+            &rp.from.alias
+        };
+        for (i, &row_idx) in active_subset.iter().enumerate() {
             // Bail to slow path if the matrix-src side isn't explicitly
             // bound on this row. `env.get` alone would silently return a
             // colliding outer-scope slot value; `is_bound` is authoritative.
-            if !env.is_bound_by_id(from_alias.id) {
+            if !batch.is_bound_at(from_alias.id, row_idx) {
                 drop(g);
                 return Ok(false);
             }
-            let src_id = if let Some(Value::Node(id)) = env.get_by_id(from_alias.id) {
-                *id
+            let src_id = if let Some(Value::Node(id)) = batch.value_at(from_alias.id, row_idx) {
+                id
             } else {
                 drop(g);
                 return Ok(false);
@@ -486,6 +490,11 @@ impl<'a> CondTraverseOp<'a> {
             (&rp.to.alias, state.fwd_dst_label_ids.as_slice())
         };
         let chain_is_empty = self.chain.is_empty();
+        let mut out_indices = Vec::new();
+        let mut out_dest_ids = Vec::new();
+        let mut out_edge_ids = Vec::new();
+        let mut out_src_ids = Vec::new();
+
         for (row_i, dest_raw) in row_is.into_iter().zip(col_is) {
             let dest_id = NodeId::from(dest_raw);
             // Post-filter final-hop dst label (= F * A * R_dst in C's algebra).
@@ -495,15 +504,16 @@ impl<'a> CondTraverseOp<'a> {
             {
                 continue;
             }
-            let env = &rows[row_i as usize];
-            // If the to-alias is already bound on the input env, the
+            let row_idx = active_subset[row_i as usize];
+            // If the to-alias is already bound on the input batch row, the
             // planner should have inserted ExpandInto, not CondTraverse —
             // but be defensive and skip mismatches.
-            if let Some(Value::Node(bound)) = env.get_by_id(to_alias.id)
-                && *bound != dest_id
+            if let Some(Value::Node(bound)) = batch.value_at(to_alias.id, row_idx)
+                && bound != dest_id
             {
                 continue;
             }
+
             if chain_is_empty {
                 // Look up one representative edge id (mirrors expand_row's
                 // anonymous-edge fast path). Required because downstream
@@ -513,8 +523,8 @@ impl<'a> CondTraverseOp<'a> {
                 // self.transposed (which only affects alias→storage mapping,
                 // not the underlying matrix orientation since
                 // build_relationship_matrix_unrestricted is non-transposed).
-                let src_id = match env.get_by_id(from_alias.id) {
-                    Some(Value::Node(id)) => *id,
+                let src_id = match batch.value_at(from_alias.id, row_idx) {
+                    Some(Value::Node(id)) => id,
                     _ => continue,
                 };
                 let mat_src = u64::from(src_id);
@@ -529,26 +539,50 @@ impl<'a> CondTraverseOp<'a> {
                         break;
                     }
                 }
-                let Some(edge_id) = found_id else { continue };
-                let mut row = env.clone();
-                row.insert(to_alias, Value::Node(dest_id));
-                row.insert(
-                    &rp.alias,
-                    Value::Relationship(Box::new((
-                        edge_id,
-                        NodeId::from(mat_src),
-                        NodeId::from(mat_dst),
-                    ))),
-                );
-                out.push(row);
+                if let Some(edge_id) = found_id {
+                    out_indices.push(row_idx);
+                    out_dest_ids.push(dest_id);
+                    out_edge_ids.push(edge_id);
+                    out_src_ids.push(src_id);
+                }
             } else {
                 // Fused chain: edges across hops are anonymous & unreferenced
                 // (enforced by the fusion pass), so no edge id is bound and
                 // no intermediate node alias is exposed.
-                let mut row = env.clone();
-                row.insert(to_alias, Value::Node(dest_id));
-                out.push(row);
+                out_indices.push(row_idx);
+                out_dest_ids.push(dest_id);
             }
+
+            if out_indices.len() >= BATCH_SIZE {
+                let mut out_batch = batch.gather(&out_indices);
+                if chain_is_empty {
+                    let triples = std::mem::take(&mut out_edge_ids)
+                        .into_iter()
+                        .zip(std::mem::take(&mut out_src_ids))
+                        .zip(out_dest_ids.iter().copied())
+                        .map(|((e, s), d)| (e, s, d))
+                        .collect();
+                    out_batch.set_column(rp.alias.id, Column::RelTriples(triples));
+                }
+                out_batch.set_column(to_alias.id, Column::NodeIds(std::mem::take(&mut out_dest_ids)));
+                out_pending.push_back(out_batch);
+                out_indices.clear();
+            }
+        }
+
+        if !out_indices.is_empty() {
+            let mut out_batch = batch.gather(&out_indices);
+            if chain_is_empty {
+                let triples = out_edge_ids
+                    .into_iter()
+                    .zip(out_src_ids)
+                    .zip(out_dest_ids.iter().copied())
+                    .map(|((e, s), d)| (e, s, d))
+                    .collect();
+                out_batch.set_column(rp.alias.id, Column::RelTriples(triples));
+            }
+            out_batch.set_column(to_alias.id, Column::NodeIds(out_dest_ids));
+            out_pending.push_back(out_batch);
         }
 
         drop(g);
@@ -557,43 +591,45 @@ impl<'a> CondTraverseOp<'a> {
 
     fn expand_row(
         &self,
-        env: &Row,
+        batch: &Batch<'a>,
+        row_idx: usize,
         out: &mut Vec<Row>,
     ) -> Result<(), String> {
         let runtime = self.runtime;
         let rp = self.relationship_pattern;
+        let env = BatchRow::new(batch, row_idx);
 
         let filter_attrs = ExprEval::from_runtime(runtime).eval(
             &rp.attrs,
             rp.attrs.root().idx(),
-            Some(env),
+            Some(&env),
             None,
         )?;
         let from_node_attrs = ExprEval::from_runtime(runtime).eval(
             &rp.from.attrs,
             rp.from.attrs.root().idx(),
-            Some(env),
+            Some(&env),
             None,
         )?;
         let to_node_attrs = ExprEval::from_runtime(runtime).eval(
             &rp.to.attrs,
             rp.to.attrs.root().idx(),
-            Some(env),
+            Some(&env),
             None,
         )?;
 
-        let from_id = env.get_by_id(rp.from.alias.id).and_then(|v| match v {
-            Value::Node(id) => Some(*id),
+        let from_id = env.value_at(rp.from.alias.id).and_then(|v| match v {
+            Value::Node(id) => Some(id),
             _ => None,
         });
-        if from_id.is_none() && env.is_bound_by_id(rp.from.alias.id) {
+        if from_id.is_none() && batch.is_bound_at(rp.from.alias.id, row_idx) {
             return Ok(());
         }
-        let to_id = env.get_by_id(rp.to.alias.id).and_then(|v| match v {
-            Value::Node(id) => Some(*id),
+        let to_id = env.value_at(rp.to.alias.id).and_then(|v| match v {
+            Value::Node(id) => Some(id),
             _ => None,
         });
-        if to_id.is_none() && env.is_bound_by_id(rp.to.alias.id) {
+        if to_id.is_none() && batch.is_bound_at(rp.to.alias.id, row_idx) {
             return Ok(());
         }
 
@@ -648,7 +684,8 @@ impl<'a> CondTraverseOp<'a> {
                 &filter_attrs,
                 &g,
                 rp,
-                env,
+                batch,
+                row_idx,
                 out,
                 self.emit_relationship,
                 self.sibling_edges,
@@ -684,7 +721,8 @@ impl<'a> CondTraverseOp<'a> {
                 &filter_attrs,
                 &g,
                 rp,
-                env,
+                batch,
+                row_idx,
                 out,
                 self.emit_relationship,
                 self.sibling_edges,
@@ -739,7 +777,8 @@ impl<'a> CondTraverseOp<'a> {
         filter_attrs: &Value,
         g: &crate::graph::graph::Graph,
         rp: &QueryRelationship<Arc<String>, Arc<String>, Variable>,
-        env: &Row,
+        batch: &Batch<'a>,
+        row_idx: usize,
         out: &mut Vec<Row>,
         emit_relationship: bool,
         sibling_edges: &[u32],
@@ -815,19 +854,20 @@ impl<'a> CondTraverseOp<'a> {
             let key = compound_key(u64::from(src), u64::from(dst));
             if !emit_relationship && !has_edge_filter {
                 let mut found_id: Option<RelationshipId> = None;
+                let env = BatchRow::new(batch, row_idx);
                 'outer: for cell in edge_iters {
                     let mut it = cell.borrow_mut();
                     it.seek(key, key);
                     for (_, raw_id) in &mut *it {
                         let id = RelationshipId::from(raw_id);
-                        if !super::edge_already_used(env, id, rp.alias.id, sibling_edges) {
+                        if !super::edge_already_used(&env, id, rp.alias.id, sibling_edges) {
                             found_id = Some(id);
                             break 'outer;
                         }
                     }
                 }
                 if let Some(id) = found_id {
-                    let mut row = env.clone();
+                    let mut row = env.to_owned_row();
                     row.insert(&rp.alias, Value::Relationship(Box::new((id, src, dst))));
                     row.insert(&rp.from.alias, Value::Node(from_node));
                     row.insert(&rp.to.alias, Value::Node(to_node));
@@ -840,11 +880,12 @@ impl<'a> CondTraverseOp<'a> {
             for cell in edge_iters {
                 let mut it = cell.borrow_mut();
                 it.seek(key, key);
+                let env = BatchRow::new(batch, row_idx);
                 for (_, raw_id) in &mut *it {
                     let id = RelationshipId::from(raw_id);
                     // Relationship uniqueness: skip edges already bound to other
                     // relationship variables in this MATCH clause.
-                    if super::edge_already_used(env, id, rp.alias.id, sibling_edges) {
+                    if super::edge_already_used(&env, id, rp.alias.id, sibling_edges) {
                         continue;
                     }
                     if let Value::Map(filter_map) = filter_attrs
@@ -898,6 +939,7 @@ impl<'a> Iterator for CondTraverseOp<'a> {
 
         // Drain leftover rows from previous call.
         super::drain_pending(&mut self.pending, &mut builder);
+        super::drain_pending_batches(&mut self.pending_batches, &mut builder);
 
         loop {
             if builder.len() >= BATCH_SIZE {
@@ -927,15 +969,10 @@ impl<'a> Iterator for CondTraverseOp<'a> {
 
                 let mut used_batched = false;
                 if self.batched_eligible && self.current_pos < active.len() {
-                    let envs_slice: Vec<Row> = active[self.current_pos..]
-                        .iter()
-                        .map(|&i| BatchRow::new(batch, i).to_owned_row())
-                        .collect();
-                    let mut expanded = Vec::new();
-                    match self.expand_batch(&envs_slice, &mut expanded) {
+                    let active_subset = &active[self.current_pos..];
+                    match self.expand_batch(batch, active_subset, &mut self.pending_batches) {
                         Ok(true) => {
                             self.current_pos = active.len();
-                            self.pending.extend(expanded);
                             used_batched = true;
                         }
                         Ok(false) => {}
@@ -947,9 +984,8 @@ impl<'a> Iterator for CondTraverseOp<'a> {
                     while self.current_pos < active.len() {
                         let row_idx = active[self.current_pos];
                         self.current_pos += 1;
-                        let env = BatchRow::new(batch, row_idx).to_owned_row();
                         let mut expanded = Vec::new();
-                        if let Err(e) = self.expand_row(&env, &mut expanded) {
+                        if let Err(e) = self.expand_row(batch, row_idx, &mut expanded) {
                             return Some(Err(e));
                         }
                         self.pending.extend(expanded);
@@ -962,6 +998,7 @@ impl<'a> Iterator for CondTraverseOp<'a> {
             }
 
             super::drain_pending(&mut self.pending, &mut builder);
+            super::drain_pending_batches(&mut self.pending_batches, &mut builder);
 
             // Check if batch is exhausted.
             if let Some(ref batch) = self.current_batch

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -35,7 +35,7 @@ use crate::parser::ast::{ExprIR, QueryExpr, QueryRelationship, Variable};
 use crate::planner::IR;
 use crate::runtime::eval::ExprEval;
 use crate::runtime::{
-    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp, BatchRow},
+    batch::{BATCH_SIZE, Batch, BatchBuilder, BatchOp, BatchRow, Column},
     row::{Row, RowView},
     runtime::Runtime,
     value::Value,
@@ -877,10 +877,10 @@ impl<'a> CondTraverseOp<'a> {
             }
 
             // Scan edges
+            let env = BatchRow::new(batch, row_idx);
             for cell in edge_iters {
                 let mut it = cell.borrow_mut();
                 it.seek(key, key);
-                let env = BatchRow::new(batch, row_idx);
                 for (_, raw_id) in &mut *it {
                     let id = RelationshipId::from(raw_id);
                     // Relationship uniqueness: skip edges already bound to other
@@ -907,7 +907,7 @@ impl<'a> CondTraverseOp<'a> {
                             continue;
                         }
                     }
-                    let mut row = env.clone();
+                    let mut row = env.to_owned_row();
                     row.insert(&rp.alias, Value::Relationship(Box::new((id, src, dst))));
                     row.insert(&rp.from.alias, Value::Node(from_node));
                     row.insert(&rp.to.alias, Value::Node(to_node));

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -564,7 +564,10 @@ impl<'a> CondTraverseOp<'a> {
                         .collect();
                     out_batch.set_column(rp.alias.id, Column::RelTriples(triples));
                 }
-                out_batch.set_column(to_alias.id, Column::NodeIds(std::mem::take(&mut out_dest_ids)));
+                out_batch.set_column(
+                    to_alias.id,
+                    Column::NodeIds(std::mem::take(&mut out_dest_ids)),
+                );
                 out_pending.push_back(out_batch);
                 out_indices.clear();
             }

--- a/graph/src/runtime/ops/cond_traverse.rs
+++ b/graph/src/runtime/ops/cond_traverse.rs
@@ -970,13 +970,20 @@ impl<'a> Iterator for CondTraverseOp<'a> {
                 let mut used_batched = false;
                 if self.batched_eligible && self.current_pos < active.len() {
                     let active_subset = &active[self.current_pos..];
-                    match self.expand_batch(batch, active_subset, &mut self.pending_batches) {
+                    let mut pending = std::mem::take(&mut self.pending_batches);
+                    match self.expand_batch(batch, active_subset, &mut pending) {
                         Ok(true) => {
+                            self.pending_batches = pending;
                             self.current_pos = active.len();
                             used_batched = true;
                         }
-                        Ok(false) => {}
-                        Err(e) => return Some(Err(e)),
+                        Ok(false) => {
+                            self.pending_batches = pending;
+                        }
+                        Err(e) => {
+                            self.pending_batches = pending;
+                            return Some(Err(e));
+                        }
                     }
                 }
 

--- a/graph/src/runtime/ops/mod.rs
+++ b/graph/src/runtime/ops/mod.rs
@@ -136,6 +136,32 @@ pub fn drain_pending(
     }
 }
 
+pub fn drain_pending_batches<'a>(
+    pending: &mut VecDeque<Batch<'a>>,
+    builder: &mut BatchBuilder,
+) {
+    while builder.len() < BATCH_SIZE {
+        if let Some(batch) = pending.pop_front() {
+            // If the whole batch fits, push it all.
+            if builder.len() + batch.len() <= BATCH_SIZE {
+                builder.push_batch_active(&batch);
+            } else {
+                // Only part of the batch fits.
+                let remaining = BATCH_SIZE - builder.len();
+                for i in 0..remaining {
+                    builder.push_batch_row(&batch, i, batch.origin_row(i));
+                }
+                // Push the remainder back to pending.
+                let indices: Vec<_> = (remaining..batch.len()).collect();
+                pending.push_front(batch.gather(&indices));
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
 /// Check whether a given edge ID is already bound to another relationship
 /// variable in the environment.
 ///

--- a/graph/src/runtime/ops/mod.rs
+++ b/graph/src/runtime/ops/mod.rs
@@ -152,7 +152,7 @@ pub fn drain_pending_batches<'a>(
                     builder.push_batch_row(&batch, i, batch.origin_row(i));
                 }
                 // Push the remainder back to pending.
-                let indices: Vec<_> = (remaining..batch.len()).collect();
+                let indices: Vec<usize> = (remaining..batch.len()).collect();
                 pending.push_front(batch.gather(&indices));
                 break;
             }

--- a/graph/src/runtime/ops/mod.rs
+++ b/graph/src/runtime/ops/mod.rs
@@ -114,7 +114,7 @@ use crate::graph::graph::RelationshipId;
 use crate::runtime::value::Value;
 
 use super::{
-    batch::{BATCH_SIZE, BatchBuilder},
+    batch::{BATCH_SIZE, Batch, BatchBuilder},
     row::{Row, RowView},
 };
 


### PR DESCRIPTION
This PR optimizes multi-hop query performance by making the `CondTraverseOp` "columnar-native".

Previously, even when using matrix multiplication for the traversal, the operator would materialize every result path into an intermediate `Row` object. For deep traversals (like 4-hop queries) that produce many paths, this caused a significant performance regression due to excessive allocations and cloning.

The new implementation:
1. Works directly with `Batch` and `Column` data.
2. Uses a vectorized `gather` approach to build output batches from GraphBLAS results.
3. Maintains a queue of `pending_batches` to yield results in optimal `BATCH_SIZE` chunks.
4. Eliminates the intermediate `Row` materialization bottleneck.

These changes bring the Rust implementation's performance profile closer to the original C version's efficient matrix-to-columnar flow.

---
*PR created automatically by Jules for task [11300799392157165966](https://jules.google.com/task/11300799392157165966) started by @gkorland*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added a batched gather mechanism to efficiently rebuild and compact typed columns and rows.
  * Conditional traversal now produces and consumes vectorized batches, improving throughput and memory behavior.
  * Added a utility to drain and assemble pending batches into sized builders for steadier batch outputs.
  * Adjusted per-row handling to interoperate with batched views for consistent alias/value checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->