### PR TITLE
ci: add RHEL8 (glibc 2.28) shared-library artifact (follow-up to #609)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -64,7 +64,8 @@ jobs:
             {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"},
-            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"}
+            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"},
+            {"suffix":"rhel8-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel8","build_image":"","cxx":"clang++"}
           ]'
           MACOS_SUFFIX="macos-arm64v8"
           if [ "$EVENT" = "workflow_dispatch" ] && [ -n "${ARCHS:-}" ] && [ "$ARCHS" != "all" ]; then

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -80,7 +80,8 @@ jobs:
             {"suffix":"x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"arm64v8","arch":"arm64v8","platform":"linux/arm64","runner":"ubuntu-24.04-arm","dockerfile":"build/runtime/Dockerfile","build_image":"ghcr.io/falkordb/falkordb-build:latest","cxx":"clang++-22"},
             {"suffix":"rhel9-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel9","build_image":"","cxx":"clang++"},
-            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"}
+            {"suffix":"amazonlinux2023-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.amazonlinux2023","build_image":"","cxx":"clang++-19"},
+            {"suffix":"rhel8-x64","arch":"x64","platform":"linux/amd64","runner":"ubuntu-latest","dockerfile":"build/runtime/Dockerfile.rhel8","build_image":"","cxx":"clang++"}
           ]'
           CELLS=$(printf '%s' "$ALL" | jq -c .)
           SUFFIXES=$(printf '%s' "$ALL" | jq -c '[ .[].suffix ]')

--- a/build/runtime/Dockerfile.rhel8
+++ b/build/runtime/Dockerfile.rhel8
@@ -1,0 +1,94 @@
+# Self-contained RHEL8 / UBI8 (glibc 2.28) builder for the FalkorDB shared
+# library. Unlike build/runtime/Dockerfile (which consumes the prebuilt Debian
+# `falkordb-build` toolchain image), this image installs its own toolchain and
+# builds GraphBLAS + LAGraph + libomp + RediSearch from source via the SAME
+# scripts the Debian toolchain uses — so the produced .so has a glibc-2.34
+# baseline and the single-.so self-containment contract still holds.
+#
+# Exported via:  docker build --target artifact --output type=local,dest=<dir>
+# Package set mirrors the C repo's build/docker/builder/Dockerfile.rhel8, minus
+# the C-only peg/libcypher-parser bits the Rust port doesn't use.
+
+ARG CXX=clang++
+# Consumed (unused) so the shared _build-artifacts.yml can pass --build-arg
+# BUILD_IMAGE uniformly without a "not consumed" warning; self-contained OSes
+# don't use a toolchain base image.
+ARG BUILD_IMAGE
+
+# ---------------------------------------------------------------------------
+# Toolchain + dependency build.
+# ---------------------------------------------------------------------------
+FROM redhat/ubi8 AS builder
+
+ENV CC=clang
+ENV CXX=clang++
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN yum install -y dnf-plugins-core && \
+    (dnf config-manager --set-enabled ubi-8-codeready-builder-rpms || true) && \
+    yum update -y && \
+    yum install -y \
+      git wget tar gzip xz which diffutils file \
+      make automake autoconf libtool perl-core \
+      gcc gcc-c++ \
+      clang clang-devel llvm \
+      openssl-devel zlib-devel \
+      python3.11 python3.11-pip python3.11-devel && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
+    alternatives --auto python3 && \
+    yum clean all
+
+# Pin cmake to the same version the C builders use (UBI9's 3.26 also works for
+# GraphBLAS, but keep one version across every OS for reproducibility).
+RUN pip3.11 install --no-cache-dir 'cmake==3.31.6'
+
+# Rust toolchain (rustup) — needed for the redisearch_rs crate and the cdylib.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+WORKDIR /data
+
+# libomp.a (static) matched to the system clang version, installed to /opt/libomp
+# so graph/build.rs links it statically (single-.so OpenMP contract).
+COPY build/libomp.sh /tmp/libomp.sh
+RUN LLVMORG_VERSION=$(clang --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1) && \
+    test -n "${LLVMORG_VERSION}" && \
+    CC=clang CXX=clang++ /tmp/libomp.sh "${LLVMORG_VERSION}" && \
+    rm -f /tmp/libomp.sh
+
+# GraphBLAS + LAGraph (static) → /usr/local/lib/libgraphblas.a + /data/lagraph_lib
+COPY graphblas.sh /data/graphblas.sh
+COPY build/graphblas /data/build/graphblas
+RUN CC=clang CXX=clang++ LAGRAPH_INSTALL_DIR=/data/lagraph_lib /data/graphblas.sh && \
+    rm -rf /data/graphblas.sh /data/build
+
+# RediSearch (static) → /data/redisearch/RediSearch/bin
+COPY redisearch.sh /data/redisearch.sh
+RUN CC=clang CXX=clang++ bash /data/redisearch.sh && \
+    rm -f /data/redisearch.sh
+
+# Build the cdylib from the repo source. Deps resolve via graph/build.rs's
+# absolute fallbacks (/data/lagraph_lib, /data/redisearch/RediSearch/bin),
+# GRAPHBLAS_LIB_DIR (/usr/local/lib default) and LIBOMP_PREFIX (/opt/libomp).
+ARG CXX
+WORKDIR /src
+COPY . .
+RUN GBDIR="$(dirname "$(find /usr/local /usr /opt -name libgraphblas.a 2>/dev/null | head -1)")" && \
+    test -n "$GBDIR" || { echo "FAIL: libgraphblas.a not found"; exit 1; } && \
+    echo "Using GRAPHBLAS_LIB_DIR=$GBDIR" && \
+    CXX="$CXX" LIBOMP_PREFIX=/opt/libomp GRAPHBLAS_LIB_DIR="$GBDIR" cargo build --release && \
+    mkdir -p /out && cp target/release/libfalkordb.so /out/falkordb.so && \
+    echo "=== verify single-.so contract on libfalkordb.so ===" && \
+    deps="$(ldd /out/falkordb.so | awk '{print $1}' | sort -u)" && \
+    echo "$deps" && \
+    if echo "$deps" | grep -E '^(libomp|libgomp|libgraphblas|liblagraph|liblagraphx|libredisearch|libVectorSimilarity)'; then \
+        echo "FAIL: libfalkordb.so has forbidden dynamic dependency"; exit 1; \
+    fi && \
+    undef="$(nm -D --undefined-only /out/falkordb.so 2>/dev/null | grep -E 'omp_|GOMP_|__kmpc_' || true)" && \
+    if [ -n "$undef" ]; then echo "FAIL: OpenMP symbols undefined in .so:"; echo "$undef"; exit 1; fi && \
+    echo "OK: libfalkordb.so is self-contained ($(du -h /out/falkordb.so | cut -f1))"
+
+# ---------------------------------------------------------------------------
+# Artifact export stage — yields ONLY the built falkordb.so.
+# ---------------------------------------------------------------------------
+FROM scratch AS artifact
+COPY --from=builder /out/falkordb.so /falkordb.so


### PR DESCRIPTION
## What

Follow-up to #609 (merged), which landed the shared-library artifact pipeline +
5 platforms green: `x64`, `arm64v8`, `rhel9-x64`, `amazonlinux2023-x64`,
`macos-arm64v8`.

This PR adds the **RHEL8 / UBI8 (glibc 2.28)** target — the oldest glibc baseline,
giving the broadest Linux compatibility for the released `.so`.

## Details

- `build/runtime/Dockerfile.rhel8`: self-contained UBI8 builder. UBI8 ships
  **clang 21** (appstream module), so RediSearch's C++20 compiles fine. Enables
  CodeReady Builder for `clang-devel`, adds `perl-core` for libomp's i18n header
  generation, resolves `GRAPHBLAS_LIB_DIR` dynamically (RHEL installs to `lib64`),
  and links the system OpenSSL 1.1. Builds GraphBLAS + LAGraph + libomp +
  RediSearch via the shared scripts and exports `falkordb-rhel8-x64.so`.
  **Validated locally (arm64 UBI8) end to end.**
- Wires the `rhel8-x64` cell into `build-artifacts.yml` + `release-artifacts.yml`.

## Verify

Add the **`verify-artifacts`** label (or, now that the workflow is on `main`,
use **Actions → Build artifacts (verify) → Run workflow** with `archs=rhel8-x64`).

## Remaining for full C parity (tracked in #608)

- `alpine-x64` / `alpine-arm64v8` (musl): blocked on `clang-sys` forcing static
  `libclang` on musl (Alpine has no monolithic `libclang.a`); needs a clang-sys
  runtime-feature path or a built `libclang.a`.
- Debug `.so` variants + RAMP `.zip` packaging.

Refs #608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RHEL8 x64 platform support, expanding FalkorDB availability to Red Hat Enterprise Linux 8 environments.

* **Chores**
  * Expanded build and release pipeline infrastructure to support the new platform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->