### PR TITLE
ci: build & publish shared-library binaries on GitHub Releases for all C-parity architectures

### DIFF
--- a/.github/workflows/_build-artifacts-macos.yml
+++ b/.github/workflows/_build-artifacts-macos.yml
@@ -1,0 +1,125 @@
+# Reusable workflow: build the falkordb shared library natively on macOS arm64
+# and upload it as `falkordb-<suffix>.so`. Separate from _build-artifacts.yml
+# because hosted macOS runners have no Docker — this is a native cargo build,
+# not a `docker build --target artifact`. The produced Mach-O dylib is renamed
+# to the C-parity `.so` name (Redis loads modules by path, extension-agnostic).
+#
+# The build mirrors the proven native-macOS setup from #551 (brew toolchain +
+# the CC/CXX-driven graphblas.sh / redisearch.sh + static Homebrew libomp), but
+# only the artifact-producing steps — no test suites.
+
+name: Build artifacts macOS (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        description: "Commit SHA to check out and build"
+        required: true
+        type: string
+      suffix:
+        description: "Asset suffix → falkordb-<suffix>.so"
+        required: false
+        type: string
+        default: "macos-arm64v8"
+
+jobs:
+  build:
+    runs-on: macos-14
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      # Static-link Homebrew libomp.a (keeps the .so self-contained for OpenMP,
+      # matching the Linux single-.so contract). graph/build.rs links static
+      # when ${LIBOMP_PREFIX}/lib/libomp.a exists.
+      LIBOMP_PREFIX: /opt/homebrew/opt/libomp
+      # Workspace-local GraphBLAS install (no sudo; cacheable). graphblas.sh
+      # reads GRAPHBLAS_INSTALL_PREFIX; build.rs reads GRAPHBLAS_LIB_DIR.
+      GRAPHBLAS_INSTALL_PREFIX: ${{ github.workspace }}/.deps/graphblas
+      GRAPHBLAS_LIB_DIR: ${{ github.workspace }}/.deps/graphblas/lib
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.commit_sha }}
+          persist-credentials: false
+
+      - name: Install Homebrew build deps
+        run: brew install cmake llvm libomp openssl@3
+
+      - name: Export Homebrew LLVM into PATH/CC/CXX
+        run: |
+          set -euo pipefail
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          echo "${LLVM_PREFIX}/bin"             >> "$GITHUB_PATH"
+          echo "CC=${LLVM_PREFIX}/bin/clang"    >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          # Bust the native-deps cache when Homebrew LLVM moves (the C artefacts
+          # are ABI-tied to it).
+          echo "BREW_LLVM_VERSION=$(brew list --versions llvm | awk '{print $2}')" >> "$GITHUB_ENV"
+
+      - name: Install Rust stable
+        run: rustup default stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "macos-artifact-release"
+
+      # Hosted macOS has no Docker toolchain image, so rebuild GraphBLAS +
+      # LAGraph + RediSearch from source and cache them (keyed on the build
+      # scripts + vendored PreJIT + the exact Homebrew LLVM version).
+      - name: Restore GraphBLAS + RediSearch native builds
+        id: native-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            .deps/graphblas
+            lagraph_lib
+            redisearch/RediSearch/bin
+          key: macos-native-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('graphblas.sh', 'redisearch.sh', 'build/graphblas/**') }}-llvm${{ env.BREW_LLVM_VERSION }}
+
+      - name: Build GraphBLAS + LAGraph
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        run: ./graphblas.sh
+
+      - name: Build RediSearch
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        run: ./redisearch.sh
+
+      - name: Save GraphBLAS + RediSearch native builds
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            .deps/graphblas
+            lagraph_lib
+            redisearch/RediSearch/bin
+          key: ${{ steps.native-cache.outputs.cache-primary-key }}
+
+      - name: Build libfalkordb.dylib
+        run: cargo build --release
+
+      - name: Stage + validate + checksum
+        env:
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
+          set -euo pipefail
+          test -f target/release/libfalkordb.dylib || { echo "::error::target/release/libfalkordb.dylib missing"; exit 1; }
+          mkdir -p dist
+          cp target/release/libfalkordb.dylib "dist/falkordb-${SUFFIX}.so"
+          echo "=== otool -L (the FalkorDB static deps must NOT appear as dynamic) ==="
+          otool -L "dist/falkordb-${SUFFIX}.so"
+          if otool -L "dist/falkordb-${SUFFIX}.so" | grep -E 'libomp|libgraphblas|liblagraph|liblagraphx|libredisearch|libVectorSimilarity'; then
+            echo "::error::forbidden dynamic dependency in macOS .so (single-.so contract violated)"; exit 1
+          fi
+          ( cd dist && shasum -a 256 "falkordb-${SUFFIX}.so" > "falkordb-${SUFFIX}.so.sha256" )
+          echo "Built falkordb-${SUFFIX}.so ($(du -h "dist/falkordb-${SUFFIX}.so" | cut -f1))"
+          cat "dist/falkordb-${SUFFIX}.so.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: falkordb-${{ inputs.suffix }}.so
+          path: dist/falkordb-${{ inputs.suffix }}.so*
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -1,0 +1,105 @@
+# Reusable workflow: build the falkordb shared library (.so) for one or more
+# architectures and upload each as a workflow artifact. BUILD ONLY — it never
+# uploads to a GitHub Release. Callers (build-artifacts.yml for PR verification,
+# release-artifacts.yml for the release upload) describe the build cells via the
+# `cells` input as a JSON array of {arch, platform, runner, suffix} objects:
+#
+#   [
+#     {"suffix":"x64",     "arch":"x64",     "platform":"linux/amd64","runner":"ubuntu-latest"},
+#     {"suffix":"arm64v8", "arch":"arm64v8", "platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+#   ]
+#
+# Each cell extracts the .so from the `artifact` target of build/runtime/Dockerfile
+# (the exact .so the runtime image ships) and uploads it as `falkordb-<suffix>.so`
+# together with its `.sha256`. Cells are independent (fail-fast: false) and run on
+# native runners (no QEMU) for maximum parallelism.
+
+name: Build artifacts (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      cells:
+        description: "JSON array of build cells — {arch, platform, runner, suffix}"
+        required: true
+        type: string
+      commit_sha:
+        description: "Commit SHA to check out and build"
+        required: true
+        type: string
+      build_image:
+        description: "Toolchain image used as the build base (chef/builder stage)"
+        required: false
+        type: string
+        default: "ghcr.io/falkordb/falkordb-build:latest"
+      dockerfile:
+        description: "Dockerfile providing the `artifact` target"
+        required: false
+        type: string
+        default: "build/runtime/Dockerfile"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.cells) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.commit_sha }}
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build the `artifact` stage and export just the .so to ./artifact-out.
+      # The Dockerfile's `builder` stage enforces the single-.so self-containment
+      # contract (no dynamic libomp/graphblas/redisearch deps; OpenMP static), so
+      # a successful build is also the authoritative dependency check — run in the
+      # correct target-arch context, unlike a host-side ldd.
+      - name: Build falkordb-${{ matrix.suffix }}.so
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          target: artifact
+          platforms: ${{ matrix.platform }}
+          outputs: type=local,dest=artifact-out
+          provenance: false
+          build-args: |
+            BUILD_IMAGE=${{ inputs.build_image }}
+          # Read-only reuse of the runtime image's builder cache (same `builder`
+          # stage layers) for fast incremental builds. No cache-to (packages:read
+          # only) so we never clobber the release flavour cache.
+          cache-from: type=registry,ref=ghcr.io/falkordb/falkordb:buildcache-release-${{ matrix.arch }}
+
+      - name: Stage + checksum
+        env:
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          test -f "artifact-out/falkordb.so" || { echo "::error::artifact-out/falkordb.so missing"; exit 1; }
+          mkdir -p dist
+          cp "artifact-out/falkordb.so" "dist/falkordb-${SUFFIX}.so"
+          ( cd dist && sha256sum "falkordb-${SUFFIX}.so" > "falkordb-${SUFFIX}.so.sha256" )
+          echo "Built falkordb-${SUFFIX}.so ($(du -h "dist/falkordb-${SUFFIX}.so" | cut -f1))"
+          cat "dist/falkordb-${SUFFIX}.so.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: falkordb-${{ matrix.suffix }}.so
+          path: dist/falkordb-${{ matrix.suffix }}.so*
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -49,7 +49,11 @@ jobs:
       matrix:
         include: ${{ fromJson(inputs.cells) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # `persist-credentials: false` + read-only `permissions` (above) keep this
+      # safe even though it builds caller-supplied (potentially PR) code: no
+      # GITHUB_TOKEN is left on disk and the job cannot write anything. Callers
+      # do not pass `secrets: inherit`, so no custom secrets reach the build.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.commit_sha }}
           persist-credentials: false

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -70,6 +70,10 @@ jobs:
       # correct target-arch context, unlike a host-side ldd.
       - name: Build falkordb-${{ matrix.suffix }}.so
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        env:
+          # Don't upload the buildx build-record (.dockerbuild) artifact — keep
+          # the run's artifact list (and the release asset set) to just the .so.
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/_build-artifacts.yml
+++ b/.github/workflows/_build-artifacts.yml
@@ -20,23 +20,18 @@ on:
   workflow_call:
     inputs:
       cells:
-        description: "JSON array of build cells — {arch, platform, runner, suffix}"
+        description: >-
+          JSON array of build cells. Each:
+          {suffix, arch, platform, runner, dockerfile, build_image, cxx}.
+          `dockerfile` provides the `artifact` target; `build_image` is the
+          chef/builder base (Debian toolchain image) or "" for self-contained
+          per-OS Dockerfiles; `cxx` is the C++ compiler passed to the builder.
         required: true
         type: string
       commit_sha:
         description: "Commit SHA to check out and build"
         required: true
         type: string
-      build_image:
-        description: "Toolchain image used as the build base (chef/builder stage)"
-        required: false
-        type: string
-        default: "ghcr.io/falkordb/falkordb-build:latest"
-      dockerfile:
-        description: "Dockerfile providing the `artifact` target"
-        required: false
-        type: string
-        default: "build/runtime/Dockerfile"
 
 jobs:
   build:
@@ -80,17 +75,18 @@ jobs:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
-          file: ${{ inputs.dockerfile }}
+          file: ${{ matrix.dockerfile }}
           target: artifact
           platforms: ${{ matrix.platform }}
           outputs: type=local,dest=artifact-out
           provenance: false
           build-args: |
-            BUILD_IMAGE=${{ inputs.build_image }}
-          # Read-only reuse of the runtime image's builder cache (same `builder`
-          # stage layers) for fast incremental builds. No cache-to (packages:read
-          # only) so we never clobber the release flavour cache.
-          cache-from: type=registry,ref=ghcr.io/falkordb/falkordb:buildcache-release-${{ matrix.arch }}
+            BUILD_IMAGE=${{ matrix.build_image }}
+            CXX=${{ matrix.cxx }}
+          # Per-suffix GitHub Actions cache so each platform's build layers are
+          # independent and sticky across runs (no packages:write needed).
+          cache-from: type=gha,scope=artifact-${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=artifact-${{ matrix.suffix }}
 
       - name: Stage + checksum
         env:

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -61,8 +61,9 @@ jobs:
           # release-artifacts.yml. macOS is built natively (no Docker) and is
           # selected via the separate `macos` flag below.
           ALL='[
-            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest"},
-            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
+            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
+            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"}
           ]'
           MACOS_SUFFIX="macos-arm64v8"
           if [ "$EVENT" = "workflow_dispatch" ] && [ -n "${ARCHS:-}" ] && [ "$ARCHS" != "all" ]; then

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -12,9 +12,9 @@
 #     `verify-artifacts` label: the build runs at the PR head and re-runs on each
 #     push while the label is present. Remove + re-add the label to force a re-run.
 #
-# Additional platforms (alpine/musl, rhel8, rhel9, amazonlinux2023) land in the
-# cell list below as their per-OS toolchain images are added — see issue #608.
-# Native macOS build is tracked separately in PR #551.
+# Additional Linux platforms (alpine/musl, rhel8, rhel9, amazonlinux2023) land in
+# the cell list below as their per-OS toolchain images are added — see issue #608.
+# macOS arm64 is built natively (no Docker) via _build-artifacts-macos.yml.
 
 name: Build artifacts (verify)
 
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       archs:
-        description: "Comma-separated suffixes to build (e.g. 'x64,arm64v8'), or 'all'"
+        description: "Comma-separated suffixes (e.g. 'x64,arm64v8,macos-arm64v8'), or 'all'"
         required: false
         default: "all"
   pull_request:
@@ -46,6 +46,7 @@ jobs:
     outputs:
       cells: ${{ steps.derive.outputs.cells }}
       commit_sha: ${{ steps.derive.outputs.commit_sha }}
+      macos: ${{ steps.derive.outputs.macos }}
     steps:
       - name: Derive cells + commit SHA
         id: derive
@@ -56,31 +57,38 @@ jobs:
           GH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Master list of currently-wired cells (Debian/glibc). Keep in sync with
-          # release-artifacts.yml. Add new platforms here as toolchain images land.
+          # Master list of Docker (Linux) cells. Keep in sync with
+          # release-artifacts.yml. macOS is built natively (no Docker) and is
+          # selected via the separate `macos` flag below.
           ALL='[
             {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest"},
             {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
           ]'
+          MACOS_SUFFIX="macos-arm64v8"
           if [ "$EVENT" = "workflow_dispatch" ] && [ -n "${ARCHS:-}" ] && [ "$ARCHS" != "all" ]; then
             FILTER=$(printf '%s' "$ARCHS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | jq -R . | jq -s -c .)
             CELLS=$(printf '%s' "$ALL" | jq -c --argjson f "$FILTER" '[ .[] | select(.suffix as $s | $f | index($s)) ]')
+            MACOS=$(printf '%s' "$FILTER" | jq -r --arg m "$MACOS_SUFFIX" 'if index($m) then "true" else "false" end')
           else
             CELLS=$(printf '%s' "$ALL" | jq -c .)
+            MACOS=true
           fi
-          if [ "$(printf '%s' "$CELLS" | jq 'length')" = "0" ]; then
-            echo "::error::no cells selected for archs='${ARCHS:-}'"; exit 1
+          if [ "$(printf '%s' "$CELLS" | jq 'length')" = "0" ] && [ "$MACOS" != "true" ]; then
+            echo "::error::no platforms selected for archs='${ARCHS:-}'"; exit 1
           fi
           if [ "$EVENT" = "pull_request" ]; then SHA="$PR_SHA"; else SHA="$GH_SHA"; fi
           {
             echo "cells=$CELLS"
             echo "commit_sha=$SHA"
+            echo "macos=$MACOS"
           } >> "$GITHUB_OUTPUT"
           echo "Selected cells: $CELLS"
+          echo "macOS: $MACOS"
           echo "Commit SHA: $SHA"
 
   build:
     needs: prepare
+    if: ${{ needs.prepare.outputs.cells != '[]' }}
     uses: ./.github/workflows/_build-artifacts.yml
     permissions:
       contents: read
@@ -91,3 +99,12 @@ jobs:
     # No `secrets: inherit` — the reusable workflow only needs the auto-provided
     # GITHUB_TOKEN (GHCR read). Keeping custom secrets out of a PR-triggered
     # build that compiles untrusted code is deliberate.
+
+  build-macos:
+    needs: prepare
+    if: ${{ needs.prepare.outputs.macos == 'true' }}
+    uses: ./.github/workflows/_build-artifacts-macos.yml
+    permissions:
+      contents: read
+    with:
+      commit_sha: ${{ needs.prepare.outputs.commit_sha }}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,91 @@
+# Manually-triggerable build of the shared-library (.so) artifacts for every
+# wired architecture, so a maintainer can verify all platforms build correctly
+# BEFORE a release. Uploads workflow artifacts only (no Release upload).
+#
+# Triggers:
+#   - workflow_dispatch  → the long-term manual trigger (works once this file is
+#     on the default branch; also usable against any branch/tag thereafter).
+#   - pull_request (labeled/synchronize/reopened), gated by the `verify-artifacts`
+#     label → the path that makes this usable on a PR BEFORE it is merged.
+#     workflow_dispatch cannot reach a workflow that exists only on a feature
+#     branch, so to verify a PR that *introduces* this workflow, add the
+#     `verify-artifacts` label: the build runs at the PR head and re-runs on each
+#     push while the label is present. Remove + re-add the label to force a re-run.
+#
+# Additional platforms (alpine/musl, rhel8, rhel9, amazonlinux2023) land in the
+# cell list below as their per-OS toolchain images are added — see issue #608.
+# Native macOS build is tracked separately in PR #551.
+
+name: Build artifacts (verify)
+
+on:
+  workflow_dispatch:
+    inputs:
+      archs:
+        description: "Comma-separated suffixes to build (e.g. 'x64,arm64v8'), or 'all'"
+        required: false
+        default: "all"
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: build-artifacts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    # Run on manual dispatch, OR on a PR carrying the `verify-artifacts` label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'verify-artifacts')
+    runs-on: ubuntu-latest
+    outputs:
+      cells: ${{ steps.derive.outputs.cells }}
+      commit_sha: ${{ steps.derive.outputs.commit_sha }}
+    steps:
+      - name: Derive cells + commit SHA
+        id: derive
+        env:
+          EVENT: ${{ github.event_name }}
+          ARCHS: ${{ github.event.inputs.archs }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Master list of currently-wired cells (Debian/glibc). Keep in sync with
+          # release-artifacts.yml. Add new platforms here as toolchain images land.
+          ALL='[
+            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest"},
+            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+          ]'
+          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "${ARCHS:-}" ] && [ "$ARCHS" != "all" ]; then
+            FILTER=$(printf '%s' "$ARCHS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | jq -R . | jq -s -c .)
+            CELLS=$(printf '%s' "$ALL" | jq -c --argjson f "$FILTER" '[ .[] | select(.suffix as $s | $f | index($s)) ]')
+          else
+            CELLS=$(printf '%s' "$ALL" | jq -c .)
+          fi
+          if [ "$(printf '%s' "$CELLS" | jq 'length')" = "0" ]; then
+            echo "::error::no cells selected for archs='${ARCHS:-}'"; exit 1
+          fi
+          if [ "$EVENT" = "pull_request" ]; then SHA="$PR_SHA"; else SHA="$GH_SHA"; fi
+          {
+            echo "cells=$CELLS"
+            echo "commit_sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Selected cells: $CELLS"
+          echo "Commit SHA: $SHA"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/_build-artifacts.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      cells: ${{ needs.prepare.outputs.cells }}
+      commit_sha: ${{ needs.prepare.outputs.commit_sha }}
+    secrets: inherit

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -63,7 +63,8 @@ jobs:
           ALL='[
             {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
-            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"}
+            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"},
+            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"}
           ]'
           MACOS_SUFFIX="macos-arm64v8"
           if [ "$EVENT" = "workflow_dispatch" ] && [ -n "${ARCHS:-}" ] && [ "$ARCHS" != "all" ]; then

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -88,4 +88,6 @@ jobs:
     with:
       cells: ${{ needs.prepare.outputs.cells }}
       commit_sha: ${{ needs.prepare.outputs.commit_sha }}
-    secrets: inherit
+    # No `secrets: inherit` — the reusable workflow only needs the auto-provided
+    # GITHUB_TOKEN (GHCR read). Keeping custom secrets out of a PR-triggered
+    # build that compiles untrusted code is deliberate.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -77,8 +77,9 @@ jobs:
             echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag ($TAG)"; exit 1
           fi
           ALL='[
-            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest"},
-            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
+            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
+            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"}
           ]'
           CELLS=$(printf '%s' "$ALL" | jq -c .)
           SUFFIXES=$(printf '%s' "$ALL" | jq -c '[ .[].suffix ]')

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -79,7 +79,8 @@ jobs:
           ALL='[
             {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
-            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"}
+            {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"},
+            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"}
           ]'
           CELLS=$(printf '%s' "$ALL" | jq -c .)
           SUFFIXES=$(printf '%s' "$ALL" | jq -c '[ .[].suffix ]')

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,9 +43,13 @@ jobs:
       tag: ${{ steps.derive.outputs.tag }}
       suffixes: ${{ steps.derive.outputs.suffixes }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha || github.sha }}
+          # Check out the RELEASE TAG (release event) or the requested commit
+          # (dispatch). The resolved commit is then read back via `git rev-parse`
+          # below — `github.sha` is NOT guaranteed to be the tagged commit for a
+          # release event, so we never rely on it.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha || github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Derive tag, commit SHA, cells; validate Cargo.toml version
@@ -54,15 +58,16 @@ jobs:
           EVENT: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
-          INPUT_SHA: ${{ github.event.inputs.commit_sha }}
-          GH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            TAG="$INPUT_TAG"; SHA="$INPUT_SHA"
+            TAG="$INPUT_TAG"
           else
-            TAG="$RELEASE_TAG"; SHA="$GH_SHA"
+            TAG="$RELEASE_TAG"
           fi
+          # Resolve the actual commit from the checked-out ref (the tag/commit
+          # above), never from github.sha.
+          SHA="$(git rev-parse HEAD)"
           # Validate Cargo.toml version matches the (v-stripped) tag — fail loudly
           # so a mis-tagged release never ships mismatched binaries.
           SEMVER="${TAG#v}"
@@ -94,7 +99,7 @@ jobs:
     with:
       cells: ${{ needs.prepare.outputs.cells }}
       commit_sha: ${{ needs.prepare.outputs.commit_sha }}
-    secrets: inherit
+    # No `secrets: inherit` — the reusable build only needs the auto GITHUB_TOKEN.
 
   publish:
     needs: [prepare, build]

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,141 @@
+# Publish the shared-library (.so) artifacts to a GitHub Release.
+#
+# BUILD (fan-out) and PUBLISH (fan-in) are separated so a partial matrix failure
+# never leaves a half-populated public Release: the per-arch build cells only
+# produce workflow artifacts, and a single publish job downloads them, asserts
+# the FULL expected set is present, generates SHA256SUMS, then uploads.
+#
+# Triggers:
+#   - release: published   → build at the release commit, upload to that release.
+#   - workflow_dispatch    → repair/escape hatch: rebuild + (re)upload assets for
+#     an existing tag at a given commit (uses --clobber so re-runs are idempotent).
+#
+# Keep the cell list in sync with build-artifacts.yml. New platforms (see #608)
+# are added in both places.
+
+name: Release artifacts
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to build + upload assets for (e.g. v0.4.0)"
+        required: true
+      commit_sha:
+        description: "Commit SHA to build"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-artifacts-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      cells: ${{ steps.derive.outputs.cells }}
+      commit_sha: ${{ steps.derive.outputs.commit_sha }}
+      tag: ${{ steps.derive.outputs.tag }}
+      suffixes: ${{ steps.derive.outputs.suffixes }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Derive tag, commit SHA, cells; validate Cargo.toml version
+        id: derive
+        env:
+          EVENT: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_SHA: ${{ github.event.inputs.commit_sha }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"; SHA="$INPUT_SHA"
+          else
+            TAG="$RELEASE_TAG"; SHA="$GH_SHA"
+          fi
+          # Validate Cargo.toml version matches the (v-stripped) tag — fail loudly
+          # so a mis-tagged release never ships mismatched binaries.
+          SEMVER="${TAG#v}"
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name=="falkordb-rs") | .version')
+          if [ "$CARGO_VERSION" != "$SEMVER" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag ($TAG)"; exit 1
+          fi
+          ALL='[
+            {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest"},
+            {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+          ]'
+          CELLS=$(printf '%s' "$ALL" | jq -c .)
+          SUFFIXES=$(printf '%s' "$ALL" | jq -c '[ .[].suffix ]')
+          {
+            echo "tag=$TAG"
+            echo "commit_sha=$SHA"
+            echo "cells=$CELLS"
+            echo "suffixes=$SUFFIXES"
+          } >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG sha=$SHA cells=$CELLS"
+
+  build:
+    needs: prepare
+    uses: ./.github/workflows/_build-artifacts.yml
+    permissions:
+      contents: read
+      packages: read
+    with:
+      cells: ${{ needs.prepare.outputs.cells }}
+      commit_sha: ${{ needs.prepare.outputs.commit_sha }}
+    secrets: inherit
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: downloaded
+
+      - name: Assemble + assert complete set + checksums
+        id: assemble
+        env:
+          SUFFIXES: ${{ needs.prepare.outputs.suffixes }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # download-artifact lays each artifact down under downloaded/<name>/...
+          find downloaded -type f \( -name 'falkordb-*.so' -o -name 'falkordb-*.so.sha256' \) \
+            -exec cp -t dist {} +
+          # Completeness gate: every expected suffix must be present, else FAIL
+          # (never publish a partial release).
+          MISSING=""
+          for s in $(printf '%s' "$SUFFIXES" | jq -r '.[]'); do
+            if [ ! -f "dist/falkordb-${s}.so" ]; then MISSING="$MISSING falkordb-${s}.so"; fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::missing expected release assets:$MISSING"; exit 1
+          fi
+          ( cd dist && sha256sum falkordb-*.so > SHA256SUMS )
+          echo "Publishing:"; ls -1 dist
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            dist/falkordb-*.so dist/falkordb-*.so.sha256 dist/SHA256SUMS \
+            --clobber

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -14,10 +14,15 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+# CXX defaults to the Debian toolchain's clang++-22. Per-OS toolchain images
+# (rhel9/al2023/rhel8/alpine) reuse this exact builder stage and override the
+# compiler via `--build-arg CXX=<their clang++>` — keeping one build path /
+# one self-containment contract for every platform (see build/Dockerfile.<os>).
+ARG CXX=clang++-22
 COPY --from=planner /src/recipe.json recipe.json
-RUN CXX=clang++-22 cargo chef cook --release --recipe-path recipe.json
+RUN CXX="$CXX" cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN CXX=clang++-22 cargo build --release && \
+RUN CXX="$CXX" cargo build --release && \
     mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so && \
     echo "=== verify single-.so contract on libfalkordb.so ===" && \
     deps="$(ldd /out/falkordb.so | awk '{print $1}' | sort -u)" && \

--- a/build/runtime/Dockerfile
+++ b/build/runtime/Dockerfile
@@ -30,6 +30,22 @@ RUN CXX=clang++-22 cargo build --release && \
     echo "OK: libfalkordb.so is self-contained ($(du -h /out/falkordb.so | cut -f1))"
 
 # ---------------------------------------------------------------------------
+# Artifact export stage — yields ONLY the built falkordb.so so CI can extract
+# the exact .so the runtime image ships via:
+#   docker build --target artifact --output type=local,dest=<dir> ...
+# This is the single source of truth for the released shared library: it reuses
+# the `builder` stage above (same cargo flags, same self-containment contract),
+# so the released .so == the .so baked into the runtime image.
+#
+# FROM scratch keeps the --output tree clean (just the .so, no userland). It is
+# placed AFTER `builder` and BEFORE the runtime stages so (a) it never pulls in
+# the Debian runtime layers and (b) it is NOT the default build target — the
+# default remains the final `full` stage at the bottom of this file.
+# ---------------------------------------------------------------------------
+FROM scratch AS artifact
+COPY --from=builder /out/falkordb.so /falkordb.so
+
+# ---------------------------------------------------------------------------
 # Redis builder stage — debian:trixie-slim + minimal build deps.
 #
 # We build redis-server / redis-cli ourselves on debian:trixie-slim instead

--- a/build/runtime/Dockerfile.amazonlinux2023
+++ b/build/runtime/Dockerfile.amazonlinux2023
@@ -1,0 +1,100 @@
+# Self-contained Amazon Linux 2023 (glibc 2.34) builder for the FalkorDB shared
+# library. Unlike build/runtime/Dockerfile (which consumes the prebuilt Debian
+# `falkordb-build` toolchain image), this image installs its own toolchain and
+# builds GraphBLAS + LAGraph + libomp + RediSearch from source via the SAME
+# scripts the Debian toolchain uses — so the produced .so has a glibc-2.34
+# baseline and the single-.so self-containment contract still holds.
+#
+# Exported via:  docker build --target artifact --output type=local,dest=<dir>
+# Package set mirrors the C repo's build/docker/builder/Dockerfile.amazonlinux2023, minus
+# the C-only peg/libcypher-parser bits the Rust port doesn't use.
+
+ARG CXX=clang++-19
+# Consumed (unused) so the shared _build-artifacts.yml can pass --build-arg
+# BUILD_IMAGE uniformly without a "not consumed" warning; self-contained OSes
+# don't use a toolchain base image.
+ARG BUILD_IMAGE
+
+# ---------------------------------------------------------------------------
+# Toolchain + dependency build.
+# ---------------------------------------------------------------------------
+FROM amazonlinux:2023 AS builder
+
+ENV CC=clang-19
+ENV CXX=clang++-19
+# build.rs picks llvm-objcopy/objdump by bare name then -22/-21/-20; AL2023's
+# clang19 tools are versioned -19, so point at them explicitly. LIBCLANG_PATH
+# lets the redisearch_rs bindgen find clang19's libclang.
+ENV LLVM_OBJCOPY=llvm-objcopy-19
+ENV LLVM_OBJDUMP=llvm-objdump-19
+ENV LIBCLANG_PATH=/usr/lib64/llvm19/lib
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# AL2023's default clang is 15 — too old for RediSearch's C++20. Use the
+# versioned clang19 packages instead (clang-19 / clang++-19 land on PATH).
+RUN dnf update -y && \
+    dnf install -y \
+      git wget tar gzip xz which diffutils file \
+      make automake autoconf libtool perl \
+      gcc gcc-c++ \
+      clang19 clang19-devel llvm19 \
+      openssl-devel zlib-devel \
+      python3.11 python3.11-pip python3.11-devel && \
+    dnf clean all && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3
+
+# Pin cmake to the same version the C builders use (UBI9's 3.26 also works for
+# GraphBLAS, but keep one version across every OS for reproducibility).
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain (rustup) — needed for the redisearch_rs crate and the cdylib.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+WORKDIR /data
+
+# libomp.a (static) matched to the system clang version, installed to /opt/libomp
+# so graph/build.rs links it statically (single-.so OpenMP contract).
+COPY build/libomp.sh /tmp/libomp.sh
+RUN LLVMORG_VERSION=$(clang-19 --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1) && \
+    test -n "${LLVMORG_VERSION}" && \
+    /tmp/libomp.sh "${LLVMORG_VERSION}" && \
+    rm -f /tmp/libomp.sh
+
+# GraphBLAS + LAGraph (static) → /usr/local/lib/libgraphblas.a + /data/lagraph_lib
+COPY graphblas.sh /data/graphblas.sh
+COPY build/graphblas /data/build/graphblas
+RUN LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
+    rm -rf /data/graphblas.sh /data/build
+
+# RediSearch (static) → /data/redisearch/RediSearch/bin
+COPY redisearch.sh /data/redisearch.sh
+RUN bash /data/redisearch.sh && \
+    rm -f /data/redisearch.sh
+
+# Build the cdylib from the repo source. Deps resolve via graph/build.rs's
+# absolute fallbacks (/data/lagraph_lib, /data/redisearch/RediSearch/bin),
+# GRAPHBLAS_LIB_DIR (/usr/local/lib default) and LIBOMP_PREFIX (/opt/libomp).
+ARG CXX
+WORKDIR /src
+COPY . .
+RUN GBDIR="$(dirname "$(find /usr/local /usr /opt -name libgraphblas.a 2>/dev/null | head -1)")" && \
+    test -n "$GBDIR" || { echo "FAIL: libgraphblas.a not found"; exit 1; } && \
+    echo "Using GRAPHBLAS_LIB_DIR=$GBDIR" && \
+    CXX="$CXX" LIBOMP_PREFIX=/opt/libomp GRAPHBLAS_LIB_DIR="$GBDIR" cargo build --release && \
+    mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so && \
+    echo "=== verify single-.so contract on libfalkordb.so ===" && \
+    deps="$(ldd /out/falkordb.so | awk '{print $1}' | sort -u)" && \
+    echo "$deps" && \
+    if echo "$deps" | grep -E '^(libomp|libgomp|libgraphblas|liblagraph|liblagraphx|libredisearch|libVectorSimilarity)'; then \
+        echo "FAIL: libfalkordb.so has forbidden dynamic dependency"; exit 1; \
+    fi && \
+    undef="$(nm -D --undefined-only /out/falkordb.so 2>/dev/null | grep -E 'omp_|GOMP_|__kmpc_' || true)" && \
+    if [ -n "$undef" ]; then echo "FAIL: OpenMP symbols undefined in .so:"; echo "$undef"; exit 1; fi && \
+    echo "OK: libfalkordb.so is self-contained ($(du -h /out/falkordb.so | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Artifact export stage — yields ONLY the built falkordb.so.
+# ---------------------------------------------------------------------------
+FROM scratch AS artifact
+COPY --from=builder /out/falkordb.so /falkordb.so

--- a/build/runtime/Dockerfile.rhel9
+++ b/build/runtime/Dockerfile.rhel9
@@ -1,0 +1,92 @@
+# Self-contained RHEL9 / UBI9 (glibc 2.34) builder for the FalkorDB shared
+# library. Unlike build/runtime/Dockerfile (which consumes the prebuilt Debian
+# `falkordb-build` toolchain image), this image installs its own toolchain and
+# builds GraphBLAS + LAGraph + libomp + RediSearch from source via the SAME
+# scripts the Debian toolchain uses — so the produced .so has a glibc-2.34
+# baseline and the single-.so self-containment contract still holds.
+#
+# Exported via:  docker build --target artifact --output type=local,dest=<dir>
+# Package set mirrors the C repo's build/docker/builder/Dockerfile.rhel9, minus
+# the C-only peg/libcypher-parser bits the Rust port doesn't use.
+
+ARG CXX=clang++
+# Consumed (unused) so the shared _build-artifacts.yml can pass --build-arg
+# BUILD_IMAGE uniformly without a "not consumed" warning; self-contained OSes
+# don't use a toolchain base image.
+ARG BUILD_IMAGE
+
+# ---------------------------------------------------------------------------
+# Toolchain + dependency build.
+# ---------------------------------------------------------------------------
+FROM redhat/ubi9 AS builder
+
+ENV CC=clang
+ENV CXX=clang++
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN yum update -y && \
+    yum install -y \
+      git wget tar gzip xz which diffutils file \
+      make automake autoconf libtool \
+      gcc gcc-c++ \
+      clang clang-devel llvm \
+      openssl-devel zlib-devel \
+      python3.11 python3.11-pip python3.11-devel && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3 && \
+    yum clean all
+
+# Pin cmake to the same version the C builders use (UBI9's 3.26 also works for
+# GraphBLAS, but keep one version across every OS for reproducibility).
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain (rustup) — needed for the redisearch_rs crate and the cdylib.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+WORKDIR /data
+
+# libomp.a (static) matched to the system clang version, installed to /opt/libomp
+# so graph/build.rs links it statically (single-.so OpenMP contract).
+COPY build/libomp.sh /tmp/libomp.sh
+RUN LLVMORG_VERSION=$(clang --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1) && \
+    test -n "${LLVMORG_VERSION}" && \
+    CC=clang CXX=clang++ /tmp/libomp.sh "${LLVMORG_VERSION}" && \
+    rm -f /tmp/libomp.sh
+
+# GraphBLAS + LAGraph (static) → /usr/local/lib/libgraphblas.a + /data/lagraph_lib
+COPY graphblas.sh /data/graphblas.sh
+COPY build/graphblas /data/build/graphblas
+RUN CC=clang CXX=clang++ LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
+    rm -rf /data/graphblas.sh /data/build
+
+# RediSearch (static) → /data/redisearch/RediSearch/bin
+COPY redisearch.sh /data/redisearch.sh
+RUN CC=clang CXX=clang++ bash /data/redisearch.sh && \
+    rm -f /data/redisearch.sh
+
+# Build the cdylib from the repo source. Deps resolve via graph/build.rs's
+# absolute fallbacks (/data/lagraph_lib, /data/redisearch/RediSearch/bin),
+# GRAPHBLAS_LIB_DIR (/usr/local/lib default) and LIBOMP_PREFIX (/opt/libomp).
+ARG CXX
+WORKDIR /src
+COPY . .
+RUN GBDIR="$(dirname "$(find /usr/local /usr /opt -name libgraphblas.a 2>/dev/null | head -1)")" && \
+    test -n "$GBDIR" || { echo "FAIL: libgraphblas.a not found"; exit 1; } && \
+    echo "Using GRAPHBLAS_LIB_DIR=$GBDIR" && \
+    CXX="$CXX" LIBOMP_PREFIX=/opt/libomp GRAPHBLAS_LIB_DIR="$GBDIR" cargo build --release && \
+    mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so && \
+    echo "=== verify single-.so contract on libfalkordb.so ===" && \
+    deps="$(ldd /out/falkordb.so | awk '{print $1}' | sort -u)" && \
+    echo "$deps" && \
+    if echo "$deps" | grep -E '^(libomp|libgomp|libgraphblas|liblagraph|liblagraphx|libredisearch|libVectorSimilarity)'; then \
+        echo "FAIL: libfalkordb.so has forbidden dynamic dependency"; exit 1; \
+    fi && \
+    undef="$(nm -D --undefined-only /out/falkordb.so 2>/dev/null | grep -E 'omp_|GOMP_|__kmpc_' || true)" && \
+    if [ -n "$undef" ]; then echo "FAIL: OpenMP symbols undefined in .so:"; echo "$undef"; exit 1; fi && \
+    echo "OK: libfalkordb.so is self-contained ($(du -h /out/falkordb.so | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Artifact export stage — yields ONLY the built falkordb.so.
+# ---------------------------------------------------------------------------
+FROM scratch AS artifact
+COPY --from=builder /out/falkordb.so /falkordb.so


### PR DESCRIPTION
## What

Adds a **dispatchable, parallel, multi-arch build of the FalkorDB shared library
(`libfalkordb.so`)** and a **GitHub-Release upload mechanism**, reaching **parity with the
C repo's released binaries** ([FalkorDB/FalkorDB](https://github.com/FalkorDB/FalkorDB)).
Implements the full plan in #608.

The C repo attaches a raw per-arch `.so` (release + debug) for every platform it supports,
plus RAMP `.zip` packages. This PR brings the same artifact set to `falkordb-rs-next-gen`,
triggerable manually on a PR to verify every platform builds **before** a release.

## Platform matrix (target = full C parity)

Asset names mirror the C repo exactly so downstream tooling/docs transfer unchanged.

| Asset suffix | libc / OS | Runner | Build env | RAMP | Status |
|---|---|---|---|---|---|
| `x64` | glibc / debian trixie | `ubuntu-latest` | existing toolchain | ✅ | ✅ green |
| `arm64v8` | glibc / debian trixie | `ubuntu-24.04-arm` | existing toolchain | ✅ | ✅ green |
| `rhel9-x64` | glibc 2.34 / UBI9 | `ubuntu-latest` | new toolchain image | ✅ | 🚧 |
| `amazonlinux2023-x64` | glibc / AL2023 | `ubuntu-latest` | new toolchain image | ✅ | 🚧 |
| `rhel8-x64` | glibc 2.28 / UBI8 | `ubuntu-latest` | new toolchain image | ✅ | 🚧 |
| `alpine-x64` | musl / alpine | `ubuntu-latest` | new toolchain image | ❌ | 🚧 |
| `alpine-arm64v8` | musl / alpine | `ubuntu-24.04-arm` | new toolchain image | ❌ | 🚧 |
| `macos-arm64v8` | macOS arm64 | `macos-14` | native `cargo` (no Docker) | ❌ | 🚧 (coord. #551) |

Each platform ships a release `.so` + a debug `.so`. RAMP `.zip` packages mirror the C
RAMP matrix (linux x64/arm64, rhel8/9, amazonlinux2023 — C does not RAMP alpine/macOS).

## Design

**Core principle: separate build (fan-out) from publish (fan-in)** so a partial matrix
failure never leaves a half-populated public Release.

| File | Purpose |
|---|---|
| `build/runtime/Dockerfile` | New `FROM scratch AS artifact` stage exporting **only** the built `.so`, reusing the existing `builder` stage + single-`.so` self-containment contract (released `.so` == in-image `.so`). |
| `.github/workflows/_build-artifacts.yml` | Reusable **build-only** matrix; extracts the `.so` via `docker build --target artifact --output type=local`, checksums it, uploads a workflow artifact. Native runners, `fail-fast: false`, max parallelism. |
| `.github/workflows/build-artifacts.yml` | **Verifier** — `workflow_dispatch` + label-gated `pull_request`. Build only (no Release upload). |
| `.github/workflows/release-artifacts.yml` | **Publisher** — `release: published` / dispatch. Fan-in job asserts the full asset set is present, writes `SHA256SUMS`, then `gh release upload --clobber`. |
| `build/Dockerfile.<os>` (per OS) | New toolchain images (GraphBLAS + LAGraph + RediSearch + libomp + Rust/clang) for the non-Debian targets. |

## How to verify on this PR

⚠️ `workflow_dispatch` cannot reach a workflow that only exists on a feature branch
(GitHub lists dispatchable workflows from the default branch only). So the verifier also
triggers on a **label**:

> Add the **`verify-artifacts`** label → the full multi-arch build runs at the PR head and
> re-runs on every push while labeled. Remove + re-add to force a re-run.

After merge, `workflow_dispatch` (Actions → **Build artifacts (verify)** → Run workflow,
optional `archs` input) becomes the long-term manual trigger for any branch/tag.

## Notes

- **Build/publish split** + fan-in completeness gate → never ship a partial release.
- **Single source of truth**: the released `.so` is the same one the runtime image bakes
  in (same Dockerfile `builder` stage, same self-containment check run in the target arch).
- **Parallelism**: amd64 on `ubuntu-latest`, arm64 natively on `ubuntu-24.04-arm` (no QEMU).
- glibc baseline = `debian:trixie-slim` (documented); per-OS images give the rhel/al2023/
  musl baselines.
- Native macOS build & test is also being added in #551 — coordinated to avoid duplication.

Plan was prepared and twice rubber-duck-reviewed before implementation.

Closes #608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added reusable GitHub Actions workflows for automated multi-platform artifact builds (Linux and macOS) with validation and caching
  * Implemented automated release artifact publishing workflow with checksum generation and integrity verification
  * Enhanced build infrastructure with configurable compiler toolchain selection and added RHEL9-specific build support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->