### PR TITLE
feat(graphblas): log-structured matrix + banded value→id store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "graph"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
  "atomic_refcell",
  "chrono",
  "crossfire",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -22,6 +22,7 @@ prejit_harvest = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = "1.7"
 atomic_refcell = "0.1.14"
 chrono = "0.4.45"
 crossfire = "3.1.16"

--- a/graph/src/graph/graphblas/lsm/mod.rs
+++ b/graph/src/graph/graphblas/lsm/mod.rs
@@ -29,9 +29,9 @@ pub(crate) mod store;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use parking_lot::RwLock;
+use arc_swap::ArcSwap;
 
-use crate::graph::graphblas::matrix::{Dup, MaskedElementWiseAdd, Matrix, New, Size};
+use crate::graph::graphblas::matrix::{Descriptor, MaskedElementWiseAdd, Matrix, New, Size};
 
 /// One band's matrix dimension: `2^60`. Rows are an encoded key's low 60 bits,
 /// columns are ids — both `< 2^60` (GraphBLAS's index ceiling). Banding (the
@@ -48,12 +48,13 @@ const F: u64 = 2;
 
 /// Cell type of an LSM matrix: presence (`bool`) or value-carrying (`u64`,
 /// packing a caller payload). Provides the type-specific GraphBLAS primitives the
-/// LSM needs — build a run, scan it, an empty matrix, and a value-preserving
-/// union. Local to this module.
-pub(crate) trait LsmCell: Copy + Send + Sync + 'static {
-    /// Bulk-build an immutable run matrix from `(rows, cols, vals)`. Entries are
+/// LSM needs — build a run, scan it, and a value-preserving suppressing union.
+/// Local to this module.
+pub(crate) trait LsmCell: Clone + Send + Sync + 'static {
+    /// Bulk-build an immutable, hypersparse run matrix from `(rows, cols, vals)`.
+    /// Empty slices yield an empty matrix (the only constructor). Entries are
     /// unique per run (an id is added once per row in a commit), so no dup
-    /// resolution is needed. GraphBLAS sorts internally — hence ingest is
+    /// resolution is needed; GraphBLAS sorts internally, so ingest is
     /// insert-order-independent.
     fn build_run(
         rows: &[u64],
@@ -69,15 +70,19 @@ pub(crate) trait LsmCell: Copy + Send + Sync + 'static {
         hi: u64,
     ) -> Box<dyn Iterator<Item = (u64, u64, Self)> + Send>;
 
-    /// An empty matrix of this cell type, full band dimensions.
-    fn empty() -> Matrix;
-
-    /// `dst = dst ∪ src`, preserving values; on a cell conflict `src` (the newer
-    /// run) wins. Used to fold a newer segment's adds into an older one.
-    fn union_into(
-        dst: &mut Matrix,
-        src: &Matrix,
-    );
+    /// Build `out = (a ∪ b) − mask` as a **fresh** matrix in one pass — no `dup`
+    /// of the base, which `a` being `Arc`-shared and immutable would otherwise
+    /// force; `a`/`b` are read, not mutated. Values are preserved (a shared cell
+    /// takes one of two identical values, see `Matrix::element_wise_add_uint64`).
+    /// `mask`, when given, is a structural complement: the cells it holds are
+    /// dropped from the result, fusing a segment's tombstone application into the
+    /// union. A missing `a` or `b` contributes nothing (`x ∪ ∅ = x`);
+    /// `(None, None)` yields `None`.
+    fn union_masked(
+        a: Option<&Matrix>,
+        b: Option<&Matrix>,
+        mask: Option<&Matrix>,
+    ) -> Option<Matrix>;
 }
 
 impl LsmCell for bool {
@@ -87,6 +92,7 @@ impl LsmCell for bool {
         _vals: &[Self],
     ) -> Matrix {
         let mut m = Matrix::new(DIM, DIM);
+        m.pin_hypersparse();
         if !rows.is_empty() {
             m.build_bool(rows, cols);
         }
@@ -101,26 +107,30 @@ impl LsmCell for bool {
         Box::new(m.iter(lo, hi).map(|(r, c)| (r, c, true)))
     }
 
-    fn empty() -> Matrix {
-        Matrix::new(DIM, DIM)
-    }
-
-    fn union_into(
-        dst: &mut Matrix,
-        src: &Matrix,
-    ) {
-        // PAIR/BOOL presence union — value is always `true`, so newer-wins is moot.
-        dst.element_wise_add(None, None, Some(src), None);
+    fn union_masked(
+        a: Option<&Matrix>,
+        b: Option<&Matrix>,
+        mask: Option<&Matrix>,
+    ) -> Option<Matrix> {
+        if a.is_none() && b.is_none() {
+            return None;
+        }
+        // Fresh, hypersparse, empty target: `c<!mask, replace> = a ∪ b`. A `None`
+        // operand defaults to the empty `c`, so a lone run passes through
+        // (`x ∪ ∅ = x`). `mask` (if any) is a structural complement applied in
+        // the same op.
+        let mut c = Self::build_run(&[], &[], &[]);
+        c.element_wise_add(mask, a, b, mask.map(|_| Descriptor::RSC));
+        Some(c)
     }
 }
 
 /// Generate a [`LsmCell`] impl for a **value-carrying** cell type by wiring its
 /// `Matrix` primitives: the typed constructor `$new`, bulk builder `$build`,
-/// value-reading range scan `$iter`, and value-preserving union `$union` (a
-/// `SECOND` semiring, so the newer run wins a conflicting cell). Presence
-/// (`bool`) is the special case implemented explicitly above; every value type
-/// shares this shape, so adding one (`f64`, `i64`, …) is one line here plus its
-/// matching `Matrix` primitives.
+/// value-reading range scan `$iter`, and value-preserving suppressing union
+/// `$union`. Presence (`bool`) is the special case implemented explicitly above;
+/// every value type shares this shape, so adding one (`f64`, `i64`, …) is one
+/// line here plus its matching `Matrix` primitives.
 macro_rules! impl_valued_lsm_cell {
     ($t:ty, $new:ident, $build:ident, $iter:ident, $union:ident) => {
         impl LsmCell for $t {
@@ -130,6 +140,7 @@ macro_rules! impl_valued_lsm_cell {
                 vals: &[Self],
             ) -> Matrix {
                 let mut m = Matrix::$new(DIM, DIM);
+                m.pin_hypersparse();
                 if !rows.is_empty() {
                     m.$build(rows, cols, vals);
                 }
@@ -144,15 +155,20 @@ macro_rules! impl_valued_lsm_cell {
                 Box::new(m.$iter(lo, hi))
             }
 
-            fn empty() -> Matrix {
-                Matrix::$new(DIM, DIM)
-            }
-
-            fn union_into(
-                dst: &mut Matrix,
-                src: &Matrix,
-            ) {
-                dst.$union(src);
+            fn union_masked(
+                a: Option<&Matrix>,
+                b: Option<&Matrix>,
+                mask: Option<&Matrix>,
+            ) -> Option<Matrix> {
+                if a.is_none() && b.is_none() {
+                    return None;
+                }
+                // Fresh, hypersparse, empty target: `c<!mask, replace> = a ∪ b`.
+                // A `None` operand defaults to the empty `c`, so a lone run
+                // passes through (`x ∪ ∅ = x`).
+                let mut c = Self::build_run(&[], &[], &[]);
+                c.$union(a, b, mask);
+                Some(c)
             }
         }
     };
@@ -169,6 +185,8 @@ impl_valued_lsm_cell!(
 /// One immutable segment: a commit's (or a merge's) net add/tombstone runs.
 /// `adds`/`tombs` are `None` when empty. `weight ≈ nnz(adds) + nnz(tombs)` drives
 /// the compaction tiering. `version` orders segments for newest-wins reads.
+/// `Clone` is shallow — the matrices are shared by `Arc`.
+#[derive(Clone)]
 struct Segment {
     version: u64,
     adds: Option<Arc<Matrix>>,
@@ -224,50 +242,42 @@ impl<V: LsmCell> Layers<V> {
 pub(crate) fn commit_layers<V: LsmCell>(
     cur: &Layers<V>,
     version: u64,
-    adds: &[(u64, u64, V)],
-    tombs: &[(u64, u64)],
+    add_rows: &[u64],
+    add_cols: &[u64],
+    add_vals: &[V],
+    tomb_rows: &[u64],
+    tomb_cols: &[u64],
 ) -> Layers<V> {
-    commit_layers_f(cur, version, adds, tombs, F)
-}
+    debug_assert_eq!(add_rows.len(), add_cols.len());
+    debug_assert_eq!(add_rows.len(), add_vals.len());
+    debug_assert_eq!(tomb_rows.len(), tomb_cols.len());
 
-/// [`commit_layers`] with an explicit compaction fan-out `f` (tuning/probe knob).
-fn commit_layers_f<V: LsmCell>(
-    cur: &Layers<V>,
-    version: u64,
-    adds: &[(u64, u64, V)],
-    tombs: &[(u64, u64)],
-    f: u64,
-) -> Layers<V> {
-    let adds_m = (!adds.is_empty()).then(|| {
-        let mut rows = Vec::with_capacity(adds.len());
-        let mut cols = Vec::with_capacity(adds.len());
-        let mut vals = Vec::with_capacity(adds.len());
-        for &(r, c, v) in adds {
-            rows.push(r);
-            cols.push(c);
-            vals.push(v);
-        }
-        Arc::new(V::build_run(&rows, &cols, &vals))
-    });
-    let tombs_m = (!tombs.is_empty()).then(|| {
-        let mut rows = Vec::with_capacity(tombs.len());
-        let mut cols = Vec::with_capacity(tombs.len());
-        for &(r, c) in tombs {
-            rows.push(r);
-            cols.push(c);
-        }
-        Arc::new(<bool as LsmCell>::build_run(&rows, &cols, &[]))
-    });
+    // Hand the caller's structure-of-arrays straight to the matrix builder — no
+    // array-of-structs rebuild. An empty side has no run.
+    let adds_m = if add_rows.is_empty() {
+        None
+    } else {
+        Some(Arc::new(V::build_run(add_rows, add_cols, add_vals)))
+    };
+    let tombs_m = if tomb_rows.is_empty() {
+        None
+    } else {
+        Some(Arc::new(<bool as LsmCell>::build_run(
+            tomb_rows,
+            tomb_cols,
+            &[],
+        )))
+    };
 
-    let mut segs = clone_segs(&cur.segs);
+    let mut segs = cur.segs.clone();
     if adds_m.is_some() || tombs_m.is_some() {
         segs.push(Segment {
             version,
             adds: adds_m,
             tombs: tombs_m,
-            weight: adds.len() as u64 + tombs.len() as u64,
+            weight: add_rows.len() as u64 + tomb_rows.len() as u64,
         });
-        compact::<V>(&mut segs, f);
+        compact::<V>(&mut segs);
     }
     Layers {
         segs,
@@ -278,12 +288,13 @@ fn commit_layers_f<V: LsmCell>(
 /// A published snapshot of one band — what a reader pins.
 pub(crate) type Snapshot<V> = Arc<Layers<V>>;
 
-/// One band's log-structured matrix: a single published [`Layers`] swapped under
-/// a lock on commit. Readers clone the `Arc` (lock-free after); the writer builds
-/// new immutable segments and publishes a new `Layers` that shares the untouched
-/// old segments by `Arc`.
+/// One band's log-structured matrix: a single published [`Layers`] swapped
+/// atomically on commit. The writer builds new immutable segments and publishes
+/// a new `Layers` that shares the untouched old ones by `Arc`; readers `load`
+/// the current `Arc` **lock-free** (writes are serialized upstream, so a single
+/// atomic publish — no reader lock — suffices).
 pub(crate) struct LsmMatrix<V: LsmCell> {
-    committed: RwLock<Snapshot<V>>,
+    committed: ArcSwap<Layers<V>>,
 }
 
 impl<V: LsmCell> Default for LsmMatrix<V> {
@@ -296,89 +307,66 @@ impl<V: LsmCell> LsmMatrix<V> {
     /// An empty band.
     pub(crate) fn new() -> Self {
         Self {
-            committed: RwLock::new(Arc::new(Layers {
-                segs: Vec::new(),
-                _v: PhantomData,
-            })),
+            committed: ArcSwap::from_pointee(Layers::empty()),
         }
     }
 
     /// Pin the latest published version — the immutable view a reader scans.
+    /// Lock-free: an atomic load plus an `Arc` bump.
     pub(crate) fn snapshot(&self) -> Snapshot<V> {
-        Arc::clone(&self.committed.read())
+        self.committed.load_full()
     }
 
     /// Append one commit's changes as a new immutable segment, run compaction,
-    /// and publish. `adds` are `(row, col, value)` cells; `tombs` are
-    /// `(row, col)` cells to suppress (the caller — the store — resolves id
-    /// deletes/updates into the exact old cells). The new version shares all
-    /// untouched old segments by `Arc`; only the small segment list is cloned, so
-    /// a quiet commit is `O(this commit's changes)` and a compacting commit pays
-    /// `O(merged nnz)` (amortized `O(log N)` per element).
+    /// and publish. Cells are passed structure-of-arrays — `add_rows`/`add_cols`/
+    /// `add_vals` are the parallel `(row, col, value)` adds; `tomb_rows`/
+    /// `tomb_cols` the `(row, col)` cells to suppress — so they reach the matrix
+    /// builder without an array-of-structs rebuild (the form
+    /// [`super::store::BandedLsmStore`] produces directly). The new version
+    /// shares all untouched old segments by `Arc`; only the small segment list is
+    /// cloned, so a quiet commit is `O(this commit's changes)` and a compacting
+    /// commit pays `O(merged nnz)` (amortized `O(log N)` per element).
     pub(crate) fn commit(
         &self,
         version: u64,
-        adds: &[(u64, u64, V)],
-        tombs: &[(u64, u64)],
+        add_rows: &[u64],
+        add_cols: &[u64],
+        add_vals: &[V],
+        tomb_rows: &[u64],
+        tomb_cols: &[u64],
     ) {
-        if adds.is_empty() && tombs.is_empty() {
-            return; // empty commit — nothing to publish
-        }
-        let cur = self.committed.read().clone();
-        let next = commit_layers::<V>(&cur, version, adds, tombs);
-        *self.committed.write() = Arc::new(next);
-    }
-
-    /// [`commit`] with an explicit compaction fan-out `f` (test/probe knob).
-    #[cfg(test)]
-    pub(crate) fn commit_f(
-        &self,
-        version: u64,
-        adds: &[(u64, u64, V)],
-        tombs: &[(u64, u64)],
-        f: u64,
-    ) {
-        if adds.is_empty() && tombs.is_empty() {
-            return;
-        }
-        let cur = self.committed.read().clone();
-        let next = commit_layers_f::<V>(&cur, version, adds, tombs, f);
-        *self.committed.write() = Arc::new(next);
+        debug_assert!(
+            !(add_rows.is_empty() && tomb_rows.is_empty()),
+            "empty commit — the caller must not publish an empty version"
+        );
+        let cur = self.committed.load_full();
+        let next = commit_layers::<V>(
+            &cur, version, add_rows, add_cols, add_vals, tomb_rows, tomb_cols,
+        );
+        self.committed.store(Arc::new(next));
     }
 
     /// Collapse all segments into a single tombstone-free base (see
     /// [`major_compact_layers`]). Publishes a new version; pinned readers keep
     /// their old segments.
     pub(crate) fn major_compact(&self) {
-        let cur = self.committed.read().clone();
+        let cur = self.committed.load_full();
         let next = major_compact_layers::<V>(&cur);
-        *self.committed.write() = Arc::new(next);
+        self.committed.store(Arc::new(next));
     }
 
     /// Number of live segments. Bounded to `O(log N)` by compaction.
     #[cfg(test)]
     pub(crate) fn seg_count(&self) -> usize {
-        self.committed.read().segs.len()
+        self.committed.load().segs.len()
     }
 
     /// Sum of segment weights — a proxy for resident cells (memory). Used by the
     /// tombstone-GC test to confirm churn doesn't grow the structure unboundedly.
     #[cfg(test)]
     pub(crate) fn total_weight(&self) -> u64 {
-        self.committed.read().segs.iter().map(|s| s.weight).sum()
+        self.committed.load().segs.iter().map(|s| s.weight).sum()
     }
-}
-
-/// Shallow-clone the segment list (each `Segment` shares its matrices by `Arc`).
-fn clone_segs(segs: &[Segment]) -> Vec<Segment> {
-    segs.iter()
-        .map(|s| Segment {
-            version: s.version,
-            adds: s.adds.clone(),
-            tombs: s.tombs.clone(),
-            weight: s.weight,
-        })
-        .collect()
 }
 
 /// Merge two adjacent segments `a` (older) and `b` (newer) into one, applying
@@ -389,42 +377,35 @@ fn clone_segs(segs: &[Segment]) -> Vec<Segment> {
 ///   tombs = (a.tombs ∪ b.tombs)           − b.adds      (dropped if `bottom`)
 /// ```
 ///
-/// `a.adds`/`a.tombs` are `Arc`-shared and never mutated — we `dup` `a` and fold
-/// `b` into the copy, leaving the originals intact for older readers. When `a` is
-/// the bottom segment (`segs[0]`), its merged tombstones suppress nothing older,
-/// so they are GC'd (`bottom = true`).
+/// Each side is one fused [`LsmCell::union_masked`] (union + masked tombstone
+/// removal) into a fresh matrix. `a`'s matrices are `Arc`-shared and immutable;
+/// `union_masked` reads them as operands rather than duplicating them, leaving
+/// the originals intact for older readers. When `a` is the bottom segment
+/// (`segs[0]`) its merged tombstones suppress nothing older, so they are GC'd
+/// (`bottom = true`).
 fn merge_segments<V: LsmCell>(
     a: &Segment,
     b: &Segment,
     bottom: bool,
 ) -> Segment {
-    // adds = (a.adds ∪ b.adds) − b.tombs
-    let mut add = a.adds.as_ref().map_or_else(V::empty, |m| m.dup());
-    if let Some(ba) = &b.adds {
-        V::union_into(&mut add, ba);
-    }
-    if let Some(bt) = &b.tombs {
-        add.remove_all(bt);
-    }
-    let add_n = add.nvals();
-    let adds = (add_n > 0).then(|| Arc::new(add));
+    // adds = (a.adds ∪ b.adds) − b.tombs, built fresh (no dup of the base).
+    let add = V::union_masked(a.adds.as_deref(), b.adds.as_deref(), b.tombs.as_deref());
+    let add_n = add.as_ref().map_or(0, Matrix::nvals);
+    let adds = add.filter(|_| add_n > 0).map(Arc::new);
 
-    // tombs = (a.tombs ∪ b.tombs) − b.adds ; dropped at the bottom (nothing older).
+    // tombs = (a.tombs ∪ b.tombs) − b.adds ; dropped at the bottom (nothing
+    // older to suppress). Tombstone runs are always `bool`; `b.adds` is the
+    // structural suppression mask.
     let (tombs, tomb_n) = if bottom {
         (None, 0)
     } else {
-        let mut t = a
-            .tombs
-            .as_ref()
-            .map_or_else(|| Matrix::new(DIM, DIM), |m| m.dup());
-        if let Some(bt) = &b.tombs {
-            t.element_wise_add(None, None, Some(bt), None);
-        }
-        if let Some(ba) = &b.adds {
-            t.remove_all(ba);
-        }
-        let n = t.nvals();
-        ((n > 0).then(|| Arc::new(t)), n)
+        let t = <bool as LsmCell>::union_masked(
+            a.tombs.as_deref(),
+            b.tombs.as_deref(),
+            b.adds.as_deref(),
+        );
+        let n = t.as_ref().map_or(0, Matrix::nvals);
+        (t.filter(|_| n > 0).map(Arc::new), n)
     };
 
     Segment {
@@ -440,10 +421,7 @@ fn merge_segments<V: LsmCell>(
 /// after each merge. Stable state has strictly `> F×` growth oldest→newest, so
 /// the segment count is `O(log_F N)`. Merging the bottom pair GC's tombstones and
 /// can drop a fully-cancelled (empty) segment.
-fn compact<V: LsmCell>(
-    segs: &mut Vec<Segment>,
-    f: u64,
-) {
+fn compact<V: LsmCell>(segs: &mut Vec<Segment>) {
     loop {
         let n = segs.len();
         if n < 2 {
@@ -453,7 +431,7 @@ fn compact<V: LsmCell>(
         // Scan newest pair → oldest; merge the first that is within a tier.
         let mut i = n - 1;
         while i >= 1 {
-            if segs[i - 1].weight <= f.saturating_mul(segs[i].weight) {
+            if segs[i - 1].weight <= F.saturating_mul(segs[i].weight) {
                 let bottom = i == 1;
                 let m = merge_segments::<V>(&segs[i - 1], &segs[i], bottom);
                 let replacement = if m.adds.is_some() || m.tombs.is_some() {
@@ -492,7 +470,7 @@ pub(crate) fn major_compact_layers<V: LsmCell>(snap: &Snapshot<V>) -> Layers<V> 
     // Already a single tombstone-free base (or empty) — nothing to gain.
     if snap.segs.len() <= 1 && snap.segs.first().is_none_or(|s| s.tombs.is_none()) {
         return Layers {
-            segs: clone_segs(&snap.segs),
+            segs: snap.segs.clone(),
             _v: PhantomData,
         };
     }
@@ -718,11 +696,88 @@ mod tests {
         out
     }
 
+    /// The segment matrices must be **hypersparse**. At `DIM = 2^60` any other
+    /// format is fatal: sparse needs an `nrows+1` row-pointer array, bitmap/full
+    /// need `nrows×ncols` cells — both `≈ 2^60`+. Commit a handful of entries at
+    /// rows scattered across the whole band and assert the published matrices
+    /// report `GxB_HYPERSPARSE`, with resident bytes `O(entries)` (not `O(2^60)`).
+    #[test]
+    fn segment_matrices_are_hypersparse() {
+        use crate::graph::graphblas::GxB_HYPERSPARSE;
+        let hyper = GxB_HYPERSPARSE as i32;
+        init();
+
+        // bool (presence) band.
+        let m = LsmMatrix::<bool>::new();
+        m.commit(
+            1,
+            &[0, 1 << 30, 1 << 50, DIM - 1],
+            &[0, 1, 2, 3],
+            &[true, true, true, true],
+            &[1 << 40], // a tombstone run too
+            &[9],
+        );
+        for seg in &m.snapshot().segs {
+            for mat in [seg.adds.as_ref(), seg.tombs.as_ref()]
+                .into_iter()
+                .flatten()
+            {
+                assert_eq!(mat.sparsity_status(), hyper, "bool segment not hypersparse");
+                assert!(
+                    mat.memory_usage() < 64 * 1024,
+                    "resident bytes scale with DIM, not entries"
+                );
+            }
+        }
+
+        // u64 (value-carrying) band.
+        let mu = LsmMatrix::<u64>::new();
+        mu.commit(
+            1,
+            &[0, 1 << 45, DIM - 1],
+            &[0, 1, 2],
+            &[7u64, 9, 11],
+            &[],
+            &[],
+        );
+        for seg in &mu.snapshot().segs {
+            if let Some(adds) = &seg.adds {
+                assert_eq!(adds.sparsity_status(), hyper, "u64 segment not hypersparse");
+                assert!(adds.memory_usage() < 64 * 1024);
+            }
+        }
+
+        // The pin must survive compaction: many equal-weight commits trigger
+        // merges (which `dup` and union segments), and a major compaction folds
+        // everything into one base via `build_run`. All must stay hypersparse.
+        let c = LsmMatrix::<u64>::new();
+        for v in 1..=64u64 {
+            c.commit(v, &[v << 40], &[v], &[v | 1], &[], &[]);
+        }
+        c.major_compact();
+        for seg in &c.snapshot().segs {
+            if let Some(adds) = &seg.adds {
+                assert_eq!(
+                    adds.sparsity_status(),
+                    hyper,
+                    "post-compaction not hypersparse"
+                );
+            }
+        }
+    }
+
     #[test]
     fn add_then_scan() {
         init();
         let m = LsmMatrix::<bool>::new();
-        m.commit(1, &[(10, 100, true), (20, 200, true), (10, 101, true)], &[]);
+        m.commit(
+            1,
+            &[10, 20, 10],
+            &[100, 200, 101],
+            &[true, true, true],
+            &[],
+            &[],
+        );
         let s = m.snapshot();
         assert_eq!(scan(&s, 10, 10), vec![(10, 100, true), (10, 101, true)]);
         assert_eq!(
@@ -736,8 +791,8 @@ mod tests {
     fn tombstone_suppresses_cell() {
         init();
         let m = LsmMatrix::<bool>::new();
-        m.commit(1, &[(10, 100, true), (10, 101, true)], &[]);
-        m.commit(2, &[], &[(10, 100)]); // delete id 100's cell at row 10
+        m.commit(1, &[10, 10], &[100, 101], &[true, true], &[], &[]);
+        m.commit(2, &[], &[], &[], &[10], &[100]); // delete id 100's cell at row 10
         let s = m.snapshot();
         assert_eq!(scan(&s, 10, 10), vec![(10, 101, true)]);
     }
@@ -746,10 +801,10 @@ mod tests {
     fn newest_wins_readd_after_tombstone() {
         init();
         let m = LsmMatrix::<u64>::new();
-        m.commit(1, &[(10, 5, 0xAAAA)], &[]); // id 5 @ row 10, value AAAA
-        m.commit(2, &[], &[(10, 5)]); // delete it
+        m.commit(1, &[10], &[5], &[0xAAAA], &[], &[]); // id 5 @ row 10, value AAAA
+        m.commit(2, &[], &[], &[], &[10], &[5]); // delete it
         // ...later re-add the *same* cell with a new value (update back).
-        m.commit(3, &[(10, 5, 0xBBBB)], &[]);
+        m.commit(3, &[10], &[5], &[0xBBBB], &[], &[]);
         let s = m.snapshot();
         assert_eq!(scan(&s, 10, 10), vec![(10, 5, 0xBBBB)]); // newest (v3 add) wins
     }
@@ -758,8 +813,8 @@ mod tests {
     fn update_moves_to_new_row() {
         init();
         let m = LsmMatrix::<u64>::new();
-        m.commit(1, &[(10, 5, 0x11)], &[]); // id 5 at value-row 10
-        m.commit(2, &[(20, 5, 0x11)], &[(10, 5)]); // update: tomb old row, add new row
+        m.commit(1, &[10], &[5], &[0x11], &[], &[]); // id 5 at value-row 10
+        m.commit(2, &[20], &[5], &[0x11], &[10], &[5]); // update: tomb old, add new
         let s = m.snapshot();
         assert_eq!(scan(&s, 0, 100), vec![(20, 5, 0x11)]);
         assert_eq!(scan(&s, 10, 10), vec![]); // old row vacated
@@ -770,9 +825,9 @@ mod tests {
         init();
         let m = LsmMatrix::<bool>::new();
         // out-of-order commits; compaction merges them into the base.
-        m.commit(1, &[(50, 1, true)], &[]);
-        m.commit(2, &[(10, 2, true)], &[]);
-        m.commit(3, &[(30, 3, true)], &[]);
+        m.commit(1, &[50], &[1], &[true], &[], &[]);
+        m.commit(2, &[10], &[2], &[true], &[], &[]);
+        m.commit(3, &[30], &[3], &[true], &[], &[]);
         assert_eq!(
             m.seg_count(),
             1,
@@ -790,10 +845,10 @@ mod tests {
     fn snapshot_isolated_from_later_commits_and_deletes() {
         init();
         let m = LsmMatrix::<bool>::new();
-        m.commit(1, &[(10, 1, true)], &[]);
+        m.commit(1, &[10], &[1], &[true], &[], &[]);
         let old = m.snapshot(); // pin version 1
-        m.commit(2, &[(20, 2, true)], &[]); // add
-        m.commit(3, &[], &[(10, 1)]); // delete the cell the old snapshot sees
+        m.commit(2, &[20], &[2], &[true], &[], &[]); // add
+        m.commit(3, &[], &[], &[], &[10], &[1]); // delete the cell the old snapshot sees
         let new = m.snapshot();
         // Old reader: unaffected by the add or the delete.
         assert_eq!(scan(&old, 0, 100), vec![(10, 1, true)]);
@@ -808,7 +863,7 @@ mod tests {
         let m = LsmMatrix::<bool>::new();
         const N: u64 = 4_096; // 2^12 equal-weight commits
         for v in 1..=N {
-            m.commit(v, &[(v, v, true)], &[]);
+            m.commit(v, &[v], &[v], &[true], &[], &[]);
         }
         // 2^12 unit segments → binary-counter merges → ~log2(N) segments.
         assert!(
@@ -831,20 +886,17 @@ mod tests {
         let mut version = 0u64;
         // round 0: initial placement at row = id.
         let mut cur_row: Vec<u64> = (0..DOCS).collect();
+        let cols: Vec<u64> = (0..DOCS).collect();
         version += 1;
-        let adds: Vec<_> = (0..DOCS)
-            .map(|d| (cur_row[d as usize], d, version))
-            .collect();
-        m.commit(version, &adds, &[]);
+        let vals = vec![version; DOCS as usize];
+        m.commit(version, &cur_row, &cols, &vals, &[], &[]);
 
         for round in 1..200u64 {
             version += 1;
             let new_row: Vec<u64> = (0..DOCS).map(|d| 1000 + round * DOCS + d).collect();
-            let adds: Vec<_> = (0..DOCS)
-                .map(|d| (new_row[d as usize], d, version))
-                .collect();
-            let tombs: Vec<_> = (0..DOCS).map(|d| (cur_row[d as usize], d)).collect();
-            m.commit(version, &adds, &tombs);
+            let vals = vec![version; DOCS as usize];
+            // adds at new rows, tombstones at the old rows — same ids (cols).
+            m.commit(version, &new_row, &cols, &vals, &cur_row, &cols);
             cur_row = new_row;
         }
 
@@ -875,14 +927,14 @@ mod tests {
         init();
         let m = LsmMatrix::<u64>::new();
         for v in 1..=10u64 {
-            m.commit(v, &[(v, v, v)], &[]);
+            m.commit(v, &[v], &[v], &[v], &[], &[]);
         }
         let pinned = m.snapshot();
         let before = scan(&pinned, 0, 1000);
         assert_eq!(before.len(), 10);
         // Heavy churn + compaction after the pin.
         for v in 11..=2_000u64 {
-            m.commit(v, &[(v, v, v)], &[(v - 10, v - 10)]);
+            m.commit(v, &[v], &[v], &[v], &[v - 10], &[v - 10]);
         }
         // The pinned snapshot is byte-for-byte unchanged.
         assert_eq!(scan(&pinned, 0, 1000), before);
@@ -911,24 +963,39 @@ mod tests {
             let version = step; // versions are strictly increasing → newest = highest
             // Build this commit's 0..7 random ops, mirroring each into the model.
             let n = (sm64(step) % 8) as usize;
-            let mut adds: Vec<(u64, u64, u64)> = Vec::new();
-            let mut tombs: Vec<(u64, u64)> = Vec::new();
+            // A commit can touch the same cell twice; collapse to its last op (a
+            // run holds each cell once) in a map, then emit it structure-of-arrays.
+            let mut ops: BTreeMap<(u64, u64), Option<u64>> = BTreeMap::new();
             for k in 0..n {
                 let h = sm64(step.wrapping_mul(131) ^ k as u64);
                 let (row, col) = (h % ROWS, (h >> 16) % COLS);
-                if h & 1 == 0 {
-                    let val = h | 1; // force nonzero so a value is never mistaken for absent
-                    adds.push((row, col, val));
-                    model.insert((row, col), (version, Some(val)));
-                } else {
-                    tombs.push((row, col));
-                    model.insert((row, col), (version, None));
+                // force nonzero so a value is never mistaken for absent
+                let op = if h & 1 == 0 { Some(h | 1) } else { None };
+                ops.insert((row, col), op);
+                model.insert((row, col), (version, op));
+            }
+            let (mut add_rows, mut add_cols, mut add_vals) = (Vec::new(), Vec::new(), Vec::new());
+            let (mut tomb_rows, mut tomb_cols) = (Vec::new(), Vec::new());
+            for (&(row, col), op) in &ops {
+                match op {
+                    Some(v) => {
+                        add_rows.push(row);
+                        add_cols.push(col);
+                        add_vals.push(*v);
+                    }
+                    None => {
+                        tomb_rows.push(row);
+                        tomb_cols.push(col);
+                    }
                 }
             }
-            // A commit can touch the same cell twice; collapse to its last op so
-            // the run (which holds each cell once) matches the model.
-            dedup_last(&mut adds, &mut tombs);
-            m.commit(version, &adds, &tombs);
+            // The store never publishes an empty version (see `commit`'s
+            // debug_assert); a no-op step changes nothing, so just skip it.
+            if !(add_rows.is_empty() && tomb_rows.is_empty()) {
+                m.commit(
+                    version, &add_rows, &add_cols, &add_vals, &tomb_rows, &tomb_cols,
+                );
+            }
 
             // Periodically verify random sub-ranges scan exactly the model's live
             // cells in that row range.
@@ -959,19 +1026,15 @@ mod tests {
         let m = LsmMatrix::<u64>::new();
         let mut version = 0u64;
         let mut cur_row: Vec<u64> = (0..40).collect();
+        let cols: Vec<u64> = (0..40).collect();
+        let vals: Vec<u64> = (0..40u64).map(|d| d | 1).collect();
         version += 1;
-        let adds: Vec<_> = (0..40u64)
-            .map(|d| (cur_row[d as usize], d, d | 1))
-            .collect();
-        m.commit(version, &adds, &[]);
+        m.commit(version, &cur_row, &cols, &vals, &[], &[]);
         for round in 1..60u64 {
             version += 1;
             let new_row: Vec<u64> = (0..40).map(|d| 1000 + round * 40 + d).collect();
-            let adds: Vec<_> = (0..40u64)
-                .map(|d| (new_row[d as usize], d, d | 1))
-                .collect();
-            let tombs: Vec<_> = (0..40u64).map(|d| (cur_row[d as usize], d)).collect();
-            m.commit(version, &adds, &tombs);
+            // adds at new rows, tombstones at the old rows — same ids (cols).
+            m.commit(version, &new_row, &cols, &vals, &cur_row, &cols);
             cur_row = new_row;
         }
         let before = scan(&m.snapshot(), 0, u64::MAX >> 4);
@@ -1033,36 +1096,12 @@ mod tests {
             .collect();
 
         for v in 1..=N {
-            m.commit(v, &[(v, v, v)], &[]);
+            m.commit(v, &[v], &[v], &[v], &[], &[]);
         }
         done.store(true, Ordering::Relaxed);
         for r in readers {
             r.join().unwrap();
         }
         assert_eq!(scan(&m.snapshot(), 0, N).len(), N as usize);
-    }
-
-    /// Within one commit a cell can appear at most once (runs hold unique cells);
-    /// collapse to the last op per cell so the run build and the reference agree.
-    fn dedup_last(
-        adds: &mut Vec<(u64, u64, u64)>,
-        tombs: &mut Vec<(u64, u64)>,
-    ) {
-        use std::collections::HashMap;
-        let mut last: HashMap<(u64, u64), Option<u64>> = HashMap::new();
-        for &(r, c, v) in adds.iter() {
-            last.insert((r, c), Some(v));
-        }
-        for &(r, c) in tombs.iter() {
-            last.insert((r, c), None);
-        }
-        adds.clear();
-        tombs.clear();
-        for ((r, c), v) in last {
-            match v {
-                Some(v) => adds.push((r, c, v)),
-                None => tombs.push((r, c)),
-            }
-        }
     }
 }

--- a/graph/src/graph/graphblas/lsm/mod.rs
+++ b/graph/src/graph/graphblas/lsm/mod.rs
@@ -1,0 +1,1068 @@
+//! Log-structured matrix — the LSM core + compaction.
+//!
+//! An **append-only list of immutable segments**: a commit *appends* one small
+//! immutable segment; it never mutates or copies anything that grows. MVCC
+//! isolation comes from immutability — published segments are frozen and
+//! `Arc`-shared, so a reader's pinned snapshot is stable while later commits add
+//! (or compact) segments.
+//!
+//! ```text
+//!   one band (rows = encoded-key low 60 bits, cols = id), newest segment last
+//!     Segment { adds: Matrix<V>,  tombs: Matrix<bool>,  version, weight }   ...
+//!
+//!   effective = ⋃ seg.adds  −  ⋃ seg.tombs            (newest version wins per cell)
+//! ```
+//!
+//! The oldest segment (`segs[0]`) is the "base": tombstones there suppress nothing
+//! older, so a bottom-merge **drops** them (tombstone GC).
+//!
+//! - **Reads** — a lazy k-way merge over the segments with newest-wins per
+//!   cell (see [`LsmCursor`]); this computes `(⋃ adds) − (⋃ tombs)`.
+//! - **Compaction** — after each append, adjacent segments closer than a
+//!   geometric factor `F` are merged ([`compact`]). This keeps the segment count
+//!   `O(log N)` (bounded read amplification) and gives amortized `O(N log N)`
+//!   ingest, insert-order-independent.
+
+/// The value→id banded store built on this log-structured matrix.
+pub(crate) mod store;
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::graph::graphblas::matrix::{Dup, MaskedElementWiseAdd, Matrix, New, Size};
+
+/// One band's matrix dimension: `2^60`. Rows are an encoded key's low 60 bits,
+/// columns are ids — both `< 2^60` (GraphBLAS's index ceiling). Banding (the
+/// high 4 bits) is handled one level up, in the store; a single
+/// [`LsmMatrix`] is one band.
+const DIM: u64 = 1 << 60;
+
+/// Compaction fan-out: adjacent segments are merged while the older is no more
+/// than `F×` the newer (i.e. they are within the same size tier). Stable state
+/// therefore has each segment `> F×` the next-newer one, so weights grow
+/// geometrically and the segment count is `O(log_F N)`. `F = 2` balances read
+/// amplification (segment count) against write amplification (merge work).
+const F: u64 = 2;
+
+/// Cell type of an LSM matrix: presence (`bool`) or value-carrying (`u64`,
+/// packing a caller payload). Provides the type-specific GraphBLAS primitives the
+/// LSM needs — build a run, scan it, an empty matrix, and a value-preserving
+/// union. Local to this module.
+pub(crate) trait LsmCell: Copy + Send + Sync + 'static {
+    /// Bulk-build an immutable run matrix from `(rows, cols, vals)`. Entries are
+    /// unique per run (an id is added once per row in a commit), so no dup
+    /// resolution is needed. GraphBLAS sorts internally — hence ingest is
+    /// insert-order-independent.
+    fn build_run(
+        rows: &[u64],
+        cols: &[u64],
+        vals: &[Self],
+    ) -> Matrix;
+
+    /// Iterate the run's cells whose row is in `[lo, hi]`, yielding
+    /// `(row, col, value)`. For `bool` the value is presence (`true`).
+    fn scan(
+        m: &Matrix,
+        lo: u64,
+        hi: u64,
+    ) -> Box<dyn Iterator<Item = (u64, u64, Self)> + Send>;
+
+    /// An empty matrix of this cell type, full band dimensions.
+    fn empty() -> Matrix;
+
+    /// `dst = dst ∪ src`, preserving values; on a cell conflict `src` (the newer
+    /// run) wins. Used to fold a newer segment's adds into an older one.
+    fn union_into(
+        dst: &mut Matrix,
+        src: &Matrix,
+    );
+}
+
+impl LsmCell for bool {
+    fn build_run(
+        rows: &[u64],
+        cols: &[u64],
+        _vals: &[Self],
+    ) -> Matrix {
+        let mut m = Matrix::new(DIM, DIM);
+        if !rows.is_empty() {
+            m.build_bool(rows, cols);
+        }
+        m
+    }
+
+    fn scan(
+        m: &Matrix,
+        lo: u64,
+        hi: u64,
+    ) -> Box<dyn Iterator<Item = (u64, u64, Self)> + Send> {
+        Box::new(m.iter(lo, hi).map(|(r, c)| (r, c, true)))
+    }
+
+    fn empty() -> Matrix {
+        Matrix::new(DIM, DIM)
+    }
+
+    fn union_into(
+        dst: &mut Matrix,
+        src: &Matrix,
+    ) {
+        // PAIR/BOOL presence union — value is always `true`, so newer-wins is moot.
+        dst.element_wise_add(None, None, Some(src), None);
+    }
+}
+
+/// Generate a [`LsmCell`] impl for a **value-carrying** cell type by wiring its
+/// `Matrix` primitives: the typed constructor `$new`, bulk builder `$build`,
+/// value-reading range scan `$iter`, and value-preserving union `$union` (a
+/// `SECOND` semiring, so the newer run wins a conflicting cell). Presence
+/// (`bool`) is the special case implemented explicitly above; every value type
+/// shares this shape, so adding one (`f64`, `i64`, …) is one line here plus its
+/// matching `Matrix` primitives.
+macro_rules! impl_valued_lsm_cell {
+    ($t:ty, $new:ident, $build:ident, $iter:ident, $union:ident) => {
+        impl LsmCell for $t {
+            fn build_run(
+                rows: &[u64],
+                cols: &[u64],
+                vals: &[Self],
+            ) -> Matrix {
+                let mut m = Matrix::$new(DIM, DIM);
+                if !rows.is_empty() {
+                    m.$build(rows, cols, vals);
+                }
+                m
+            }
+
+            fn scan(
+                m: &Matrix,
+                lo: u64,
+                hi: u64,
+            ) -> Box<dyn Iterator<Item = (u64, u64, Self)> + Send> {
+                Box::new(m.$iter(lo, hi))
+            }
+
+            fn empty() -> Matrix {
+                Matrix::$new(DIM, DIM)
+            }
+
+            fn union_into(
+                dst: &mut Matrix,
+                src: &Matrix,
+            ) {
+                dst.$union(src);
+            }
+        }
+    };
+}
+
+impl_valued_lsm_cell!(
+    u64,
+    new_uint64,
+    build_uint64,
+    iter_values,
+    element_wise_add_uint64
+);
+
+/// One immutable segment: a commit's (or a merge's) net add/tombstone runs.
+/// `adds`/`tombs` are `None` when empty. `weight ≈ nnz(adds) + nnz(tombs)` drives
+/// the compaction tiering. `version` orders segments for newest-wins reads.
+struct Segment {
+    version: u64,
+    adds: Option<Arc<Matrix>>,
+    tombs: Option<Arc<Matrix>>,
+    weight: u64,
+}
+
+/// One published, immutable version of a band: a version-ordered segment list
+/// (oldest first; `segs[0]` is the base). Everything is `Arc`-shared and never
+/// mutated after publish, so a reader holding this is fully isolated from later
+/// commits and compactions.
+pub(crate) struct Layers<V: LsmCell> {
+    segs: Vec<Segment>,
+    _v: PhantomData<V>,
+}
+
+// `Layers`/`LsmMatrix`/`LsmCursor` hold GraphBLAS matrices behind `Arc`; they are
+// immutable once published and only read concurrently, so sharing is safe.
+unsafe impl<V: LsmCell> Send for Layers<V> {}
+unsafe impl<V: LsmCell> Sync for Layers<V> {}
+
+impl<V: LsmCell> Layers<V> {
+    /// An empty band version (no segments).
+    pub(crate) fn empty() -> Self {
+        Layers {
+            segs: Vec::new(),
+            _v: PhantomData,
+        }
+    }
+
+    /// Approximate resident bytes across this band's segment matrices.
+    pub(crate) fn memory_usage(&self) -> usize {
+        self.segs
+            .iter()
+            .map(|s| {
+                s.adds.as_ref().map_or(0, |m| m.memory_usage())
+                    + s.tombs.as_ref().map_or(0, |m| m.memory_usage())
+            })
+            .sum()
+    }
+}
+
+/// Apply one commit's changes to a band, returning the new immutable version:
+/// append a segment for `(adds, tombs)` and compact. Pure (no lock) so the
+/// multi-band store can drive all bands under its own single lock. `adds` are
+/// `(row, col, value)` cells; `tombs` are `(row, col)` cells to suppress. The
+/// result shares all untouched old segments with `cur` by `Arc`.
+///
+/// Compaction runs **synchronously** on the commit here, so a writer pays the
+/// (amortized `O(log N)`) merge cost inline. Moving it to a background thread —
+/// the writer only appends, a compactor merges and republishes — is a write-path
+/// optimization left for later.
+pub(crate) fn commit_layers<V: LsmCell>(
+    cur: &Layers<V>,
+    version: u64,
+    adds: &[(u64, u64, V)],
+    tombs: &[(u64, u64)],
+) -> Layers<V> {
+    commit_layers_f(cur, version, adds, tombs, F)
+}
+
+/// [`commit_layers`] with an explicit compaction fan-out `f` (tuning/probe knob).
+fn commit_layers_f<V: LsmCell>(
+    cur: &Layers<V>,
+    version: u64,
+    adds: &[(u64, u64, V)],
+    tombs: &[(u64, u64)],
+    f: u64,
+) -> Layers<V> {
+    let adds_m = (!adds.is_empty()).then(|| {
+        let mut rows = Vec::with_capacity(adds.len());
+        let mut cols = Vec::with_capacity(adds.len());
+        let mut vals = Vec::with_capacity(adds.len());
+        for &(r, c, v) in adds {
+            rows.push(r);
+            cols.push(c);
+            vals.push(v);
+        }
+        Arc::new(V::build_run(&rows, &cols, &vals))
+    });
+    let tombs_m = (!tombs.is_empty()).then(|| {
+        let mut rows = Vec::with_capacity(tombs.len());
+        let mut cols = Vec::with_capacity(tombs.len());
+        for &(r, c) in tombs {
+            rows.push(r);
+            cols.push(c);
+        }
+        Arc::new(<bool as LsmCell>::build_run(&rows, &cols, &[]))
+    });
+
+    let mut segs = clone_segs(&cur.segs);
+    if adds_m.is_some() || tombs_m.is_some() {
+        segs.push(Segment {
+            version,
+            adds: adds_m,
+            tombs: tombs_m,
+            weight: adds.len() as u64 + tombs.len() as u64,
+        });
+        compact::<V>(&mut segs, f);
+    }
+    Layers {
+        segs,
+        _v: PhantomData,
+    }
+}
+
+/// A published snapshot of one band — what a reader pins.
+pub(crate) type Snapshot<V> = Arc<Layers<V>>;
+
+/// One band's log-structured matrix: a single published [`Layers`] swapped under
+/// a lock on commit. Readers clone the `Arc` (lock-free after); the writer builds
+/// new immutable segments and publishes a new `Layers` that shares the untouched
+/// old segments by `Arc`.
+pub(crate) struct LsmMatrix<V: LsmCell> {
+    committed: RwLock<Snapshot<V>>,
+}
+
+impl<V: LsmCell> Default for LsmMatrix<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: LsmCell> LsmMatrix<V> {
+    /// An empty band.
+    pub(crate) fn new() -> Self {
+        Self {
+            committed: RwLock::new(Arc::new(Layers {
+                segs: Vec::new(),
+                _v: PhantomData,
+            })),
+        }
+    }
+
+    /// Pin the latest published version — the immutable view a reader scans.
+    pub(crate) fn snapshot(&self) -> Snapshot<V> {
+        Arc::clone(&self.committed.read())
+    }
+
+    /// Append one commit's changes as a new immutable segment, run compaction,
+    /// and publish. `adds` are `(row, col, value)` cells; `tombs` are
+    /// `(row, col)` cells to suppress (the caller — the store — resolves id
+    /// deletes/updates into the exact old cells). The new version shares all
+    /// untouched old segments by `Arc`; only the small segment list is cloned, so
+    /// a quiet commit is `O(this commit's changes)` and a compacting commit pays
+    /// `O(merged nnz)` (amortized `O(log N)` per element).
+    pub(crate) fn commit(
+        &self,
+        version: u64,
+        adds: &[(u64, u64, V)],
+        tombs: &[(u64, u64)],
+    ) {
+        if adds.is_empty() && tombs.is_empty() {
+            return; // empty commit — nothing to publish
+        }
+        let cur = self.committed.read().clone();
+        let next = commit_layers::<V>(&cur, version, adds, tombs);
+        *self.committed.write() = Arc::new(next);
+    }
+
+    /// [`commit`] with an explicit compaction fan-out `f` (test/probe knob).
+    #[cfg(test)]
+    pub(crate) fn commit_f(
+        &self,
+        version: u64,
+        adds: &[(u64, u64, V)],
+        tombs: &[(u64, u64)],
+        f: u64,
+    ) {
+        if adds.is_empty() && tombs.is_empty() {
+            return;
+        }
+        let cur = self.committed.read().clone();
+        let next = commit_layers_f::<V>(&cur, version, adds, tombs, f);
+        *self.committed.write() = Arc::new(next);
+    }
+
+    /// Collapse all segments into a single tombstone-free base (see
+    /// [`major_compact_layers`]). Publishes a new version; pinned readers keep
+    /// their old segments.
+    pub(crate) fn major_compact(&self) {
+        let cur = self.committed.read().clone();
+        let next = major_compact_layers::<V>(&cur);
+        *self.committed.write() = Arc::new(next);
+    }
+
+    /// Number of live segments. Bounded to `O(log N)` by compaction.
+    #[cfg(test)]
+    pub(crate) fn seg_count(&self) -> usize {
+        self.committed.read().segs.len()
+    }
+
+    /// Sum of segment weights — a proxy for resident cells (memory). Used by the
+    /// tombstone-GC test to confirm churn doesn't grow the structure unboundedly.
+    #[cfg(test)]
+    pub(crate) fn total_weight(&self) -> u64 {
+        self.committed.read().segs.iter().map(|s| s.weight).sum()
+    }
+}
+
+/// Shallow-clone the segment list (each `Segment` shares its matrices by `Arc`).
+fn clone_segs(segs: &[Segment]) -> Vec<Segment> {
+    segs.iter()
+        .map(|s| Segment {
+            version: s.version,
+            adds: s.adds.clone(),
+            tombs: s.tombs.clone(),
+            weight: s.weight,
+        })
+        .collect()
+}
+
+/// Merge two adjacent segments `a` (older) and `b` (newer) into one, applying
+/// newest-wins:
+///
+/// ```text
+///   adds  = (a.adds ∪ b.adds[newer wins]) − b.tombs
+///   tombs = (a.tombs ∪ b.tombs)           − b.adds      (dropped if `bottom`)
+/// ```
+///
+/// `a.adds`/`a.tombs` are `Arc`-shared and never mutated — we `dup` `a` and fold
+/// `b` into the copy, leaving the originals intact for older readers. When `a` is
+/// the bottom segment (`segs[0]`), its merged tombstones suppress nothing older,
+/// so they are GC'd (`bottom = true`).
+fn merge_segments<V: LsmCell>(
+    a: &Segment,
+    b: &Segment,
+    bottom: bool,
+) -> Segment {
+    // adds = (a.adds ∪ b.adds) − b.tombs
+    let mut add = a.adds.as_ref().map_or_else(V::empty, |m| m.dup());
+    if let Some(ba) = &b.adds {
+        V::union_into(&mut add, ba);
+    }
+    if let Some(bt) = &b.tombs {
+        add.remove_all(bt);
+    }
+    let add_n = add.nvals();
+    let adds = (add_n > 0).then(|| Arc::new(add));
+
+    // tombs = (a.tombs ∪ b.tombs) − b.adds ; dropped at the bottom (nothing older).
+    let (tombs, tomb_n) = if bottom {
+        (None, 0)
+    } else {
+        let mut t = a
+            .tombs
+            .as_ref()
+            .map_or_else(|| Matrix::new(DIM, DIM), |m| m.dup());
+        if let Some(bt) = &b.tombs {
+            t.element_wise_add(None, None, Some(bt), None);
+        }
+        if let Some(ba) = &b.adds {
+            t.remove_all(ba);
+        }
+        let n = t.nvals();
+        ((n > 0).then(|| Arc::new(t)), n)
+    };
+
+    Segment {
+        version: b.version,
+        adds,
+        tombs,
+        weight: add_n + tomb_n,
+    }
+}
+
+/// Size-tiered compaction. After an append, repeatedly merge the newest adjacent
+/// pair whose older segment is within `F×` the newer (same tier), restarting
+/// after each merge. Stable state has strictly `> F×` growth oldest→newest, so
+/// the segment count is `O(log_F N)`. Merging the bottom pair GC's tombstones and
+/// can drop a fully-cancelled (empty) segment.
+fn compact<V: LsmCell>(
+    segs: &mut Vec<Segment>,
+    f: u64,
+) {
+    loop {
+        let n = segs.len();
+        if n < 2 {
+            return;
+        }
+        let mut merged = false;
+        // Scan newest pair → oldest; merge the first that is within a tier.
+        let mut i = n - 1;
+        while i >= 1 {
+            if segs[i - 1].weight <= f.saturating_mul(segs[i].weight) {
+                let bottom = i == 1;
+                let m = merge_segments::<V>(&segs[i - 1], &segs[i], bottom);
+                let replacement = if m.adds.is_some() || m.tombs.is_some() {
+                    vec![m]
+                } else {
+                    Vec::new() // both runs fully cancelled — drop the segment
+                };
+                segs.splice(i - 1..=i, replacement);
+                merged = true;
+                break;
+            }
+            i -= 1;
+        }
+        if !merged {
+            return;
+        }
+    }
+}
+
+/// **Major compaction**: collapse a band's entire segment list into a single
+/// tombstone-free base. Where [`compact`] (minor, per-commit) only bounds the run
+/// count to `O(log N)` — leaving several matrices per band (k-way read merge) —
+/// this folds *everything* into one matrix: all tombstones applied and dropped,
+/// superseded cells resolved.
+///
+/// Implemented as **one k-way merge**, not a pairwise fold: the [`LsmCursor`]
+/// already merges all segments newest-wins and applies tombstones, yielding the
+/// effective live cells in `(row, col)` order in `O(N log K)` (`K` = segment
+/// count); we collect them and `build` one matrix in `O(N)`. (A naive
+/// fold-into-a-growing-accumulator would be `O(N·K)` — quadratic in the segment
+/// count, catastrophic when compaction was deferred during a bulk load.)
+///
+/// MVCC-safe: returns a new immutable [`Layers`]; readers pinned to the old
+/// snapshot keep their segments until they drop.
+pub(crate) fn major_compact_layers<V: LsmCell>(snap: &Snapshot<V>) -> Layers<V> {
+    // Already a single tombstone-free base (or empty) — nothing to gain.
+    if snap.segs.len() <= 1 && snap.segs.first().is_none_or(|s| s.tombs.is_none()) {
+        return Layers {
+            segs: clone_segs(&snap.segs),
+            _v: PhantomData,
+        };
+    }
+    let version = snap.segs.last().map_or(0, |s| s.version);
+    let mut cursor = LsmCursor::new(Arc::clone(snap), 0, DIM - 1);
+    let (mut rows, mut cols, mut vals) = (Vec::new(), Vec::new(), Vec::new());
+    while let Some((r, c, v)) = cursor.next_cell() {
+        rows.push(r);
+        cols.push(c);
+        vals.push(v);
+    }
+    let segs = if rows.is_empty() {
+        Vec::new()
+    } else {
+        let weight = rows.len() as u64;
+        vec![Segment {
+            version,
+            adds: Some(Arc::new(V::build_run(&rows, &cols, &vals))),
+            tombs: None,
+            weight,
+        }]
+    };
+    Layers {
+        segs,
+        _v: PhantomData,
+    }
+}
+
+/// One source's current front in the merge heap: the smallest `(row, col)` it
+/// has not yet emitted, tagged with the segment's `version` (for newest-wins) and
+/// the source index `src` (to advance it after popping). `value` is `Some` for an
+/// add run, `None` for a tombstone. Ordered by `(row, col)` only — `version`/
+/// `value` are resolved when popping equal cells, so they're excluded from `Ord`.
+struct Entry<V> {
+    row: u64,
+    col: u64,
+    version: u64,
+    value: Option<V>,
+    src: usize,
+}
+
+impl<V> PartialEq for Entry<V> {
+    fn eq(
+        &self,
+        other: &Self,
+    ) -> bool {
+        (self.row, self.col) == (other.row, other.col)
+    }
+}
+impl<V> Eq for Entry<V> {}
+impl<V> PartialOrd for Entry<V> {
+    fn partial_cmp(
+        &self,
+        other: &Self,
+    ) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<V> Ord for Entry<V> {
+    fn cmp(
+        &self,
+        other: &Self,
+    ) -> std::cmp::Ordering {
+        (self.row, self.col).cmp(&(other.row, other.col))
+    }
+}
+
+/// Lazy k-way merge over one band's segments for the inclusive row range
+/// `[lo, hi]`. For each `(row, col)` the **newest** source wins: an add yields the
+/// cell live, a tombstone suppresses it.
+///
+/// Uses a **binary min-heap** keyed by `(row, col)`: each step pops the smallest
+/// cell and re-pushes the advanced source's next front — `O(log K)` per emitted
+/// cell (`K` = live segment streams), versus a linear scan of all `K` fronts
+/// (`O(K)`). This keeps reads cheap even with many segments, which is what lets
+/// compaction be less aggressive. Owns the pinned [`Snapshot`] (so it is `Send`
+/// and reclaims by `Arc`-drop).
+pub(crate) struct LsmCursor<V: LsmCell> {
+    _snap: Snapshot<V>,
+    /// One boxed iterator per source (add or tomb run), indexed by `src`.
+    iters: Vec<Box<dyn Iterator<Item = (u64, u64, Option<V>)> + Send>>,
+    /// Segment version of each source (parallel to `iters`).
+    versions: Vec<u64>,
+    /// Min-heap of each source's current front (`Reverse` flips the max-heap).
+    heap: std::collections::BinaryHeap<std::cmp::Reverse<Entry<V>>>,
+}
+
+unsafe impl<V: LsmCell> Send for LsmCursor<V> {}
+
+impl<V: LsmCell> LsmCursor<V> {
+    pub(crate) fn new(
+        snap: Snapshot<V>,
+        lo: u64,
+        hi: u64,
+    ) -> Self {
+        let mut iters: Vec<Box<dyn Iterator<Item = (u64, u64, Option<V>)> + Send>> = Vec::new();
+        let mut versions: Vec<u64> = Vec::new();
+        if lo <= hi {
+            for seg in &snap.segs {
+                if let Some(m) = &seg.adds {
+                    iters.push(Box::new(
+                        V::scan(m, lo, hi).map(|(r, c, v)| (r, c, Some(v))),
+                    ));
+                    versions.push(seg.version);
+                }
+                if let Some(m) = &seg.tombs {
+                    iters.push(Box::new(
+                        <bool as LsmCell>::scan(m, lo, hi).map(|(r, c, _)| (r, c, None)),
+                    ));
+                    versions.push(seg.version);
+                }
+            }
+        }
+        let mut heap = std::collections::BinaryHeap::with_capacity(iters.len());
+        for src in 0..iters.len() {
+            if let Some((row, col, value)) = iters[src].next() {
+                heap.push(std::cmp::Reverse(Entry {
+                    row,
+                    col,
+                    version: versions[src],
+                    value,
+                    src,
+                }));
+            }
+        }
+        Self {
+            _snap: snap,
+            iters,
+            versions,
+            heap,
+        }
+    }
+
+    /// Pull the next item from source `src` and re-push its front onto the heap.
+    fn advance(
+        &mut self,
+        src: usize,
+    ) {
+        if let Some((row, col, value)) = self.iters[src].next() {
+            self.heap.push(std::cmp::Reverse(Entry {
+                row,
+                col,
+                version: self.versions[src],
+                value,
+                src,
+            }));
+        }
+    }
+
+    /// The next live cell `(row, col, value)` in range, or `None` when exhausted.
+    pub(crate) fn next_cell(&mut self) -> Option<(u64, u64, V)> {
+        loop {
+            // Pop the globally smallest (row, col).
+            let std::cmp::Reverse(first) = self.heap.pop()?;
+            let (row, col) = (first.row, first.col);
+            let mut best_ver = first.version;
+            let mut best_val = first.value;
+            self.advance(first.src);
+
+            // Resolve all other sources at the same cell: newest version wins.
+            while let Some(&std::cmp::Reverse(Entry {
+                row: pr, col: pc, ..
+            })) = self.heap.peek()
+            {
+                if (pr, pc) != (row, col) {
+                    break;
+                }
+                let std::cmp::Reverse(e) = self.heap.pop().unwrap();
+                // Two sources at the same cell with the *same* version means one
+                // commit both added and tombstoned that cell — the caller must
+                // resolve that before commit, or newest-wins here is ambiguous
+                // (heap pop order would decide). Guard the invariant.
+                debug_assert_ne!(
+                    e.version, best_ver,
+                    "add+tombstone of the same cell at one version: {row},{col}"
+                );
+                if e.version >= best_ver {
+                    best_ver = e.version;
+                    best_val = e.value;
+                }
+                self.advance(e.src);
+            }
+
+            if let Some(val) = best_val {
+                return Some((row, col, val));
+            }
+            // Newest was a tombstone → cell is dead; keep merging.
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn init() {
+        crate::graph::graphblas::test_init_graphblas();
+    }
+
+    /// splitmix64 — deterministic pseudo-randomness, no `rand` dep.
+    fn sm64(mut z: u64) -> u64 {
+        z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Collect `(row, col, value)` cells in `[lo, hi]` from a snapshot, sorted
+    /// lexicographically by `(row, col, value)` so assertions can compare against
+    /// a fixed expected order.
+    fn scan<V: LsmCell + Ord>(
+        snap: &Snapshot<V>,
+        lo: u64,
+        hi: u64,
+    ) -> Vec<(u64, u64, V)> {
+        let mut c = LsmCursor::new(Arc::clone(snap), lo, hi);
+        let mut out = Vec::new();
+        while let Some(cell) = c.next_cell() {
+            out.push(cell);
+        }
+        out.sort_unstable();
+        out
+    }
+
+    #[test]
+    fn add_then_scan() {
+        init();
+        let m = LsmMatrix::<bool>::new();
+        m.commit(1, &[(10, 100, true), (20, 200, true), (10, 101, true)], &[]);
+        let s = m.snapshot();
+        assert_eq!(scan(&s, 10, 10), vec![(10, 100, true), (10, 101, true)]);
+        assert_eq!(
+            scan(&s, 0, 100),
+            vec![(10, 100, true), (10, 101, true), (20, 200, true)]
+        );
+        assert_eq!(scan(&s, 11, 19), vec![]);
+    }
+
+    #[test]
+    fn tombstone_suppresses_cell() {
+        init();
+        let m = LsmMatrix::<bool>::new();
+        m.commit(1, &[(10, 100, true), (10, 101, true)], &[]);
+        m.commit(2, &[], &[(10, 100)]); // delete id 100's cell at row 10
+        let s = m.snapshot();
+        assert_eq!(scan(&s, 10, 10), vec![(10, 101, true)]);
+    }
+
+    #[test]
+    fn newest_wins_readd_after_tombstone() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        m.commit(1, &[(10, 5, 0xAAAA)], &[]); // id 5 @ row 10, value AAAA
+        m.commit(2, &[], &[(10, 5)]); // delete it
+        // ...later re-add the *same* cell with a new value (update back).
+        m.commit(3, &[(10, 5, 0xBBBB)], &[]);
+        let s = m.snapshot();
+        assert_eq!(scan(&s, 10, 10), vec![(10, 5, 0xBBBB)]); // newest (v3 add) wins
+    }
+
+    #[test]
+    fn update_moves_to_new_row() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        m.commit(1, &[(10, 5, 0x11)], &[]); // id 5 at value-row 10
+        m.commit(2, &[(20, 5, 0x11)], &[(10, 5)]); // update: tomb old row, add new row
+        let s = m.snapshot();
+        assert_eq!(scan(&s, 0, 100), vec![(20, 5, 0x11)]);
+        assert_eq!(scan(&s, 10, 10), vec![]); // old row vacated
+    }
+
+    #[test]
+    fn compaction_merges_and_preserves_results() {
+        init();
+        let m = LsmMatrix::<bool>::new();
+        // out-of-order commits; compaction merges them into the base.
+        m.commit(1, &[(50, 1, true)], &[]);
+        m.commit(2, &[(10, 2, true)], &[]);
+        m.commit(3, &[(30, 3, true)], &[]);
+        assert_eq!(
+            m.seg_count(),
+            1,
+            "equal-weight commits collapse to one segment"
+        );
+        let s = m.snapshot();
+        assert_eq!(scan(&s, 10, 30), vec![(10, 2, true), (30, 3, true)]);
+        assert_eq!(
+            scan(&s, 0, 100),
+            vec![(10, 2, true), (30, 3, true), (50, 1, true)]
+        );
+    }
+
+    #[test]
+    fn snapshot_isolated_from_later_commits_and_deletes() {
+        init();
+        let m = LsmMatrix::<bool>::new();
+        m.commit(1, &[(10, 1, true)], &[]);
+        let old = m.snapshot(); // pin version 1
+        m.commit(2, &[(20, 2, true)], &[]); // add
+        m.commit(3, &[], &[(10, 1)]); // delete the cell the old snapshot sees
+        let new = m.snapshot();
+        // Old reader: unaffected by the add or the delete.
+        assert_eq!(scan(&old, 0, 100), vec![(10, 1, true)]);
+        // New reader: sees the add, not the deleted cell.
+        assert_eq!(scan(&new, 0, 100), vec![(20, 2, true)]);
+    }
+
+    /// Compaction keeps the segment count logarithmic in the number of commits.
+    #[test]
+    fn compaction_bounds_segment_count() {
+        init();
+        let m = LsmMatrix::<bool>::new();
+        const N: u64 = 4_096; // 2^12 equal-weight commits
+        for v in 1..=N {
+            m.commit(v, &[(v, v, true)], &[]);
+        }
+        // 2^12 unit segments → binary-counter merges → ~log2(N) segments.
+        assert!(
+            m.seg_count() <= 16,
+            "segment count {} not bounded ~log2({N})",
+            m.seg_count()
+        );
+        // All cells still present and correct.
+        assert_eq!(scan(&m.snapshot(), 1, N).len(), N as usize);
+    }
+
+    /// Update churn on a fixed id set: each round tombstones old cells and adds
+    /// new ones. Tombstones must be GC'd by bottom-merges, so the resident weight
+    /// stays bounded (≈ live set), not growing with the number of rounds.
+    #[test]
+    fn tombstone_gc_under_churn() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        const DOCS: u64 = 64;
+        let mut version = 0u64;
+        // round 0: initial placement at row = id.
+        let mut cur_row: Vec<u64> = (0..DOCS).collect();
+        version += 1;
+        let adds: Vec<_> = (0..DOCS)
+            .map(|d| (cur_row[d as usize], d, version))
+            .collect();
+        m.commit(version, &adds, &[]);
+
+        for round in 1..200u64 {
+            version += 1;
+            let new_row: Vec<u64> = (0..DOCS).map(|d| 1000 + round * DOCS + d).collect();
+            let adds: Vec<_> = (0..DOCS)
+                .map(|d| (new_row[d as usize], d, version))
+                .collect();
+            let tombs: Vec<_> = (0..DOCS).map(|d| (cur_row[d as usize], d)).collect();
+            m.commit(version, &adds, &tombs);
+            cur_row = new_row;
+        }
+
+        // Live set is exactly DOCS cells regardless of how many rounds ran.
+        let live = scan(&m.snapshot(), 0, u64::MAX >> 4);
+        assert_eq!(live.len(), DOCS as usize, "live set must equal doc count");
+        for d in 0..DOCS {
+            assert_eq!(live[d as usize].1, d);
+            assert_eq!(live[d as usize].0, cur_row[d as usize]);
+        }
+        // Resident weight stays small — tombstones GC'd, not accumulated over 200
+        // rounds × 64 ids (= 12.8k churned cells). The bound is the live set
+        // (`DOCS`) times a slack factor for the few not-yet-bottom-merged
+        // segments still holding superseded cells.
+        const RESIDENT_SLACK: u64 = 4;
+        assert!(
+            m.total_weight() < RESIDENT_SLACK * DOCS,
+            "resident weight {} should stay ≈ live set, not grow with churn",
+            m.total_weight()
+        );
+    }
+
+    /// A reader pinned before a burst of commits + compactions still scans its
+    /// original version correctly — its segments stay `Arc`-alive even as
+    /// compaction replaces the live segment list (MVCC reclamation).
+    #[test]
+    fn reader_survives_compaction() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        for v in 1..=10u64 {
+            m.commit(v, &[(v, v, v)], &[]);
+        }
+        let pinned = m.snapshot();
+        let before = scan(&pinned, 0, 1000);
+        assert_eq!(before.len(), 10);
+        // Heavy churn + compaction after the pin.
+        for v in 11..=2_000u64 {
+            m.commit(v, &[(v, v, v)], &[(v - 10, v - 10)]);
+        }
+        // The pinned snapshot is byte-for-byte unchanged.
+        assert_eq!(scan(&pinned, 0, 1000), before);
+    }
+
+    /// Differential fuzz: drive the band with random add/tombstone commits and
+    /// check every range scan against a plain reference model, so the LSM's
+    /// merge + per-commit compaction must stay bit-exact with newest-wins
+    /// semantics across hundreds of merges.
+    ///
+    /// The model is a `BTreeMap<(row, col) → (version, Option<value>)>`: each
+    /// commit overwrites a cell's entry with its newest event — `Some(value)` for
+    /// an add, `None` for a tombstone. A cell is *live* in the model iff its
+    /// newest entry is `Some`. The key space is deliberately tiny (`ROWS × COLS`)
+    /// so cells are revisited constantly — lots of updates, tombstones, and
+    /// resurrections, which is what stresses newest-wins and tombstone GC.
+    #[test]
+    fn differential_fuzz_vs_reference() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        let mut model: BTreeMap<(u64, u64), (u64, Option<u64>)> = BTreeMap::new();
+        const ROWS: u64 = 200;
+        const COLS: u64 = 50;
+
+        for step in 1..=400u64 {
+            let version = step; // versions are strictly increasing → newest = highest
+            // Build this commit's 0..7 random ops, mirroring each into the model.
+            let n = (sm64(step) % 8) as usize;
+            let mut adds: Vec<(u64, u64, u64)> = Vec::new();
+            let mut tombs: Vec<(u64, u64)> = Vec::new();
+            for k in 0..n {
+                let h = sm64(step.wrapping_mul(131) ^ k as u64);
+                let (row, col) = (h % ROWS, (h >> 16) % COLS);
+                if h & 1 == 0 {
+                    let val = h | 1; // force nonzero so a value is never mistaken for absent
+                    adds.push((row, col, val));
+                    model.insert((row, col), (version, Some(val)));
+                } else {
+                    tombs.push((row, col));
+                    model.insert((row, col), (version, None));
+                }
+            }
+            // A commit can touch the same cell twice; collapse to its last op so
+            // the run (which holds each cell once) matches the model.
+            dedup_last(&mut adds, &mut tombs);
+            m.commit(version, &adds, &tombs);
+
+            // Periodically verify random sub-ranges scan exactly the model's live
+            // cells in that row range.
+            if step % 7 == 0 {
+                let s = m.snapshot();
+                for q in 0..4u64 {
+                    let a = sm64(step ^ q) % ROWS;
+                    let b = sm64(step ^ q ^ 0xFF) % ROWS;
+                    let (lo, hi) = (a.min(b), a.max(b));
+                    let got = scan(&s, lo, hi);
+                    let mut want: Vec<(u64, u64, u64)> = model
+                        .iter()
+                        .filter(|((r, _), (_, v))| *r >= lo && *r <= hi && v.is_some())
+                        .map(|((r, c), (_, v))| (*r, *c, v.unwrap()))
+                        .collect();
+                    want.sort_unstable();
+                    assert_eq!(got, want, "mismatch at step {step}, range [{lo},{hi}]");
+                }
+            }
+        }
+    }
+
+    /// Major compaction collapses many segments into one tombstone-free base
+    /// without changing scan results, and a reader pinned before it is unaffected.
+    #[test]
+    fn major_compaction_collapses_and_preserves() {
+        init();
+        let m = LsmMatrix::<u64>::new();
+        let mut version = 0u64;
+        let mut cur_row: Vec<u64> = (0..40).collect();
+        version += 1;
+        let adds: Vec<_> = (0..40u64)
+            .map(|d| (cur_row[d as usize], d, d | 1))
+            .collect();
+        m.commit(version, &adds, &[]);
+        for round in 1..60u64 {
+            version += 1;
+            let new_row: Vec<u64> = (0..40).map(|d| 1000 + round * 40 + d).collect();
+            let adds: Vec<_> = (0..40u64)
+                .map(|d| (new_row[d as usize], d, d | 1))
+                .collect();
+            let tombs: Vec<_> = (0..40u64).map(|d| (cur_row[d as usize], d)).collect();
+            m.commit(version, &adds, &tombs);
+            cur_row = new_row;
+        }
+        let before = scan(&m.snapshot(), 0, u64::MAX >> 4);
+        assert_eq!(before.len(), 40);
+        let pinned = m.snapshot(); // pin pre-compaction
+        let pinned_before = scan(&pinned, 0, u64::MAX >> 4);
+
+        m.major_compact();
+
+        assert_eq!(
+            m.seg_count(),
+            1,
+            "major compaction must collapse to one segment"
+        );
+        assert_eq!(scan(&m.snapshot(), 0, u64::MAX >> 4), before);
+        assert_eq!(scan(&pinned, 0, u64::MAX >> 4), pinned_before); // MVCC
+
+        // Idempotent: compacting an already-collapsed base is a no-op — still one
+        // segment, same cells.
+        m.major_compact();
+        assert_eq!(m.seg_count(), 1);
+        assert_eq!(scan(&m.snapshot(), 0, u64::MAX >> 4), before);
+    }
+
+    /// Concurrent MVCC: many reader threads scan while a writer commits +
+    /// compacts. Each commit `v` appends exactly one new cell `(v, v, v)`, so any
+    /// consistent snapshot must observe a *contiguous* id prefix `{1..k}` — a gap
+    /// would be a torn / non-isolated read. Exercises the lock-free `Arc`
+    /// snapshot + compacting-commit path under contention (no UB / panics).
+    #[test]
+    fn concurrent_readers_during_commits() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::thread;
+
+        init();
+        const N: u64 = 2_000;
+        let m = Arc::new(LsmMatrix::<u64>::new());
+        let done = Arc::new(AtomicBool::new(false));
+
+        let readers: Vec<_> = (0..4)
+            .map(|_| {
+                let m = Arc::clone(&m);
+                let done = Arc::clone(&done);
+                thread::spawn(move || {
+                    let mut max_seen = 0u64;
+                    while !done.load(Ordering::Relaxed) {
+                        let snap = m.snapshot();
+                        let cells = scan(&snap, 0, N);
+                        for (i, &(r, c, v)) in cells.iter().enumerate() {
+                            assert_eq!(c, i as u64 + 1, "non-contiguous snapshot → torn read");
+                            assert_eq!((r, v), (c, c), "cell row/value inconsistent with commit");
+                        }
+                        let k = cells.len() as u64;
+                        assert!(k >= max_seen, "snapshot regressed: {k} < {max_seen}");
+                        max_seen = k;
+                    }
+                })
+            })
+            .collect();
+
+        for v in 1..=N {
+            m.commit(v, &[(v, v, v)], &[]);
+        }
+        done.store(true, Ordering::Relaxed);
+        for r in readers {
+            r.join().unwrap();
+        }
+        assert_eq!(scan(&m.snapshot(), 0, N).len(), N as usize);
+    }
+
+    /// Within one commit a cell can appear at most once (runs hold unique cells);
+    /// collapse to the last op per cell so the run build and the reference agree.
+    fn dedup_last(
+        adds: &mut Vec<(u64, u64, u64)>,
+        tombs: &mut Vec<(u64, u64)>,
+    ) {
+        use std::collections::HashMap;
+        let mut last: HashMap<(u64, u64), Option<u64>> = HashMap::new();
+        for &(r, c, v) in adds.iter() {
+            last.insert((r, c), Some(v));
+        }
+        for &(r, c) in tombs.iter() {
+            last.insert((r, c), None);
+        }
+        adds.clear();
+        tombs.clear();
+        for ((r, c), v) in last {
+            match v {
+                Some(v) => adds.push((r, c, v)),
+                None => tombs.push((r, c)),
+            }
+        }
+    }
+}

--- a/graph/src/graph/graphblas/lsm/store.rs
+++ b/graph/src/graph/graphblas/lsm/store.rs
@@ -52,7 +52,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use parking_lot::{Mutex, RwLock};
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
 
 use super::{Layers, LsmCell, LsmCursor, commit_layers, major_compact_layers};
 
@@ -119,9 +120,9 @@ struct Writer {
 /// `(row, id) → cell` matrix set plus writer-only bookkeeping, generic over the
 /// cell type `V` (a `bool` presence cell, or a `u64` caller payload cell).
 pub(crate) struct BandedLsmStore<V: LsmCell> {
-    /// Latest committed bands. Swapped per commit; readers clone the
-    /// `Arc` to pin their version.
-    committed: RwLock<Snapshot<V>>,
+    /// Latest committed bands, published as one atomic snapshot. Swapped per
+    /// commit; readers `load` the `Arc` lock-free to pin their version.
+    committed: ArcSwap<Bands<V>>,
     /// Serialized writer state.
     ///
     /// A commit is a read-modify-write — snapshot the latest version, apply the
@@ -149,7 +150,7 @@ impl<V: LsmCell> BandedLsmStore<V> {
     /// A fresh, empty store at version 0.
     pub(crate) fn new() -> Self {
         Self {
-            committed: RwLock::new(Arc::new(new_bands::<V>())),
+            committed: ArcSwap::from_pointee(new_bands::<V>()),
             writer: Mutex::new(Writer {
                 reverse_id_row_mapping: HashMap::new(),
                 version: 0,
@@ -158,9 +159,9 @@ impl<V: LsmCell> BandedLsmStore<V> {
     }
 
     /// An `Arc` share of the latest committed bands — the immutable view a
-    /// reader scans. Cheap: one `Arc` clone, no lock held after.
+    /// reader scans. Lock-free: an atomic load plus an `Arc` bump.
     pub(crate) fn snapshot(&self) -> Snapshot<V> {
-        Arc::clone(&self.committed.read())
+        self.committed.load_full()
     }
 
     /// The committed logical version.
@@ -171,7 +172,7 @@ impl<V: LsmCell> BandedLsmStore<V> {
 
     /// Approximate resident bytes across all band matrices.
     pub(crate) fn memory_usage(&self) -> usize {
-        self.committed.read().iter().map(|b| b.memory_usage()).sum()
+        self.committed.load().iter().map(|b| b.memory_usage()).sum()
     }
 
     /// Apply one commit's mutations, publishing a new immutable version at
@@ -191,18 +192,25 @@ impl<V: LsmCell> BandedLsmStore<V> {
         // Serialize the whole commit (single writer).
         let mut w = self.writer.lock();
 
-        // Group this commit's cells per band: add cells `(row, col, value)` and
-        // tombstone cells `(row, col)`. The LSM never mutates published state, so
-        // an id delete/update is resolved here (via `reverse_id_row_mapping`) into
-        // the exact old cells to tombstone.
-        let mut band_adds: [Vec<(u64, u64, V)>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
-        let mut band_tombs: [Vec<(u64, u64)>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        // Group this commit's cells per band as structure-of-arrays — parallel
+        // `rows`/`cols` (and `vals` for adds) built directly, so `commit_layers`
+        // hands them to the matrix builder without an array-of-structs rebuild.
+        // The LSM never mutates published state, so an id delete/update is
+        // resolved here (via `reverse_id_row_mapping`) into the exact old cells
+        // to tombstone.
+        let mut add_rows: [Vec<u64>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        let mut add_cols: [Vec<u64>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        let mut add_vals: [Vec<V>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        let mut tomb_rows: [Vec<u64>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        let mut tomb_cols: [Vec<u64>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
 
         // Value-less removals: tombstone each id's currently occupied cells.
         for &doc in remove {
             if let Some(keys) = w.reverse_id_row_mapping.remove(&doc) {
                 for k in keys {
-                    band_tombs[band_of(k)].push((row_of(k), doc));
+                    let b = band_of(k);
+                    tomb_rows[b].push(row_of(k));
+                    tomb_cols[b].push(doc);
                 }
             }
         }
@@ -211,7 +219,9 @@ impl<V: LsmCell> BandedLsmStore<V> {
         for (doc, keys, cell) in adds {
             if let Some(prev) = w.reverse_id_row_mapping.remove(doc) {
                 for k in prev {
-                    band_tombs[band_of(k)].push((row_of(k), *doc));
+                    let b = band_of(k);
+                    tomb_rows[b].push(row_of(k));
+                    tomb_cols[b].push(*doc);
                 }
             }
             if keys.is_empty() {
@@ -222,7 +232,10 @@ impl<V: LsmCell> BandedLsmStore<V> {
             owned.sort_unstable();
             owned.dedup();
             for &k in &owned {
-                band_adds[band_of(k)].push((row_of(k), *doc, *cell));
+                let b = band_of(k);
+                add_rows[b].push(row_of(k));
+                add_cols[b].push(*doc);
+                add_vals[b].push(cell.clone());
             }
             w.reverse_id_row_mapping.insert(*doc, owned);
         }
@@ -230,32 +243,49 @@ impl<V: LsmCell> BandedLsmStore<V> {
         // A cell re-added this commit (e.g. an update that keeps a row, or a
         // remove+re-add of the same id) must NOT be tombstoned this commit:
         // both runs carry the same version, so drop the superseded tombstone.
+        // Filter the parallel tomb arrays in lockstep, in place.
         for b in 0..NUM_BANDS {
-            if band_tombs[b].is_empty() || band_adds[b].is_empty() {
+            if tomb_rows[b].is_empty() || add_rows[b].is_empty() {
                 continue;
             }
-            let added: HashSet<(u64, u64)> = band_adds[b].iter().map(|&(r, c, _)| (r, c)).collect();
-            band_tombs[b].retain(|rc| !added.contains(rc));
+            let added: HashSet<(u64, u64)> = add_rows[b]
+                .iter()
+                .zip(&add_cols[b])
+                .map(|(&r, &c)| (r, c))
+                .collect();
+            let mut keep = 0;
+            for i in 0..tomb_rows[b].len() {
+                if !added.contains(&(tomb_rows[b][i], tomb_cols[b][i])) {
+                    tomb_rows[b][keep] = tomb_rows[b][i];
+                    tomb_cols[b][keep] = tomb_cols[b][i];
+                    keep += 1;
+                }
+            }
+            tomb_rows[b].truncate(keep);
+            tomb_cols[b].truncate(keep);
         }
 
         // Build the next version: untouched bands are shared by `Arc`; touched
         // bands get a fresh `Layers` (append + compact, no growing copy).
-        let cur = self.committed.read().clone();
+        let cur = self.committed.load_full();
         let next: Bands<V> = std::array::from_fn(|b| {
-            if band_adds[b].is_empty() && band_tombs[b].is_empty() {
+            if add_rows[b].is_empty() && tomb_rows[b].is_empty() {
                 Arc::clone(&cur[b])
             } else {
                 Arc::new(commit_layers::<V>(
                     &cur[b],
                     version,
-                    &band_adds[b],
-                    &band_tombs[b],
+                    &add_rows[b],
+                    &add_cols[b],
+                    &add_vals[b],
+                    &tomb_rows[b],
+                    &tomb_cols[b],
                 ))
             }
         });
 
         // Publish atomically, then advance the version.
-        *self.committed.write() = Arc::new(next);
+        self.committed.store(Arc::new(next));
         w.version = version;
     }
 
@@ -266,9 +296,9 @@ impl<V: LsmCell> BandedLsmStore<V> {
     /// atomic snapshot swap, so concurrent readers and writers are unaffected.
     pub(crate) fn major_compact(&self) {
         let _w = self.writer.lock();
-        let cur = self.committed.read().clone();
+        let cur = self.committed.load_full();
         let next: Bands<V> = std::array::from_fn(|b| Arc::new(major_compact_layers::<V>(&cur[b])));
-        *self.committed.write() = Arc::new(next);
+        self.committed.store(Arc::new(next));
     }
 }
 

--- a/graph/src/graph/graphblas/lsm/store.rs
+++ b/graph/src/graph/graphblas/lsm/store.rs
@@ -1,0 +1,607 @@
+//! An ordered `(value → id)` store on a log-structured GraphBLAS matrix
+//! ([`super`]) — an **order-preserving banded layout** that maps full-`u64` row
+//! keys onto legal matrix indices.
+//!
+//! # Typed cells
+//!
+//! Generic over the matrix cell type [`LsmCell`]:
+//!
+//! - `BandedLsmStore<bool>` — the cell is mere **presence**; a scan yields the
+//!   matching id.
+//! - `BandedLsmStore<u64>` — the cell carries a caller-defined `u64` payload; a
+//!   value scan yields `(id, payload)` inline, so a caller that packs related
+//!   data into the cell needs no second structure and no resolution hop.
+//!
+//! # Why banding
+//!
+//! SuiteSparse GraphBLAS packs row/column indices into 60-bit fields, so every
+//! matrix index must be `< 2^60`. Order-preserving row keys span the **full**
+//! `u64` range and routinely exceed `2^60`, so a key cannot be a matrix row
+//! directly. We split the 64-bit key into a high **band** selector and a low
+//! 60-bit **row**:
+//!
+//! ```text
+//!   band = key >> BAND_BITS     (the high 4 bits → one of 16 bands)
+//!   row  = key &  ROW_MASK      (the low 60 bits → a legal matrix index)
+//! ```
+//!
+//! Each band is its own log-structured matrix ([`Layers`]); band *b* covers the
+//! contiguous key interval `[b·2^BAND_BITS, (b+1)·2^BAND_BITS)`. Because the row
+//! index *is* the key's low bits, **rows are stored in key order**: a range query
+//! is a contiguous matrix row-sweep (`iter(lo_row, hi_row)`), not a per-value
+//! dictionary lookup. A range that crosses band boundaries fans out to one
+//! contiguous sweep per band it touches (≤ [`NUM_BANDS`] of them).
+//!
+//! # MVCC
+//!
+//! - The [`NUM_BANDS`] bands are versioned **together** as one [`Snapshot`]
+//!   (`Arc<[Arc<Layers<V>>; NUM_BANDS]>`). A reader pins the whole array and never
+//!   locks during the scan; the writer appends an immutable segment to each
+//!   touched band ([`commit_layers`] — build + compact, no growing copy),
+//!   `Arc`-shares the untouched bands, and swaps the outer `Arc`. Old readers keep
+//!   their `Arc` (and the immutable segments it points at, even across later
+//!   compactions); reclamation is `Arc`-drop.
+//! - There is **no dictionary**: the key → (band, row) map is pure arithmetic
+//!   and identical for every reader, so nothing about ordering is versioned.
+//! - The **`reverse_id_row_mapping`** (`id → row keys`) is writer-only. Writes
+//!   are serialized (one [`Writer`] mutex), so it always reflects the latest
+//!   committed matrices and readers never consult it. It lets a value-less
+//!   `remove` clear every cell of an id without scanning or knowing its old
+//!   value.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock};
+
+use super::{Layers, LsmCell, LsmCursor, commit_layers, major_compact_layers};
+
+/// Low bits of an encoded key used as the matrix row index. `60` keeps each row
+/// within GraphBLAS's `< 2^60` index limit while needing only the minimum number
+/// of bands to cover the full `u64` key space.
+const BAND_BITS: u64 = 60;
+
+/// Number of bands = `2^(64 - BAND_BITS)` — how many `BAND_BITS`-wide intervals
+/// tile the full 64-bit key space. `16` at `BAND_BITS = 60`.
+const NUM_BANDS: usize = 1 << (u64::BITS as u64 - BAND_BITS);
+
+/// Mask selecting the low [`BAND_BITS`] of a key (the within-band row index).
+///
+/// Each band matrix is `2^BAND_BITS × 2^BAND_BITS` (rows = a key's low
+/// `BAND_BITS`; columns = the id space, capped at GraphBLAS's
+/// `GrB_INDEX_MAX`). That dimension is a *logical* bound, not an allocation:
+/// GraphBLAS matrices are hypersparse, so memory scales with the stored entries,
+/// not with `nrows × ncols`. The LSM owns this dimension internally (its `DIM`).
+const ROW_MASK: u64 = (1u64 << BAND_BITS) - 1;
+
+/// The band a key falls in (its high bits).
+#[inline]
+fn band_of(key: u64) -> usize {
+    (key >> BAND_BITS) as usize
+}
+
+/// The within-band matrix row of a key (its low [`BAND_BITS`] bits).
+#[inline]
+fn row_of(key: u64) -> u64 {
+    key & ROW_MASK
+}
+
+/// The [`NUM_BANDS`] log-structured bands that make up one logical index version.
+/// Each band is an `Arc<Layers<V>>` so an untouched band is shared by `Arc` across
+/// versions; only touched bands get a fresh [`Layers`] on commit.
+type Bands<V> = [Arc<Layers<V>>; NUM_BANDS];
+
+/// One published, immutable version — what a reader pins.
+/// All bands are shared behind a single outer `Arc`, so a snapshot is atomic
+/// across bands; each band's segments are immutable, isolating committed state
+/// from the writer's next version and from later compactions.
+pub(crate) type Snapshot<V> = Arc<Bands<V>>;
+
+/// A fresh, empty set of bands (no segments — hypersparse, no allocation).
+fn new_bands<V: LsmCell>() -> Bands<V> {
+    std::array::from_fn(|_| Arc::new(Layers::<V>::empty()))
+}
+
+/// Writer-only state. Commits are serialized through this mutex, so it always
+/// reflects the latest committed matrices.
+struct Writer {
+    /// Reverse mapping `id → the encoded keys it currently occupies` (each
+    /// key pins one `(band, row)` cell). Lets a value-less `remove` clear every
+    /// cell of an id without scanning the matrices or knowing the id's old
+    /// value — the matrix iterates by row, so locating an id's cells the other
+    /// way would mean sweeping every band.
+    reverse_id_row_mapping: HashMap<u64, Vec<u64>>,
+    /// Committed logical version (== the graph commit version).
+    version: u64,
+}
+
+/// The logical-MVCC store: a banded, order-preserving
+/// `(row, id) → cell` matrix set plus writer-only bookkeeping, generic over the
+/// cell type `V` (a `bool` presence cell, or a `u64` caller payload cell).
+pub(crate) struct BandedLsmStore<V: LsmCell> {
+    /// Latest committed bands. Swapped per commit; readers clone the
+    /// `Arc` to pin their version.
+    committed: RwLock<Snapshot<V>>,
+    /// Serialized writer state.
+    ///
+    /// A commit is a read-modify-write — snapshot the latest version, apply the
+    /// mutation, publish the new version — so two concurrent commits could
+    /// `dup()` the same base and the later publish would clobber the earlier one
+    /// (a lost update), while both mutate `reverse_id_row_mapping` at once. This
+    /// mutex makes the whole commit atomic and is the sole writer of that map;
+    /// readers never take it (they only clone the `committed` `Arc`), so reads
+    /// stay lock-free.
+    ///
+    /// The engine already serializes writes upstream, so in practice this lock is
+    /// uncontended. We hold it anyway rather than **silently depending on that
+    /// external invariant**: `BandedLsmStore` must be correct on its own terms, not
+    /// because of how today's callers happen to be scheduled.
+    writer: Mutex<Writer>,
+}
+
+impl<V: LsmCell> Default for BandedLsmStore<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: LsmCell> BandedLsmStore<V> {
+    /// A fresh, empty store at version 0.
+    pub(crate) fn new() -> Self {
+        Self {
+            committed: RwLock::new(Arc::new(new_bands::<V>())),
+            writer: Mutex::new(Writer {
+                reverse_id_row_mapping: HashMap::new(),
+                version: 0,
+            }),
+        }
+    }
+
+    /// An `Arc` share of the latest committed bands — the immutable view a
+    /// reader scans. Cheap: one `Arc` clone, no lock held after.
+    pub(crate) fn snapshot(&self) -> Snapshot<V> {
+        Arc::clone(&self.committed.read())
+    }
+
+    /// The committed logical version.
+    #[cfg(test)]
+    pub(crate) fn version(&self) -> u64 {
+        self.writer.lock().version
+    }
+
+    /// Approximate resident bytes across all band matrices.
+    pub(crate) fn memory_usage(&self) -> usize {
+        self.committed.read().iter().map(|b| b.memory_usage()).sum()
+    }
+
+    /// Apply one commit's mutations, publishing a new immutable version at
+    /// `version`. Each add is `(id, encoded row keys, cell value)`: the cell
+    /// value is presence (`true`) for a `bool` store and the caller's packed
+    /// `u64` payload for a `u64` store — the same value is written at every one
+    /// of the id's rows. `remove` are ids whose every cell is cleared. An id in
+    /// `adds` is tombstoned first (so re-inserting a changed value moves it to
+    /// its new rows rather than accumulating stale ones), making the operation
+    /// safe whether or not the caller also listed it in `remove`.
+    pub(crate) fn commit(
+        &self,
+        version: u64,
+        adds: &[(u64, Vec<u64>, V)],
+        remove: &[u64],
+    ) {
+        // Serialize the whole commit (single writer).
+        let mut w = self.writer.lock();
+
+        // Group this commit's cells per band: add cells `(row, col, value)` and
+        // tombstone cells `(row, col)`. The LSM never mutates published state, so
+        // an id delete/update is resolved here (via `reverse_id_row_mapping`) into
+        // the exact old cells to tombstone.
+        let mut band_adds: [Vec<(u64, u64, V)>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+        let mut band_tombs: [Vec<(u64, u64)>; NUM_BANDS] = std::array::from_fn(|_| Vec::new());
+
+        // Value-less removals: tombstone each id's currently occupied cells.
+        for &doc in remove {
+            if let Some(keys) = w.reverse_id_row_mapping.remove(&doc) {
+                for k in keys {
+                    band_tombs[band_of(k)].push((row_of(k), doc));
+                }
+            }
+        }
+
+        // Additions: tombstone the id's prior placement, then add its new rows.
+        for (doc, keys, cell) in adds {
+            if let Some(prev) = w.reverse_id_row_mapping.remove(doc) {
+                for k in prev {
+                    band_tombs[band_of(k)].push((row_of(k), *doc));
+                }
+            }
+            if keys.is_empty() {
+                continue;
+            }
+            // Dedup so an array repeating a value records each row once.
+            let mut owned = keys.clone();
+            owned.sort_unstable();
+            owned.dedup();
+            for &k in &owned {
+                band_adds[band_of(k)].push((row_of(k), *doc, *cell));
+            }
+            w.reverse_id_row_mapping.insert(*doc, owned);
+        }
+
+        // A cell re-added this commit (e.g. an update that keeps a row, or a
+        // remove+re-add of the same id) must NOT be tombstoned this commit:
+        // both runs carry the same version, so drop the superseded tombstone.
+        for b in 0..NUM_BANDS {
+            if band_tombs[b].is_empty() || band_adds[b].is_empty() {
+                continue;
+            }
+            let added: HashSet<(u64, u64)> = band_adds[b].iter().map(|&(r, c, _)| (r, c)).collect();
+            band_tombs[b].retain(|rc| !added.contains(rc));
+        }
+
+        // Build the next version: untouched bands are shared by `Arc`; touched
+        // bands get a fresh `Layers` (append + compact, no growing copy).
+        let cur = self.committed.read().clone();
+        let next: Bands<V> = std::array::from_fn(|b| {
+            if band_adds[b].is_empty() && band_tombs[b].is_empty() {
+                Arc::clone(&cur[b])
+            } else {
+                Arc::new(commit_layers::<V>(
+                    &cur[b],
+                    version,
+                    &band_adds[b],
+                    &band_tombs[b],
+                ))
+            }
+        });
+
+        // Publish atomically, then advance the version.
+        *self.committed.write() = Arc::new(next);
+        w.version = version;
+    }
+
+    /// **Major compaction**: collapse every band's segments into a single
+    /// tombstone-free base, minimizing resident matrices (fragmentation) and read
+    /// amplification. A logical no-op (same data), so it keeps the committed
+    /// version; serialized with `commit` via the writer lock and published as one
+    /// atomic snapshot swap, so concurrent readers and writers are unaffected.
+    pub(crate) fn major_compact(&self) {
+        let _w = self.writer.lock();
+        let cur = self.committed.read().clone();
+        let next: Bands<V> = std::array::from_fn(|b| Arc::new(major_compact_layers::<V>(&cur[b])));
+        *self.committed.write() = Arc::new(next);
+    }
+}
+
+/// A lazy, `Send`, self-contained cursor over the ids whose encoded key falls
+/// in the inclusive range `[lo, hi]` of one pinned snapshot — the **scan** form
+/// (presence only), used by a `bool` store.
+///
+/// It **owns** a [`Snapshot`] share (so it is `Send` and reclaims by `Arc`-drop
+/// — no borrow of the store, no lock held). Because rows are key-ordered, the
+/// range is a contiguous row-sweep per band: the cursor walks bands
+/// `band_of(lo) ..= band_of(hi)`, opening one [`MatrixIter`] per band over that
+/// band's slice of the range, and yields each `(row, id)` cell's id. An id
+/// stored under several in-range keys is yielded once per occupied row; the scan
+/// layer dedups.
+pub(crate) struct MatrixRangeCursor<V: LsmCell> {
+    bands: Snapshot<V>,
+    lo: u64,
+    hi: u64,
+    /// First and last band the range touches (inclusive).
+    band_lo: usize,
+    band_hi: usize,
+    /// Band whose cursor is currently open (or next to open).
+    band: usize,
+    /// LSM merge cursor over the current band's in-range rows.
+    cursor: Option<LsmCursor<V>>,
+    done: bool,
+}
+
+impl<V: LsmCell> MatrixRangeCursor<V> {
+    /// A cursor over `bands` restricted to the inclusive encoded-key range
+    /// `[lo, hi]`. An empty range (`lo > hi`) yields nothing.
+    pub(crate) fn new(
+        bands: Snapshot<V>,
+        lo: u64,
+        hi: u64,
+    ) -> Self {
+        let done = lo > hi;
+        let band_lo = band_of(lo);
+        let band_hi = band_of(hi);
+        Self {
+            bands,
+            lo,
+            hi,
+            band_lo,
+            band_hi,
+            band: band_lo,
+            cursor: None,
+            done,
+        }
+    }
+
+    /// The next id in range, or `None` when exhausted. Walks each band's
+    /// contiguous in-range row slice (one LSM merge cursor per band), advancing to
+    /// the next band when one is drained.
+    pub(crate) fn next_col(&mut self) -> Option<u64> {
+        loop {
+            if self.done {
+                return None;
+            }
+            match self.cursor.as_mut() {
+                // Drain the current band's merge cursor.
+                Some(c) => match c.next_cell() {
+                    Some((_row, doc, _value)) => return Some(doc),
+                    None => {
+                        self.cursor = None;
+                        self.band += 1;
+                    }
+                },
+                // Open the next band's in-range row sweep. The start row is the
+                // key's row only in the first band (0 thereafter); the end row
+                // is the key's row only in the last band (ROW_MASK before).
+                None => {
+                    if self.band > self.band_hi {
+                        self.done = true;
+                        return None;
+                    }
+                    let start = if self.band == self.band_lo {
+                        row_of(self.lo)
+                    } else {
+                        0
+                    };
+                    let end = if self.band == self.band_hi {
+                        row_of(self.hi)
+                    } else {
+                        ROW_MASK
+                    };
+                    self.cursor = Some(LsmCursor::new(
+                        Arc::clone(&self.bands[self.band]),
+                        start,
+                        end,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// The **value** form of [`MatrixRangeCursor`], used by a `u64` store: yields
+/// `(id, cell_value)` so the caller's packed `u64` payload comes straight from
+/// the cell — no separate resolution structure. Only available for `u64`
+/// (value-carrying) stores.
+pub(crate) struct ValueRangeCursor {
+    bands: Snapshot<u64>,
+    lo: u64,
+    hi: u64,
+    band_lo: usize,
+    band_hi: usize,
+    band: usize,
+    cursor: Option<LsmCursor<u64>>,
+    done: bool,
+}
+
+impl ValueRangeCursor {
+    pub(crate) fn new(
+        bands: Snapshot<u64>,
+        lo: u64,
+        hi: u64,
+    ) -> Self {
+        let done = lo > hi;
+        let band_lo = band_of(lo);
+        let band_hi = band_of(hi);
+        Self {
+            bands,
+            lo,
+            hi,
+            band_lo,
+            band_hi,
+            band: band_lo,
+            cursor: None,
+            done,
+        }
+    }
+
+    /// The next `(id, value)` in range, or `None` when exhausted.
+    pub(crate) fn next_value(&mut self) -> Option<(u64, u64)> {
+        loop {
+            if self.done {
+                return None;
+            }
+            match self.cursor.as_mut() {
+                Some(c) => match c.next_cell() {
+                    Some((_row, doc, value)) => return Some((doc, value)),
+                    None => {
+                        self.cursor = None;
+                        self.band += 1;
+                    }
+                },
+                None => {
+                    if self.band > self.band_hi {
+                        self.done = true;
+                        return None;
+                    }
+                    let start = if self.band == self.band_lo {
+                        row_of(self.lo)
+                    } else {
+                        0
+                    };
+                    let end = if self.band == self.band_hi {
+                        row_of(self.hi)
+                    } else {
+                        ROW_MASK
+                    };
+                    self.cursor = Some(LsmCursor::new(
+                        Arc::clone(&self.bands[self.band]),
+                        start,
+                        end,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Commit `pairs` (id → encoded keys) at version 1 into a fresh `bool` store.
+    fn store_with(pairs: &[(u64, &[u64])]) -> BandedLsmStore<bool> {
+        crate::graph::graphblas::test_init_graphblas();
+        let s = BandedLsmStore::<bool>::new();
+        let adds: Vec<(u64, Vec<u64>, bool)> = pairs
+            .iter()
+            .map(|(d, ks)| (*d, ks.to_vec(), true))
+            .collect();
+        s.commit(1, &adds, &[]);
+        s
+    }
+
+    /// Collect, sorted, the ids whose key falls in `[lo, hi]` of `snap`.
+    fn collect(
+        snap: &Snapshot<bool>,
+        lo: u64,
+        hi: u64,
+    ) -> Vec<u64> {
+        let mut c = MatrixRangeCursor::new(Arc::clone(snap), lo, hi);
+        let mut out = Vec::new();
+        while let Some(id) = c.next_col() {
+            out.push(id);
+        }
+        out.sort_unstable();
+        out
+    }
+
+    /// Compose a key in band `b` at within-band row `row` (band-count agnostic).
+    fn key(
+        b: u64,
+        row: u64,
+    ) -> u64 {
+        (b << BAND_BITS) | row
+    }
+
+    #[test]
+    fn point_and_range_select_expected_docs() {
+        // (id, keys): ids 200 and 201 share key 20, so a point lookup on 20
+        // returns both; ids 100/300 sit at keys 10/30.
+        let s = store_with(&[(100, &[10]), (200, &[20]), (201, &[20]), (300, &[30])]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 20, 20), vec![200, 201]);
+        assert_eq!(collect(&snap, 10, 20), vec![100, 200, 201]);
+        assert_eq!(collect(&snap, 0, 1000), vec![100, 200, 201, 300]);
+        assert_eq!(collect(&snap, 11, 19), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn empty_range_yields_nothing() {
+        let s = store_with(&[(10, &[1])]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 20, 10), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn array_doc_occupies_many_rows() {
+        // One id stored under three keys.
+        let s = store_with(&[(7, &[1, 5, 9])]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 1, 1), vec![7]);
+        assert_eq!(collect(&snap, 5, 5), vec![7]);
+        assert_eq!(collect(&snap, 9, 9), vec![7]);
+        // The id appears once per occupied in-range row.
+        assert_eq!(collect(&snap, 1, 9), vec![7, 7, 7]);
+    }
+
+    #[test]
+    fn remove_tombstones_every_row_of_doc() {
+        let s = store_with(&[(7, &[1, 5, 9]), (8, &[5])]);
+        s.commit(2, &[], &[7]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 0, 100), vec![8]); // id 7 gone everywhere
+        assert_eq!(collect(&snap, 5, 5), vec![8]); // row 5 still has id 8
+        assert_eq!(collect(&snap, 1, 1), Vec::<u64>::new()); // row emptied
+    }
+
+    #[test]
+    fn update_moves_doc_to_new_rows() {
+        let s = store_with(&[(7, &[10])]);
+        // Re-insert id 7 under a new key; the old row must be vacated even though
+        // the caller did not list 7 in `remove`.
+        s.commit(2, &[(7, vec![20], true)], &[]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 10, 10), Vec::<u64>::new());
+        assert_eq!(collect(&snap, 20, 20), vec![7]);
+    }
+
+    #[test]
+    fn reader_snapshot_is_isolated_from_later_commit() {
+        let s = store_with(&[(7, &[10])]);
+        let old = s.snapshot(); // pin version 1
+        s.commit(2, &[(8, vec![10], true)], &[]); // add id 8 at the same key/row
+        let new = s.snapshot();
+        assert_eq!(collect(&old, 10, 10), vec![7]); // old reader unaffected
+        assert_eq!(collect(&new, 10, 10), vec![7, 8]); // new reader sees add
+        assert_eq!(s.version(), 2);
+    }
+
+    #[test]
+    fn interleaved_inserts_preserve_key_order() {
+        // Insert out of key order across commits; ranges must still be correct
+        // because rows are stored in key order regardless of insertion order.
+        crate::graph::graphblas::test_init_graphblas();
+        let s = BandedLsmStore::<bool>::new();
+        s.commit(1, &[(1, vec![50], true)], &[]);
+        s.commit(2, &[(2, vec![10], true)], &[]);
+        s.commit(3, &[(3, vec![30], true)], &[]);
+        let snap = s.snapshot();
+        assert_eq!(collect(&snap, 10, 30), vec![2, 3]);
+        assert_eq!(collect(&snap, 0, 100), vec![1, 2, 3]);
+        assert_eq!(collect(&snap, 50, 50), vec![1]);
+    }
+
+    #[test]
+    fn ranges_span_band_boundaries() {
+        // Three ids in three different bands. Exercises the multi-band sweep
+        // and the per-band start/end row clamping.
+        let s = store_with(&[
+            (100, &[key(0, 5)]),
+            (200, &[key(1, 7)]),
+            (300, &[key(2, 3)]),
+        ]);
+        let snap = s.snapshot();
+        // Full sweep across all three bands.
+        assert_eq!(collect(&snap, key(0, 0), key(3, 0)), vec![100, 200, 300]);
+        // All of band 1, but only row 0 of band 2 → excludes id 300 (row 3).
+        assert_eq!(collect(&snap, key(1, 0), key(2, 0)), vec![200]);
+        // Point lookup inside band 1.
+        assert_eq!(collect(&snap, key(1, 7), key(1, 7)), vec![200]);
+        // Band 0 only (up to its top row).
+        assert_eq!(collect(&snap, key(0, 0), key(0, ROW_MASK)), vec![100]);
+    }
+
+    /// `u64` store: the cell packs an opaque caller payload that a value scan
+    /// returns inline with each matched id.
+    #[test]
+    fn value_store_yields_packed_cell() {
+        crate::graph::graphblas::test_init_graphblas();
+        let s = BandedLsmStore::<u64>::new();
+        // (id, keys, packed payload).
+        s.commit(
+            1,
+            &[(5, vec![10], 0xAAAA_BBBB), (9, vec![20], 0x1111_2222)],
+            &[],
+        );
+        let snap = s.snapshot();
+        let mut c = ValueRangeCursor::new(Arc::clone(&snap), 0, 100);
+        let mut got = Vec::new();
+        while let Some(dv) = c.next_value() {
+            got.push(dv);
+        }
+        got.sort_unstable();
+        assert_eq!(got, vec![(5, 0xAAAA_BBBB), (9, 0x1111_2222)]);
+        // Point lookup returns the one id + its packed value.
+        let mut c = ValueRangeCursor::new(Arc::clone(&snap), 20, 20);
+        assert_eq!(c.next_value(), Some((9, 0x1111_2222)));
+        assert_eq!(c.next_value(), None);
+    }
+}

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -89,13 +89,13 @@ use super::{
     GrB_Matrix_get_INT32, GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals,
     GrB_Matrix_removeElement, GrB_Matrix_resize, GrB_Matrix_setElement_BOOL,
     GrB_Matrix_setElement_UINT64, GrB_Matrix_wait, GrB_Mode, GrB_UINT64, GrB_WaitMode,
-    GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL, GxB_ANY_UINT64,
-    GxB_Container_free, GxB_Container_new, GxB_Global_Option_set_INT32, GxB_Iterator,
-    GxB_Iterator_free, GxB_Iterator_new, GxB_JIT_Control, GxB_Matrix_fprint,
-    GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field, GxB_Print_Level,
-    GxB_init, GxB_load_Matrix_from_Container, GxB_rowIterator_attach, GxB_rowIterator_getColIndex,
-    GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol, GxB_rowIterator_nextRow,
-    GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
+    GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL, GxB_ANY_SECOND_UINT64,
+    GxB_ANY_UINT64, GxB_Container_free, GxB_Container_new, GxB_Global_Option_set_INT32,
+    GxB_Iterator, GxB_Iterator_free, GxB_Iterator_get_UINT64, GxB_Iterator_new, GxB_JIT_Control,
+    GxB_Matrix_fprint, GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field,
+    GxB_Print_Level, GxB_init, GxB_load_Matrix_from_Container, GxB_rowIterator_attach,
+    GxB_rowIterator_getColIndex, GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol,
+    GxB_rowIterator_nextRow, GxB_rowIterator_seekRow, GxB_unload_Matrix_into_Container,
 };
 
 /// Initializes the GraphBLAS library in non-blocking mode.
@@ -322,6 +322,37 @@ impl MaskedElementWiseAdd for Matrix {
                 a.map_or(*self.m, |a| *a.m),
                 b.map_or(*self.m, |b| *b.m),
                 descriptor.map_or(null_mut(), std::convert::Into::into),
+            );
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        }
+        self.has_pending.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Matrix {
+    /// Value-preserving union `self = self ∪ other` for **UINT64** matrices,
+    /// used to fold a versioned matrix's delta-plus into its base without
+    /// clobbering the stored values.
+    ///
+    /// The bool [`MaskedElementWiseAdd::element_wise_add`] hardcodes
+    /// `GxB_ANY_PAIR_BOOL`, whose `PAIR` multiply and bool domain typecast every
+    /// cell to `1` — fine for presence matrices, fatal for value-carrying ones.
+    /// Here the additive monoid is `GxB_ANY_UINT64` over the `SECOND` semiring,
+    /// so non-overlapping entries (the only case: `m` and `dp` never share a
+    /// cell) are copied through with their `u64` value intact.
+    pub fn element_wise_add_uint64(
+        &mut self,
+        other: &Matrix,
+    ) {
+        unsafe {
+            let info = GrB_Matrix_eWiseAdd_Semiring(
+                *self.m,
+                null_mut(),
+                GxB_ANY_UINT64,
+                GxB_ANY_SECOND_UINT64,
+                *self.m,
+                *other.m,
+                null_mut(),
             );
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
         }
@@ -1000,6 +1031,18 @@ impl Matrix {
         Iter::new(self, min_row, max_row)
     }
 
+    /// Iterate `(row, col, value)` triples whose row is in `[min_row, max_row]`,
+    /// extracting the UINT64 cell value. The ranged counterpart of
+    /// [`Self::uint64_iter`], used by value-carrying versioned matrices.
+    #[must_use]
+    pub fn iter_values(
+        &self,
+        min_row: u64,
+        max_row: u64,
+    ) -> Iter<Uint64Extract> {
+        Iter::new(self, min_row, max_row)
+    }
+
     pub fn print(
         &self,
         level: GxB_Print_Level,
@@ -1178,9 +1221,10 @@ pub trait IterExtract {
     /// Extract the item from the current iterator position.
     ///
     /// # Safety
-    /// `m` must be a valid `GrB_Matrix` and the iterator must be positioned on a valid entry.
+    /// `iter` must be a valid `GxB_Iterator` positioned on a valid entry; `row`
+    /// and `col` are that entry's coordinates (already read by the caller).
     unsafe fn extract(
-        m: GrB_Matrix,
+        iter: GxB_Iterator,
         row: u64,
         col: u64,
     ) -> Self::Item;
@@ -1193,7 +1237,7 @@ impl IterExtract for BoolExtract {
     type Item = (u64, u64);
 
     unsafe fn extract(
-        _m: GrB_Matrix,
+        _iter: GxB_Iterator,
         row: u64,
         col: u64,
     ) -> Self::Item {
@@ -1208,12 +1252,14 @@ impl IterExtract for Uint64Extract {
     type Item = (u64, u64, u64);
 
     unsafe fn extract(
-        m: GrB_Matrix,
+        iter: GxB_Iterator,
         row: u64,
         col: u64,
     ) -> Self::Item {
-        let mut val: u64 = 0;
-        unsafe { GrB_Matrix_extractElement_UINT64(&raw mut val, m, row, col) };
+        // Read the value at the iterator's current position — O(1), no random
+        // `extractElement` lookup (the difference between a sequential scan and
+        // a random-access one on large matrices).
+        let val = unsafe { GxB_Iterator_get_UINT64(iter) };
         (row, col, val)
     }
 }
@@ -1335,7 +1381,7 @@ impl<E: IterExtract> Iterator for Iter<E> {
         unsafe {
             let row = GxB_rowIterator_getRowIndex(self.inner);
             let col = GxB_rowIterator_getColIndex(self.inner);
-            let item = E::extract(*self.m, row, col);
+            let item = E::extract(self.inner, row, col);
             if GxB_rowIterator_nextCol(self.inner) != GrB_Info::GrB_SUCCESS {
                 let mut info = GxB_rowIterator_nextRow(self.inner);
                 debug_assert!(

--- a/graph/src/graph/graphblas/matrix.rs
+++ b/graph/src/graph/graphblas/matrix.rs
@@ -89,9 +89,10 @@ use super::{
     GrB_Matrix_get_INT32, GrB_Matrix_ncols, GrB_Matrix_new, GrB_Matrix_nrows, GrB_Matrix_nvals,
     GrB_Matrix_removeElement, GrB_Matrix_resize, GrB_Matrix_setElement_BOOL,
     GrB_Matrix_setElement_UINT64, GrB_Matrix_wait, GrB_Mode, GrB_UINT64, GrB_WaitMode,
-    GrB_finalize, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL, GxB_ANY_SECOND_UINT64,
-    GxB_ANY_UINT64, GxB_Container_free, GxB_Container_new, GxB_Global_Option_set_INT32,
-    GxB_Iterator, GxB_Iterator_free, GxB_Iterator_get_UINT64, GxB_Iterator_new, GxB_JIT_Control,
+    GrB_finalize, GrB_init, GrB_mxm, GrB_transpose, GxB_ANY_BOOL, GxB_ANY_PAIR_BOOL,
+    GxB_ANY_SECOND_UINT64, GxB_ANY_UINT64, GxB_Container_free, GxB_Container_new,
+    GxB_Global_Option_set_INT32, GxB_HYPERSPARSE, GxB_Iterator, GxB_Iterator_free,
+    GxB_Iterator_new, GxB_JIT_Control, GxB_Matrix_Option_get_INT32, GxB_Matrix_Option_set_INT32,
     GxB_Matrix_fprint, GxB_Matrix_memoryUsage, GxB_Matrix_type, GxB_NTHREADS, GxB_Option_Field,
     GxB_Print_Level, GxB_init, GxB_load_Matrix_from_Container, GxB_rowIterator_attach,
     GxB_rowIterator_getColIndex, GxB_rowIterator_getRowIndex, GxB_rowIterator_nextCol,
@@ -100,12 +101,15 @@ use super::{
 
 /// Initializes the GraphBLAS library in non-blocking mode.
 ///
-/// Custom allocators can be provided to integrate with Redis memory management.
-/// This ensures GraphBLAS memory counts toward Redis limits.
+/// Custom allocators can be provided to integrate with Redis memory management,
+/// so GraphBLAS memory counts toward Redis limits. Passing `None` for the
+/// malloc function selects GraphBLAS's built-in ANSI-C allocators via
+/// `GrB_init` (the unit-test path, which has no Redis allocators to install);
+/// the production module-load path passes Redis's.
 ///
 /// # Errors
 ///
-/// Returns `Err` with a descriptive message if `GxB_init` or `LAGraph_Init`
+/// Returns `Err` with a descriptive message if init or `LAGraph_Init`
 /// fail. The caller (Redis module-load path) should propagate this as
 /// `Status::Err` so Redis refuses to load the module rather than aborting
 /// the whole server process.
@@ -119,15 +123,20 @@ pub fn init(
     user_free_function: Option<unsafe extern "C" fn(arg1: *mut c_void)>,
 ) -> Result<(), String> {
     unsafe {
-        let info = GxB_init(
-            GrB_Mode::GrB_NONBLOCKING as _,
-            user_malloc_function,
-            user_calloc_function,
-            user_realloc_function,
-            user_free_function,
-        );
+        // `GxB_init` requires non-null malloc/free; with no custom allocators
+        // fall back to `GrB_init`, which wires up GraphBLAS's built-in ones.
+        let info = match user_malloc_function {
+            Some(_) => GxB_init(
+                GrB_Mode::GrB_NONBLOCKING as _,
+                user_malloc_function,
+                user_calloc_function,
+                user_realloc_function,
+                user_free_function,
+            ),
+            None => GrB_init(GrB_Mode::GrB_NONBLOCKING as _),
+        };
         if info != GrB_Info::GrB_SUCCESS {
-            return Err(format!("GraphBLAS GxB_init failed: {info:?}"));
+            return Err(format!("GraphBLAS init failed: {info:?}"));
         }
 
         // Pick GraphBLAS JIT control level:
@@ -330,29 +339,46 @@ impl MaskedElementWiseAdd for Matrix {
 }
 
 impl Matrix {
-    /// Value-preserving union `self = self ∪ other` for **UINT64** matrices,
-    /// used to fold a versioned matrix's delta-plus into its base without
-    /// clobbering the stored values.
+    /// Value-preserving masked union `self = (a ∪ b) [− mask]` for **UINT64**
+    /// matrices, written into `self` from inputs `a` and `b`. `self` is
+    /// overwritten (the descriptor replaces it), so the caller seeds it as empty
+    /// — no `dup` of a (possibly large) base, which `a` being `Arc`-shared and
+    /// immutable would otherwise force. A `None` operand defaults to `self`: with
+    /// `self` empty that side contributes nothing (`x ∪ ∅ = x`), exactly as the
+    /// bool [`MaskedElementWiseAdd::element_wise_add`] handles a missing operand.
     ///
-    /// The bool [`MaskedElementWiseAdd::element_wise_add`] hardcodes
-    /// `GxB_ANY_PAIR_BOOL`, whose `PAIR` multiply and bool domain typecast every
-    /// cell to `1` — fine for presence matrices, fatal for value-carrying ones.
-    /// Here the additive monoid is `GxB_ANY_UINT64` over the `SECOND` semiring,
-    /// so non-overlapping entries (the only case: `m` and `dp` never share a
-    /// cell) are copied through with their `u64` value intact.
+    /// That bool method hardcodes `GxB_ANY_PAIR_BOOL`, whose `PAIR` multiply and
+    /// bool domain typecast every cell to `1` — fine for presence matrices, fatal
+    /// for value-carrying ones. Here the monoid is `GxB_ANY_UINT64` (the `SECOND`
+    /// semiring), so values are carried through intact.
+    ///
+    /// On a cell present in **both** `a` and `b` the monoid is `ANY`, so the
+    /// surviving value is one of the two, chosen arbitrarily. That is safe for
+    /// the only caller (the LSM merge): a cell is `(value, doc)` and a doc's
+    /// value at a given row is fixed, so the two values are always **identical**
+    /// — the pick is immaterial. (It is *not* a general-purpose merge of
+    /// differing values.)
+    ///
+    /// `mask`, when given, is applied as a **structural complement**: cells
+    /// present in it are dropped from the result in the same pass — used to apply
+    /// a segment's tombstones while folding it in, fusing union + removal into
+    /// one GraphBLAS op.
     pub fn element_wise_add_uint64(
         &mut self,
-        other: &Matrix,
+        a: Option<&Matrix>,
+        b: Option<&Matrix>,
+        mask: Option<&Matrix>,
     ) {
         unsafe {
+            let (mask, desc) = mask.map_or((null_mut(), null_mut()), |m| (*m.m, GrB_DESC_RSC));
             let info = GrB_Matrix_eWiseAdd_Semiring(
                 *self.m,
-                null_mut(),
+                mask,
                 GxB_ANY_UINT64,
                 GxB_ANY_SECOND_UINT64,
-                *self.m,
-                *other.m,
-                null_mut(),
+                a.map_or(*self.m, |a| *a.m),
+                b.map_or(*self.m, |b| *b.m),
+                desc,
             );
             debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
         }
@@ -841,6 +867,39 @@ impl Matrix {
         }
     }
 
+    /// The matrix's current GraphBLAS storage format (`GxB_SPARSITY_STATUS`):
+    /// one of [`GxB_HYPERSPARSE`], [`GxB_SPARSE`], [`GxB_BITMAP`], [`GxB_FULL`].
+    /// At the LSM's `2^60` dimensions only hypersparse is viable — the other
+    /// formats allocate per-row or per-cell storage over the full dimension.
+    #[must_use]
+    pub fn sparsity_status(&self) -> i32 {
+        unsafe {
+            let mut status: i32 = 0;
+            let info = GxB_Matrix_Option_get_INT32(
+                *self.m,
+                GxB_Option_Field::GxB_SPARSITY_STATUS as i32,
+                &raw mut status,
+            );
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+            status
+        }
+    }
+
+    /// Pin the matrix to **hypersparse** only (`GxB_SPARSITY_CONTROL =
+    /// GxB_HYPERSPARSE`), so GraphBLAS never auto-converts it to sparse, bitmap,
+    /// or full. Required for the LSM's `2^60`-dimension matrices, where any other
+    /// format would allocate per-row/per-cell storage over the full dimension.
+    pub fn pin_hypersparse(&mut self) {
+        unsafe {
+            let info = GxB_Matrix_Option_set_INT32(
+                *self.m,
+                GxB_Option_Field::GxB_SPARSITY_CONTROL as i32,
+                GxB_HYPERSPARSE as i32,
+            );
+            debug_assert_eq!(info, GrB_Info::GrB_SUCCESS);
+        }
+    }
+
     pub fn clear(&mut self) {
         unsafe {
             let info = GrB_Matrix_clear(*self.m);
@@ -1218,13 +1277,13 @@ where
 pub trait IterExtract {
     type Item;
 
-    /// Extract the item from the current iterator position.
+    /// Extract the item at `(row, col)` from the matrix `m`.
     ///
     /// # Safety
-    /// `iter` must be a valid `GxB_Iterator` positioned on a valid entry; `row`
-    /// and `col` are that entry's coordinates (already read by the caller).
+    /// `m` must be a valid `GrB_Matrix`; `(row, col)` must be an entry present in
+    /// it (the caller read those coordinates from the row iterator).
     unsafe fn extract(
-        iter: GxB_Iterator,
+        m: GrB_Matrix,
         row: u64,
         col: u64,
     ) -> Self::Item;
@@ -1237,7 +1296,7 @@ impl IterExtract for BoolExtract {
     type Item = (u64, u64);
 
     unsafe fn extract(
-        _iter: GxB_Iterator,
+        _m: GrB_Matrix,
         row: u64,
         col: u64,
     ) -> Self::Item {
@@ -1252,14 +1311,14 @@ impl IterExtract for Uint64Extract {
     type Item = (u64, u64, u64);
 
     unsafe fn extract(
-        iter: GxB_Iterator,
+        m: GrB_Matrix,
         row: u64,
         col: u64,
     ) -> Self::Item {
-        // Read the value at the iterator's current position — O(1), no random
-        // `extractElement` lookup (the difference between a sequential scan and
-        // a random-access one on large matrices).
-        let val = unsafe { GxB_Iterator_get_UINT64(iter) };
+        // Look the value up by coordinate, so the result is the value at exactly
+        // `(row, col)` regardless of any iterator's current position.
+        let mut val: u64 = 0;
+        unsafe { GrB_Matrix_extractElement_UINT64(&raw mut val, m, row, col) };
         (row, col, val)
     }
 }
@@ -1381,7 +1440,7 @@ impl<E: IterExtract> Iterator for Iter<E> {
         unsafe {
             let row = GxB_rowIterator_getRowIndex(self.inner);
             let col = GxB_rowIterator_getColIndex(self.inner);
-            let item = E::extract(self.inner, row, col);
+            let item = E::extract(*self.m, row, col);
             if GxB_rowIterator_nextCol(self.inner) != GrB_Info::GrB_SUCCESS {
                 let mut info = GxB_rowIterator_nextRow(self.inner);
                 debug_assert!(

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -62,29 +62,18 @@ pub mod vector;
 pub mod versioned_matrix;
 
 /// Initialize GraphBLAS once for unit tests that build matrices directly,
-/// outside the Redis module-load path that normally calls [`matrix::init`].
-/// Without it the first `GrB_Matrix_new` aborts with `GrB_PANIC`. Non-blocking
-/// mode, built-in ANSI-C allocators, JIT disabled (its `dlopen` path is slow and
-/// fork-unsafe; the generic kernels suffice). The [`Once`](std::sync::Once)
-/// guard makes it idempotent across the many tests that call it.
+/// outside the Redis module-load path. Delegates to [`matrix::init`] with the
+/// built-in ANSI-C allocators (the module-load path passes Redis's instead).
+/// Without it the first `GrB_Matrix_new` aborts with `GrB_PANIC`. The
+/// [`Once`](std::sync::Once) guard makes it idempotent across the many tests
+/// that call it.
 #[cfg(test)]
 pub(crate) fn test_init_graphblas() {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
-    INIT.call_once(|| unsafe {
-        let info = GrB_init(GrB_Mode::GrB_NONBLOCKING as _);
-        assert_eq!(info, GrB_Info::GrB_SUCCESS, "GrB_init failed: {info:?}");
-        let info = GrB_Global_set_INT32(
-            GrB_GLOBAL,
-            GxB_JIT_Control::GxB_JIT_OFF as i32,
-            GxB_Option_Field::GxB_JIT_C_CONTROL as _,
-        );
-        assert_eq!(
-            info,
-            GrB_Info::GrB_SUCCESS,
-            "GraphBLAS JIT-off failed: {info:?}"
-        );
+    INIT.call_once(|| {
+        matrix::init(None, None, None, None).expect("GraphBLAS test init failed");
     });
 }
 

--- a/graph/src/graph/graphblas/mod.rs
+++ b/graph/src/graph/graphblas/mod.rs
@@ -53,11 +53,40 @@
 
 pub mod lagraph_bindings;
 pub mod lagraphx_bindings;
+#[allow(dead_code)]
+pub(crate) mod lsm;
 pub mod matrix;
 pub mod serialization;
 pub mod tensor;
 pub mod vector;
 pub mod versioned_matrix;
+
+/// Initialize GraphBLAS once for unit tests that build matrices directly,
+/// outside the Redis module-load path that normally calls [`matrix::init`].
+/// Without it the first `GrB_Matrix_new` aborts with `GrB_PANIC`. Non-blocking
+/// mode, built-in ANSI-C allocators, JIT disabled (its `dlopen` path is slow and
+/// fork-unsafe; the generic kernels suffice). The [`Once`](std::sync::Once)
+/// guard makes it idempotent across the many tests that call it.
+#[cfg(test)]
+pub(crate) fn test_init_graphblas() {
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(|| unsafe {
+        let info = GrB_init(GrB_Mode::GrB_NONBLOCKING as _);
+        assert_eq!(info, GrB_Info::GrB_SUCCESS, "GrB_init failed: {info:?}");
+        let info = GrB_Global_set_INT32(
+            GrB_GLOBAL,
+            GxB_JIT_Control::GxB_JIT_OFF as i32,
+            GxB_Option_Field::GxB_JIT_C_CONTROL as _,
+        );
+        assert_eq!(
+            info,
+            GrB_Info::GrB_SUCCESS,
+            "GraphBLAS JIT-off failed: {info:?}"
+        );
+    });
+}
 
 #[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
 #[repr(C)]


### PR DESCRIPTION
A general-purpose, log-structured GraphBLAS matrix and a banded ordered
(value→id) store built on it. It lands on its own so it can be reviewed in
isolation; the consumer (a native index) arrives in a follow-up PR, so the
module is currently unused in the default build (`#[allow(dead_code)]`) but is
fully covered by its own test suite.

## What

- **`LsmMatrix`** — an append-only list of immutable segments. A commit appends
  one segment; reads are a lazy k-way merge over the segments (newest-wins per
  cell). Size-tiered compaction keeps the segment count `O(log N)` for bounded
  read amplification, and bottom-merges GC tombstones. Reads pin an `Arc`
  snapshot and are lock-free. The cell type is pluggable via the `LsmCell`
  trait — presence (`bool`) and value-carrying (`u64`) today; a new scalar type
  (`f64`, `i64`, …) is one macro line plus its `Matrix` primitives.
- **`BandedLsmStore`** — bands the full `u64` key space into per-band
  `LsmMatrix`es so order-preserving keys map onto GraphBLAS's `< 2^60` index
  limit; a range query is then a contiguous row sweep. Lock-free `Arc`
  snapshots; writes serialized through one mutex.
- **`matrix.rs`** — adds the `u64` value-preserving union and the value-reading
  range iterator the store needs (values are read off the row iterator's cursor
  position rather than re-looked-up by coordinate).

## Notes
- Compaction is synchronous on the commit path for now; moving it to a
  background thread is a follow-up write-path optimization.
- `#[allow(dead_code)]` until the consumer lands; CI builds and tests it through
  its own suite.

## Tests
Differential fuzz vs a reference model, tiered-compaction + tombstone-GC bounds,
MVCC snapshot isolation, and a concurrent reader/writer test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced log-structured matrix storage with multi-version concurrency control and lock-free snapshot reads for safer concurrent access.
  * Added support for value-carrying UINT64 matrices, including element-wise masked addition and value iteration across row ranges.
  * Added new range cursors for efficient ordered scanning and retrieval of presence and value results.

* **Improvements**
  * Added GraphBLAS utilities to query and control sparsity behavior (including hypersparse pinning) and enhanced iterator/value extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->