### PR TITLE
perf(mem): box QueryGraph in ExprIR::Pattern/PatternComprehension

### DIFF
--- a/graph/src/parser/ast.rs
+++ b/graph/src/parser/ast.rs
@@ -230,11 +230,15 @@ pub enum ExprIR<TVar> {
     /// Pattern comprehension [(pattern) WHERE cond | expr]
     /// Stores the graph pattern for runtime traversal.
     /// Children: [where_condition, result_expression]
-    PatternComprehension(QueryGraph<Arc<String>, Arc<String>, TVar>),
+    ///
+    /// Boxed: `QueryGraph` is 72 bytes but this variant is rare, so inlining
+    /// it would bloat every node of every expression tree.
+    PatternComprehension(Box<QueryGraph<Arc<String>, Arc<String>, TVar>>),
     /// Parenthesized expression (for precedence)
     Paren,
-    /// Pattern predicate should be rewritten in planner
-    Pattern(QueryGraph<Arc<String>, Arc<String>, TVar>),
+    /// Pattern predicate should be rewritten in planner (boxed; see
+    /// `PatternComprehension`).
+    Pattern(Box<QueryGraph<Arc<String>, Arc<String>, TVar>>),
     /// shortestPath((a)-[*]->(b)) or allShortestPaths((a)-[*]->(b))
     /// Children: [source_var_expr, dest_var_expr]
     ShortestPath {

--- a/graph/src/parser/cypher.rs
+++ b/graph/src/parser/cypher.rs
@@ -1769,7 +1769,7 @@ impl<'a> Parser<'a> {
                     && let Ok(pattern) = self.parse_pattern(&Keyword::Match)
                     && !pattern.relationships().is_empty()
                 {
-                    return Ok((tree!(ExprIR::Pattern(pattern)), false));
+                    return Ok((tree!(ExprIR::Pattern(Box::new(pattern))), false));
                 }
 
                 // Not a pattern predicate - restore and parse normally
@@ -2462,7 +2462,7 @@ impl<'a> Parser<'a> {
         match_token!(self.lexer, RBrace);
 
         Ok(tree!(
-            ExprIR::PatternComprehension(graph),
+            ExprIR::PatternComprehension(Box::new(graph)),
             condition,
             result_expr
         ))

--- a/graph/src/planner/binder.rs
+++ b/graph/src/planner/binder.rs
@@ -1794,7 +1794,8 @@ impl Binder {
                     outer_scope_names.contains(name) || name.starts_with("_anon")
                 });
 
-                let mut new_tree = DynTree::new(ExprIR::PatternComprehension(bound_graph));
+                let mut new_tree =
+                    DynTree::new(ExprIR::PatternComprehension(Box::new(bound_graph)));
                 let mut root = new_tree.root_mut();
                 for child in children {
                     root.push_child_tree(child);
@@ -1983,7 +1984,7 @@ impl Binder {
                             outer_scope_names.contains(name) || name.starts_with("_anon")
                         });
 
-                        ExprIR::Pattern(result?)
+                        ExprIR::Pattern(Box::new(result?))
                     }
                 };
                 // Constructor rewrite: detect `duration({...})`, `date({...})`,

--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -790,7 +790,7 @@ impl Planner {
 
                 extracted.push((
                     var.clone(),
-                    (**graph).clone(),
+                    graph.as_ref().clone(),
                     where_tree,
                     result_tree,
                     vec![],
@@ -818,7 +818,7 @@ impl Planner {
 
                 extracted.push((
                     var.clone(),
-                    (**graph).clone(),
+                    graph.as_ref().clone(),
                     None,
                     Arc::new(DynTree::new(ExprIR::Variable(path_var))),
                     vec![query_path],
@@ -1121,7 +1121,7 @@ impl Planner {
             ExprIR::Pattern(graph) => {
                 if can_extract {
                     // Top-level conjunct: extract for SemiApply, replace with true.
-                    extractable.push(((**graph).clone(), false));
+                    extractable.push((graph.as_ref().clone(), false));
                     DynTree::new(ExprIR::Constant(Value::Bool(true)))
                 } else {
                     // Under OR/NOT: replace with a fresh boolean variable and
@@ -1134,7 +1134,7 @@ impl Planner {
                         ty: Type::Bool,
                     };
                     self.scope_vars[current_scope as usize].push(var.clone());
-                    inline.insert(var.id, (**graph).clone());
+                    inline.insert(var.id, graph.as_ref().clone());
                     DynTree::new(ExprIR::Variable(var))
                 }
             }
@@ -1146,7 +1146,7 @@ impl Planner {
                 {
                     if can_extract {
                         // Extract for AntiSemiApply (is_anti = true).
-                        extractable.push(((**graph).clone(), true));
+                        extractable.push((graph.as_ref().clone(), true));
                         return DynTree::new(ExprIR::Constant(Value::Bool(true)));
                     }
                     // Inline: create NOT(synth_var) so expr_to_plan can
@@ -1159,7 +1159,7 @@ impl Planner {
                         ty: Type::Bool,
                     };
                     self.scope_vars[current_scope as usize].push(var.clone());
-                    inline.insert(var.id, (**graph).clone());
+                    inline.insert(var.id, graph.as_ref().clone());
                     let mut new_tree = DynTree::new(ExprIR::Not);
                     new_tree
                         .root_mut()

--- a/graph/src/planner/mod.rs
+++ b/graph/src/planner/mod.rs
@@ -788,7 +788,13 @@ impl Planner {
                     extracted,
                 ));
 
-                extracted.push((var.clone(), graph.clone(), where_tree, result_tree, vec![]));
+                extracted.push((
+                    var.clone(),
+                    (**graph).clone(),
+                    where_tree,
+                    result_tree,
+                    vec![],
+                ));
                 DynTree::new(ExprIR::Variable(var))
             }
             ExprIR::Pattern(graph) => {
@@ -812,7 +818,7 @@ impl Planner {
 
                 extracted.push((
                     var.clone(),
-                    graph.clone(),
+                    (**graph).clone(),
                     None,
                     Arc::new(DynTree::new(ExprIR::Variable(path_var))),
                     vec![query_path],
@@ -1115,7 +1121,7 @@ impl Planner {
             ExprIR::Pattern(graph) => {
                 if can_extract {
                     // Top-level conjunct: extract for SemiApply, replace with true.
-                    extractable.push((graph.clone(), false));
+                    extractable.push(((**graph).clone(), false));
                     DynTree::new(ExprIR::Constant(Value::Bool(true)))
                 } else {
                     // Under OR/NOT: replace with a fresh boolean variable and
@@ -1128,7 +1134,7 @@ impl Planner {
                         ty: Type::Bool,
                     };
                     self.scope_vars[current_scope as usize].push(var.clone());
-                    inline.insert(var.id, graph.clone());
+                    inline.insert(var.id, (**graph).clone());
                     DynTree::new(ExprIR::Variable(var))
                 }
             }
@@ -1140,7 +1146,7 @@ impl Planner {
                 {
                     if can_extract {
                         // Extract for AntiSemiApply (is_anti = true).
-                        extractable.push((graph.clone(), true));
+                        extractable.push(((**graph).clone(), true));
                         return DynTree::new(ExprIR::Constant(Value::Bool(true)));
                     }
                     // Inline: create NOT(synth_var) so expr_to_plan can
@@ -1153,7 +1159,7 @@ impl Planner {
                         ty: Type::Bool,
                     };
                     self.scope_vars[current_scope as usize].push(var.clone());
-                    inline.insert(var.id, graph.clone());
+                    inline.insert(var.id, (**graph).clone());
                     let mut new_tree = DynTree::new(ExprIR::Not);
                     new_tree
                         .root_mut()


### PR DESCRIPTION
## Summary

`ExprIR<TVar>` is an enum, so it is sized to its largest variant. Two variants — `Pattern(QueryGraph<…>)` and `PatternComprehension(QueryGraph<…>)` — embedded a **72-byte `QueryGraph` inline**, forcing *every* node of *every* expression tree (`Arc<DynTree<ExprIR>>`) to 80 bytes, even though the overwhelmingly common variants are much smaller (`Property(Arc)` = 8, `Constant(Value)` = 16, `Add`/`Eq`/`Variable`, …).

Pattern predicates and pattern comprehensions are rare, so this boxes their payloads — the textbook enum-size trade (one cold-path indirection to shrink the hot common node).

## Measured impact

| Type | before | after |
|---|---:|---:|
| `size_of::<ExprIR<Arc<String>>>()` | 80 B | **40 B** |

That halves the per-node footprint of the parser/binder expression trees allocated on every cache-miss query parse+bind.

## Honest scope note

While preparing this I measured that boxing `QueryGraph` does **not** shrink two things my original review estimated it would, so I deliberately kept them out:

- **`ExprIR<Variable>`** (the cache-resident instantiation) stays **80 B** — it is independently capped by the `Reduce { accumulator: Variable, iterator: Variable }` variant (2 × 40 B). It only drops once `Variable` shrinks.
- **`IR`** (planner) stays **120 B** — capped by the vector-scan variants (`NodeByVectorScan`/`EdgeByVectorScan`), also a function of `Variable` being 40 B, not `QueryGraph`. I reverted the speculative `IR::Create`/`Merge` boxing since it delivered zero size reduction on its own and would only add an allocation.

Both of those require shrinking `Variable`/`Type` (e.g. boxing `Type::Union(Vec<Self>)`), which touches ~196 `Type::Union(vec![…])` sites — a much larger, higher-risk change best done and reviewed on its own. This PR is the contained, zero-risk half that stands alone.

## Testing
- `cargo check` (workspace) — clean
- `CXX=clang++ cargo clippy -p graph --lib` — no new warnings in edited files
- `cargo fmt --all -- --check` — clean
- `cargo test -p graph --lib` — **90 passed**, 0 failed

No behavior change — purely a memory-layout change to two enum variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
