### PR TITLE
fix(mvcc): avoid mutable-borrow race when publishing indexer graph ref

### DIFF
--- a/graph/src/graph/graph.rs
+++ b/graph/src/graph/graph.rs
@@ -3423,8 +3423,15 @@ impl Graph {
         self.edge_indexer.cancel();
     }
 
+    /// Takes `&self` (not `&mut self`): it only publishes the graph
+    /// reference into the node/edge indexers' own `Mutex`-guarded fields,
+    /// via `Indexer::set_graph`. This lets `MvccGraph::commit()` call it
+    /// through an immutable borrow of the graph, so the background index
+    /// population thread's own immutable borrows of the same
+    /// `AtomicRefCell<Graph>` are never blocked by (or racing against) a
+    /// concurrent mutable borrow here -- see `MvccGraph::commit()`.
     pub fn set_indexer_graph(
-        &mut self,
+        &self,
         graph: Arc<AtomicRefCell<Self>>,
     ) {
         self.node_indexer.set_graph(graph.clone());

--- a/graph/src/graph/mvcc_graph.rs
+++ b/graph/src/graph/mvcc_graph.rs
@@ -160,7 +160,14 @@ impl MvccGraph {
             new_graph.borrow_mut().schema_version += 1;
         }
 
-        new_graph.borrow_mut().set_indexer_graph(new_graph.clone());
+        // Use an immutable borrow here: `set_indexer_graph` only publishes
+        // `new_graph` into the indexers' own `Mutex`-guarded fields. Holding
+        // a mutable borrow across this call previously created a race with
+        // the background index population thread, which fetches this same
+        // graph reference from the indexer and immediately calls `.borrow()`
+        // on it -- if that happened before this statement's `borrow_mut()`
+        // guard was dropped, it panicked with "already mutably borrowed".
+        new_graph.borrow().set_indexer_graph(new_graph.clone());
         self.graph = new_graph;
         self.write.store(false, Ordering::Release);
     }

--- a/graph/src/index/indexer.rs
+++ b/graph/src/index/indexer.rs
@@ -846,8 +846,15 @@ impl Indexer {
         Ok(())
     }
 
+    /// Only touches the `Indexer`'s own `Mutex`-guarded field, so this takes
+    /// `&self` deliberately: it must be callable while the caller holds only
+    /// an immutable borrow of the enclosing `Graph` (see
+    /// `Graph::set_indexer_graph`), so that background index population
+    /// (which also just needs an immutable borrow of the committed graph)
+    /// never races with this call and panics with "already mutably
+    /// borrowed".
     pub fn set_graph(
-        &mut self,
+        &self,
         graph: Arc<AtomicRefCell<Graph>>,
     ) {
         *self.graph.lock() = Some(graph);

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -135,7 +135,7 @@ pub fn graph_copy(
     // Wrap the decoded graph and set on dest key.
     let mvcc = MvccGraph::from_graph(new_graph);
     let graph_arc = mvcc.read();
-    graph_arc.borrow_mut().set_indexer_graph(graph_arc.clone());
+    graph_arc.borrow().set_indexer_graph(graph_arc.clone());
     let tg = ThreadedGraph::from_mvcc(mvcc);
     let boxed = Arc::new(RwLock::new(tg));
 

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -43,7 +43,7 @@ pub fn graph_restore(
     // Wrap the decoded graph and set on dest key.
     let mvcc = MvccGraph::from_graph(new_graph);
     let graph_arc = mvcc.read();
-    graph_arc.borrow_mut().set_indexer_graph(graph_arc.clone());
+    graph_arc.borrow().set_indexer_graph(graph_arc.clone());
     let tg = ThreadedGraph::from_mvcc(mvcc);
     let boxed = Arc::new(RwLock::new(tg));
 

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -88,7 +88,7 @@ unsafe extern "C" fn graph_rdb_load(
             // Single-key load (key_count == 1) -- graph is fully loaded.
             let mvcc = MvccGraph::from_graph(graph);
             let graph_arc = mvcc.read();
-            graph_arc.borrow_mut().set_indexer_graph(graph_arc.clone());
+            graph_arc.borrow().set_indexer_graph(graph_arc.clone());
             let tg = ThreadedGraph::from_mvcc(mvcc);
             let arc = Arc::new(RwLock::new(tg));
             crate::graph_core::register_graph(key_name, arc.clone());
@@ -104,7 +104,7 @@ unsafe extern "C" fn graph_rdb_load(
                 if let Some(graph) = decode_state.finalized.remove(&key_name) {
                     let mvcc = MvccGraph::from_graph(graph);
                     let graph_arc = mvcc.read();
-                    graph_arc.borrow_mut().set_indexer_graph(graph_arc.clone());
+                    graph_arc.borrow().set_indexer_graph(graph_arc.clone());
                     drop(graph_arc);
                     // If a placeholder Arc was already registered for this
                     // key (main key loaded in middle of stream), mutate it
@@ -748,7 +748,7 @@ fn install_graph(
 ) {
     let mvcc = MvccGraph::from_graph(graph);
     let graph_arc = mvcc.read();
-    graph_arc.borrow_mut().set_indexer_graph(graph_arc.clone());
+    graph_arc.borrow().set_indexer_graph(graph_arc.clone());
     drop(graph_arc);
 
     if let Some(ph) = placeholder {


### PR DESCRIPTION
## Summary
Fixes a real data race in `MvccGraph::commit()` that caused intermittent `AtomicRefCell` panics ("already mutably borrowed"), crashing the whole `redis-server` process (the global panic hook calls `std::process::exit(1)` on any panic). This is the root cause of the flaky `-svc`/ASAN flow test failures seen on `main` and on unrelated PRs (`test_stress`, `test_index_create`, `test_index_scans`, `test_wcc`, `test_constraint`, etc. — the tests that exercise concurrent writes + background index population).

## Root cause
`MvccGraph::commit()` published the newly committed graph to the node/edge `Indexer`s like this:

```rust
new_graph.borrow_mut().set_indexer_graph(new_graph.clone());
self.graph = new_graph;
```

`set_indexer_graph`/`Indexer::set_graph` only assign into an `Arc<Mutex<Option<...>>>` field — they never need exclusive (`&mut`) access to the `Graph` — but their signatures took `&mut self`, forcing the caller to hold a mutable `AtomicRefCell` borrow across the whole publish call.

Meanwhile, the background index-population worker (`populate_index_batch` in `graph/src/graph/graph.rs`) fetches this same graph `Arc` via `Indexer::get_graph()` and immediately calls `.borrow()` on it to scan entities. If that happened while `commit()`'s `borrow_mut()` guard was still alive (i.e., before the whole statement finished), `AtomicRefCell` panicked with "already mutably borrowed".

## Changes
- `Indexer::set_graph`: `&mut self` → `&self` (body only locks an internal `Mutex`).
- `Graph::set_indexer_graph`: `&mut self` → `&self` (same reason; delegates to the above).
- `MvccGraph::commit()`: publish the new graph reference through `new_graph.borrow()` (immutable) instead of `new_graph.borrow_mut()`.
- Follow-up consistency fix: the 3 remaining call sites of `set_indexer_graph` in the root crate (RDB single/multi-key load in `redis_type.rs`, `GRAPH.RESTORE`, `GRAPH.COPY`) also switched from `.borrow_mut()` to `.borrow()`. These build a brand-new, not-yet-published graph so they weren't exposed to the same race, but there's no reason to hold an unneeded exclusive borrow there either, and this avoids reintroducing the same bug class if those paths are ever changed to publish earlier.

This removes the race window entirely — commit's publish step is now just another immutable reader, so it can never conflict with the background populate thread's own immutable borrows of the same graph.

## Testing
- `cargo build` (workspace) — `falkordb-rs` and `graph` compile cleanly. (The `graph-fuzz`/`runtime-fuzz-target` crates fail to *link* in this sandbox due to pre-existing missing `LAGraph`/AFL instrumentation symbols, unrelated to this change.)
- `cargo test -p graph --lib` and `cargo test -p graph --tests` — 90/90 passed.
- `cargo fmt --all -- --check` — clean.
- `CXX=clang++ cargo clippy -p graph --lib` — no new warnings introduced by this change (pre-existing, unrelated clippy debt elsewhere in the crate is untouched).

## Note on other CI failures observed on this PR
Re-running this PR's own CI surfaced two **unrelated**, pre-existing flaky failures not touched by this change (confirmed by file scope — this PR only touches `graph.rs`/`mvcc_graph.rs`/`indexer.rs` borrow semantics and 3 unrelated `set_indexer_graph` call sites):
1. `flow-release / test_stress.py (svc)`: `env.assertFalse(in_progress)` timing assertion on BGSAVE completion (`tests/flow/test_stress.py:71`) — a shared-runner timing flake; the file already has a comment documenting this exact flakiness for ASAN/coverage builds, and this instance hit the plain `release` build under CI load.
2. `flow-coverage / test_concurrent_query.py (svc)`: a **different**, real bug — `debug_assert!` failure in `register_graph` (`src/graph_core.rs:94`, "name already registered; missing graph_free or placeholder swap") in `test_04`/`test_05`'s concurrent-delete-then-recreate scenario. This is a separate concurrency issue in graph key (re)registration, unrelated to the `AtomicRefCell` borrow race fixed here, and needs its own follow-up investigation/PR.

## Memory / Performance Impact
None. This only changes which borrow kind (`&`/`&mut`) is used around a single `Mutex` write during commit; no allocation or algorithmic change.

## Related Issues
- Root-causes the flakiness noted in `flow-asan`/`flow-release` `-svc` jobs (`test_stress`, `test_index_create`, `test_wcc`, `test_index_scans`, `test_constraint`) observed on `main` and PR #648.