### PR TITLE
fix(security): avoid UB from from_utf8_unchecked on binary key names

### DIFF
--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -518,11 +518,18 @@ unsafe fn scan_and_clean_graphdata_keys(
                 let kptr = raw::RedisModule_CallReplyStringPtr.unwrap()(elem, &raw mut key_len);
                 // Redis key names are binary-safe, so a graphdata-typed key may
                 // have a non-UTF-8 name (e.g. `GRAPH.QUERY "\xff" ...`). Building a
-                // `str` over non-UTF-8 bytes via `from_utf8_unchecked` is UB, so use
-                // the lossy conversion like the other key-name reads in this file.
-                let key_name =
-                    String::from_utf8_lossy(std::slice::from_raw_parts(kptr.cast(), key_len))
-                        .to_string();
+                // `str` over non-UTF-8 bytes via `from_utf8_unchecked` is UB. Skip
+                // any non-UTF-8 key rather than decoding it lossily: this name is
+                // fed back into `RedisModule_CreateString` for the open/delete
+                // below, and a lossy name no longer round-trips to the same key
+                // (and could even alias a different one). Real graph keys are
+                // always UTF-8 (see the lossy `graph_rdb_save`/`graph_rdb_load`
+                // paths), so a non-UTF-8 graphdata key is never a live graph.
+                let key_bytes = std::slice::from_raw_parts(kptr.cast::<u8>(), key_len);
+                let Ok(key_name) = std::str::from_utf8(key_bytes) else {
+                    continue;
+                };
+                let key_name = key_name.to_string();
 
                 let rm_str = raw::RedisModule_CreateString.unwrap()(
                     ctx,
@@ -678,12 +685,16 @@ unsafe fn scan_keys_by_type(
                 let elem = raw::call_reply_array_element(arr_reply, i);
                 let mut name_len: usize = 0;
                 let kptr = raw::RedisModule_CallReplyStringPtr.unwrap()(elem, &raw mut name_len);
-                // Key names are binary-safe; avoid UB from `from_utf8_unchecked` on
-                // a non-UTF-8 name by converting lossily (see scan_and_clean above).
-                let key_name =
-                    String::from_utf8_lossy(std::slice::from_raw_parts(kptr.cast(), name_len))
-                        .to_string();
-                out.push(key_name);
+                // Key names are binary-safe; skip any non-UTF-8 name rather than
+                // decoding it lossily. `out` names are round-tripped back through
+                // `RedisModule_CreateString`/`OpenKey` for deletion, so a lossy name
+                // would target the wrong key; and `from_utf8_unchecked` on non-UTF-8
+                // bytes is UB (see scan_and_clean_graphdata_keys above).
+                let key_bytes = std::slice::from_raw_parts(kptr.cast::<u8>(), name_len);
+                let Ok(key_name) = std::str::from_utf8(key_bytes) else {
+                    continue;
+                };
+                out.push(key_name.to_string());
             }
 
             cursor_val = CString::new(new_cursor).unwrap();

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -47,7 +47,7 @@ use graph::graph::mvcc_graph::MvccGraph;
 use graph::runtime::functions::{GraphFn, register_udf};
 use graph::udf::get_udf_repo;
 use parking_lot::RwLock;
-use redis_module::logging::log_notice;
+use redis_module::logging::{log_notice, log_warning};
 use redis_module::raw::{
     self, RedisModuleCtx, RedisModuleIO, load_string_buffer, load_unsigned, save_string,
     save_unsigned,
@@ -528,6 +528,10 @@ unsafe fn scan_and_clean_graphdata_keys(
                 // does not regress any normally (UTF-8) named graph.
                 let key_bytes = std::slice::from_raw_parts(kptr.cast::<u8>(), key_len);
                 let Ok(key_name) = std::str::from_utf8(key_bytes) else {
+                    log_warning(format!(
+                        "Skipping graphdata key with non-UTF-8 name during scan (lossy display: {})",
+                        String::from_utf8_lossy(key_bytes)
+                    ));
                     continue;
                 };
                 let key_name = key_name.to_string();
@@ -693,6 +697,10 @@ unsafe fn scan_keys_by_type(
                 // bytes is UB (see scan_and_clean_graphdata_keys above).
                 let key_bytes = std::slice::from_raw_parts(kptr.cast::<u8>(), name_len);
                 let Ok(key_name) = std::str::from_utf8(key_bytes) else {
+                    log_warning(format!(
+                        "Skipping key with non-UTF-8 name during type scan (lossy display: {})",
+                        String::from_utf8_lossy(key_bytes)
+                    ));
                     continue;
                 };
                 out.push(key_name.to_string());

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -516,8 +516,12 @@ unsafe fn scan_and_clean_graphdata_keys(
                 let elem = raw::call_reply_array_element(arr_reply, i);
                 let mut key_len: usize = 0;
                 let kptr = raw::RedisModule_CallReplyStringPtr.unwrap()(elem, &raw mut key_len);
+                // Redis key names are binary-safe, so a graphdata-typed key may
+                // have a non-UTF-8 name (e.g. `GRAPH.QUERY "\xff" ...`). Building a
+                // `str` over non-UTF-8 bytes via `from_utf8_unchecked` is UB, so use
+                // the lossy conversion like the other key-name reads in this file.
                 let key_name =
-                    std::str::from_utf8_unchecked(std::slice::from_raw_parts(kptr.cast(), key_len))
+                    String::from_utf8_lossy(std::slice::from_raw_parts(kptr.cast(), key_len))
                         .to_string();
 
                 let rm_str = raw::RedisModule_CreateString.unwrap()(
@@ -674,11 +678,11 @@ unsafe fn scan_keys_by_type(
                 let elem = raw::call_reply_array_element(arr_reply, i);
                 let mut name_len: usize = 0;
                 let kptr = raw::RedisModule_CallReplyStringPtr.unwrap()(elem, &raw mut name_len);
-                let key_name = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                    kptr.cast(),
-                    name_len,
-                ))
-                .to_string();
+                // Key names are binary-safe; avoid UB from `from_utf8_unchecked` on
+                // a non-UTF-8 name by converting lossily (see scan_and_clean above).
+                let key_name =
+                    String::from_utf8_lossy(std::slice::from_raw_parts(kptr.cast(), name_len))
+                        .to_string();
                 out.push(key_name);
             }
 

--- a/src/redis_type.rs
+++ b/src/redis_type.rs
@@ -522,9 +522,10 @@ unsafe fn scan_and_clean_graphdata_keys(
                 // any non-UTF-8 key rather than decoding it lossily: this name is
                 // fed back into `RedisModule_CreateString` for the open/delete
                 // below, and a lossy name no longer round-trips to the same key
-                // (and could even alias a different one). Real graph keys are
-                // always UTF-8 (see the lossy `graph_rdb_save`/`graph_rdb_load`
-                // paths), so a non-UTF-8 graphdata key is never a live graph.
+                // (and could even alias a different one). A non-UTF-8 graph name
+                // is not round-trippable here and is already handled only lossily
+                // elsewhere (`graph_rdb_save`/`graph_rdb_load`), so skipping it
+                // does not regress any normally (UTF-8) named graph.
                 let key_bytes = std::slice::from_raw_parts(kptr.cast::<u8>(), key_len);
                 let Ok(key_name) = std::str::from_utf8(key_bytes) else {
                     continue;

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -603,3 +603,39 @@ class testGraphPersistency():
         # assert that peak memory did not cross 1.50 * base_memory_consumption
         self.env.assertLess(peak_memory_consumption, 1.50 * base_memory_consumption)
 
+
+    # Regression test: Redis key names are binary-safe, so a graph can live
+    # under a non-UTF-8 key name (e.g. GRAPH.QUERY "\xc3\x28" ...). The
+    # SAVE-time SCAN passes (scan_and_clean_graphdata_keys /
+    # delete_stale_graphmeta_keys) must skip such names instead of building a
+    # str over them (formerly `from_utf8_unchecked` -> UB), and skipping must
+    # not delete or corrupt the graph stored under them.
+    def test_binary_key_name_scan_skip(self):
+        binary_name = b"\xc3\x28persistency_binary"  # invalid UTF-8
+        utf8_name   = "persistency_utf8_sibling"
+
+        # Create a graph under a non-UTF-8 key name (raw command; the client's
+        # Graph API assumes str names) and a normal UTF-8 sibling graph.
+        self.conn.execute_command("GRAPH.QUERY", binary_name, "CREATE (:B {v: 1})")
+        g = self.db.select_graph(utf8_name)
+        g.query("CREATE (:U {v: 2})")
+
+        # Synchronous SAVE triggers the graphdata/graphmeta key scans, which
+        # must skip the binary-named key without touching it.
+        self.conn.execute_command("SAVE")
+
+        # The binary-named key must survive the scan (not be misidentified as
+        # a stale virtual key and deleted).
+        self.env.assertEqual(self.conn.execute_command("EXISTS", binary_name), 1)
+
+        # Reload from RDB; both graphs must round-trip.
+        self.env.dumpAndReload()
+
+        self.env.assertEqual(self.conn.execute_command("EXISTS", binary_name), 1)
+
+        res = self.conn.execute_command("GRAPH.RO_QUERY", binary_name,
+                                        "MATCH (b:B) RETURN b.v")
+        self.env.assertEqual(res[1], [[1]])
+
+        res = g.ro_query("MATCH (u:U) RETURN u.v").result_set
+        self.env.assertEqual(res, [[2]])


### PR DESCRIPTION
## Summary

`scan_and_clean_graphdata_keys` and `scan_keys_by_type` in `src/redis_type.rs` converted the key names returned by `SCAN ... TYPE graphdata` into a `String` using `std::str::from_utf8_unchecked`. Redis keys are **binary-safe**, so a `graphdata`-typed key can legitimately have a name that is not valid UTF-8. Constructing a `str`/`String` over non-UTF-8 bytes is **instantaneous undefined behavior** per the safety contract of `from_utf8_unchecked` — independent of how the value is later used.

This was surfaced by a security review as a soundness bug not covered by #638 (which focused on DoS-via-panic/overflow on the deserialization, parser, and bulk paths).

## Attack path

1. An untrusted client runs e.g. `GRAPH.QUERY "\xff\xfe" "RETURN 1"`. The key name flows unvalidated from the command into `open_key_writable`, creating a `graphdata`-typed key with an invalid-UTF-8 name (only `graphdata`-typed keys match `SCAN ... TYPE graphdata`).
2. A later maintenance event scans those keys and feeds the raw bytes into `from_utf8_unchecked`:
   - synchronous `SAVE` → `create_virtual_keys` → `scan_and_clean_graphdata_keys`
   - post-resync `LOADING_ENDED`/`LOADING_FAILED` → `delete_stale_virtual_keys` → `scan_keys_by_type`
   - `GRAPH.DEBUG`
3. → UB on the main server process. No memory-corruption primitive is demonstrated (the pointer/length pair is valid and downstream ops are byte-oriented), so impact is language-level UB / potential miscompilation rather than proven RCE. Severity: **Medium**.

## Fix

Replace both key-name conversions with checked UTF-8 decoding and **skip invalid UTF-8 key names** in both scan paths.

This keeps behavior safe and precise:
- removes UB from `from_utf8_unchecked`
- avoids lossy-decoding collisions (`from_utf8_lossy` mapping distinct byte keys to the same Unicode string)
- prevents opening/deleting a different key than the one returned by SCAN

The adjacent numeric SCAN **cursor** reads still use `from_utf8_unchecked`; these are left as-is because Redis always emits the cursor as an ASCII decimal string, so they are valid UTF-8 by construction.

## Testing

- `cargo check` — clean (0 errors; only pre-existing unrelated warnings in `aggregation.rs`).
- `cargo fmt --all -- --check` — clean.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis key handling so binary or non-UTF-8 key names are processed safely.
  * Prevented potential crashes or undefined behavior when scanning Redis keys.
  * Invalid UTF-8 SCAN key names are now skipped instead of being lossily remapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis key scanning to be safe with non-UTF-8 key names.
  * Non-text (binary) keys are now ignored during cleanup rather than decoded unsafely.
  * Added a regression test covering `SAVE`/snapshot behavior to ensure binary-named keys are not incorrectly removed and still round-trip correctly after reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->