### PR TITLE
Match C #2156 var-len trail semantics; fix silent OpenMP loss on macOS

### DIFF
--- a/graph/src/runtime/ops/cond_var_len_traverse.rs
+++ b/graph/src/runtime/ops/cond_var_len_traverse.rs
@@ -1,8 +1,8 @@
 //! Batch-mode variable-length traverse operator — multi-hop relationship expansion.
 //!
 //! Implements Cypher patterns like `(a)-[*2..5]->(b)`. For each active row
-//! in each input batch, enumerates all simple paths (no repeated edges within
-//! a single path) from the source node up to `max_hops` away, yielding result
+//! in each input batch, enumerates all trails (no repeated edges within a
+//! single path; nodes may repeat) from the source node up to `max_hops` away, yielding result
 //! rows for destinations reached at or beyond `min_hops`. Output rows are
 //! accumulated into batches of up to `BATCH_SIZE`.
 //!
@@ -93,8 +93,11 @@ struct VarLenIter<'a> {
     current_start: Option<NodeId>,
     /// Lazily-built adjacency cache, shared across the row's whole DFS.
     adj_cache: HashMap<u64, Vec<(NodeId, NodeId, RelationshipId)>>,
-    /// DFS frames: (node, path_elems, used_edges, nodes_in_path).
-    stack: Vec<(NodeId, ThinVec<Value>, RoaringTreemap, RoaringTreemap)>,
+    /// DFS frames: (node, path_elems, used_edges, depth). Depth counts edges
+    /// traversed so far; uniqueness is edge-based (Cypher trail semantics —
+    /// nodes may repeat, relationships may not), matching the C engine's
+    /// `Path_ContainsEdge` check.
+    stack: Vec<(NodeId, ThinVec<Value>, RoaringTreemap, u32)>,
     /// Current frame's emissions, stored reversed so `pop()` yields them in
     /// adjacency order. Bounded by the frame's fan-out.
     buf: FrameBuf,
@@ -135,19 +138,13 @@ impl VarLenIter<'_> {
             self.buf.push((start_node, start_node, path));
         }
         // The path is only materialized when consumed downstream; otherwise it
-        // stays empty (hop-counting uses `nodes_in_path`).
+        // stays empty (hop-counting uses the frame's depth counter).
         let mut initial_path = ThinVec::new();
         if self.emit_path {
             initial_path.push(Value::Node(start_node));
         }
-        let mut initial_nodes = RoaringTreemap::new();
-        initial_nodes.insert(u64::from(start_node));
-        self.stack.push((
-            start_node,
-            initial_path,
-            RoaringTreemap::new(),
-            initial_nodes,
-        ));
+        self.stack
+            .push((start_node, initial_path, RoaringTreemap::new(), 0));
     }
 
     /// Process one DFS frame under a single graph borrow: collect the frame's
@@ -178,13 +175,8 @@ impl VarLenIter<'_> {
             &rp.to.labels
         };
 
-        while let Some((current, mut path, mut used_edges, mut nodes_in_path)) = self.stack.pop() {
-            // Hops so far = distinct nodes visited - 1. Derived from
-            // `nodes_in_path` (always maintained for cycle detection) rather
-            // than `path.len()`, so path materialization can be skipped
-            // entirely when `emit_path` is false.
-            let hops_so_far = (nodes_in_path.len() as u32).saturating_sub(1);
-            let hop = hops_so_far + 1;
+        while let Some((current, mut path, mut used_edges, depth)) = self.stack.pop() {
+            let hop = depth + 1;
             if hop > max_hops {
                 continue;
             }
@@ -271,8 +263,7 @@ impl VarLenIter<'_> {
                             .iter()
                             .all(|l| g.get_node_labels(dest).any(|nl| nl == *l)));
 
-                let node_already_in_path = nodes_in_path.contains(u64::from(dest));
-                let will_continue = hop < max_hops && !node_already_in_path;
+                let will_continue = hop < max_hops;
 
                 if !will_emit && !will_continue {
                     continue;
@@ -314,13 +305,7 @@ impl VarLenIter<'_> {
                         used_edges.clone()
                     };
                     next_used.insert(u64::from(edge_id));
-                    let mut next_nodes = if is_last {
-                        std::mem::replace(&mut nodes_in_path, RoaringTreemap::new())
-                    } else {
-                        nodes_in_path.clone()
-                    };
-                    next_nodes.insert(u64::from(dest));
-                    self.stack.push((dest, owned, next_used, next_nodes));
+                    self.stack.push((dest, owned, next_used, hop));
                 } else if will_emit {
                     // Emit only — move path directly into Arc
                     let emit_path_val = emit_path.then(|| Value::Path(Arc::new(new_path)));
@@ -333,13 +318,7 @@ impl VarLenIter<'_> {
                         used_edges.clone()
                     };
                     next_used.insert(u64::from(edge_id));
-                    let mut next_nodes = if is_last {
-                        std::mem::replace(&mut nodes_in_path, RoaringTreemap::new())
-                    } else {
-                        nodes_in_path.clone()
-                    };
-                    next_nodes.insert(u64::from(dest));
-                    self.stack.push((dest, new_path, next_used, next_nodes));
+                    self.stack.push((dest, new_path, next_used, hop));
                 }
             }
 

--- a/graphblas.sh
+++ b/graphblas.sh
@@ -91,7 +91,13 @@ if [ -n "${CXX:-}" ]; then CMAKE_COMPILER_ARGS+=(-DCMAKE_CXX_COMPILER="${CXX}");
 
 # OpenMP: only force the static-libomp wiring inside the Docker toolchain
 # image (where build/libomp.sh has produced /opt/libomp/lib/libomp.a). On
-# every other host let cmake's find_package(OpenMP) auto-detect.
+# macOS, wire Homebrew's libomp explicitly: Apple clang has no -fopenmp
+# driver flag, so cmake's find_package(OpenMP) fails *silently* and
+# GraphBLAS builds single-threaded — every mxm/mxv then runs on one core
+# (measured ~4x slower harmonic centrality / ~3x slower MSF vs the C
+# engine, whose build wires libomp). `-Xclang -fopenmp` bypasses the
+# driver check and works on both Apple clang and Homebrew LLVM clang.
+# On every other host let cmake's find_package(OpenMP) auto-detect.
 LIBOMP_PREFIX="${LIBOMP_PREFIX:-/opt/libomp}"
 OPENMP_CMAKE_ARGS=()
 INCLUDE_FLAG=""
@@ -103,6 +109,17 @@ if [ -f "${LIBOMP_PREFIX}/lib/libomp.a" ]; then
         -DOpenMP_C_LIB_NAMES=omp
         -DOpenMP_CXX_LIB_NAMES=omp
         -DOpenMP_omp_LIBRARY="${LIBOMP_PREFIX}/lib/libomp.a"
+    )
+elif [ "$(uname -s)" = "Darwin" ] \
+    && BREW_LIBOMP="$(brew --prefix libomp 2>/dev/null)" \
+    && [ -f "${BREW_LIBOMP}/lib/libomp.dylib" ]; then
+    INCLUDE_FLAG="-I${BREW_LIBOMP}/include"
+    OPENMP_CMAKE_ARGS=(
+        "-DOpenMP_C_FLAGS=-Xclang -fopenmp -I${BREW_LIBOMP}/include"
+        "-DOpenMP_CXX_FLAGS=-Xclang -fopenmp -I${BREW_LIBOMP}/include"
+        -DOpenMP_C_LIB_NAMES=omp
+        -DOpenMP_CXX_LIB_NAMES=omp
+        -DOpenMP_omp_LIBRARY="${BREW_LIBOMP}/lib/libomp.dylib"
     )
 fi
 

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -258,9 +258,9 @@ class testVariableLengthTraversals(FlowTestsBase):
         # a->b->c->a
         #
         # variable length traversal should not get stuck in a cycle
-        # in addition, the traversal mustn't continue traversing once a cycle
-        # is detected, for the test graph that means that the path: a->b->c->a->d/b
-        # can't be matched
+        # traversal follows Cypher trail semantics: relationships are unique
+        # within a path but nodes may repeat, so a->b->c->a->d is matched
+        # (a->b->c->a->b is not, edge a->b would repeat)
 
         # clear previous data
         self.graph.delete()
@@ -280,9 +280,10 @@ class testVariableLengthTraversals(FlowTestsBase):
                    ORDER BY z.v"""
 
         result = self.graph.query(query).result_set
-        self.env.assertEqual(len(result), 2)
+        self.env.assertEqual(len(result), 3)
         self.env.assertEqual(result[0][0], 'a')
         self.env.assertEqual(result[1][0], 'c')
+        self.env.assertEqual(result[2][0], 'd')
 
     def test13_fanout(self):
         # create a tree structure graph with a fanout of 3


### PR DESCRIPTION
## Summary

Two fixes found while profiling the poor Rust-side numbers in the CI benchmark (see #655 discussion):

1. **Var-len traversal now uses edge-uniqueness (Cypher trail semantics), matching C HEAD after FalkorDB/FalkorDB#2156**
2. **graphblas.sh silently built GraphBLAS single-threaded on macOS** — OpenMP was never detected

---

## 1. Edge-uniqueness in `VarLenIter` (`graph/src/runtime/ops/cond_var_len_traverse.rs`)

### Before
The DFS enforced **node**-uniqueness: a path could never revisit a node. That is neither Cypher-correct nor what the C engine does.

### After
Uniqueness is **edge**-based (a `RoaringTreemap` of used edge IDs per frame): relationships are unique within a path, nodes may repeat. This matches openCypher trail semantics and the C engine's `Path_ContainsEdge` check.

### Why now
FalkorDB/FalkorDB#2156 (merged 2026-07-05) removed the C engine's algebraic `*n..n` -> M^n fast path *because* it violates edge-uniqueness. Post-#2156, C enumerates trails for fixed-length ranges too. This PR brings the Rust engine to the same (correct) semantics.

### Correctness evidence
- Diamond graph `*2..2`: 2 trails / 1 distinct endpoint — matches C HEAD exactly.
- Medium benchmark graph, hop-4 distinct endpoints: **38,629, exactly matching C**. The old node-unique code returned 38,628 — it wrongly pruned trails passing through a repeated intermediate node, silently missing a reachable endpoint.
- 5-hop trail count: 15,815,611 trails in 3.23s — same speed as before; dropping the per-frame node-bitmap clone offsets the extra trail work.

### Test update
`tests/flow/test_variable_length_traversals.py::test12_close_cycle` updated from 2 -> 3 expected rows (`a->b->c->a->d` is a valid trail; no edge repeats). This mirrors the identical test change the C repo made in #2156 — our copy was stale.

## 2. macOS OpenMP fix (`graphblas.sh`)

Apple clang has no `-fopenmp` driver flag, so cmake's `find_package(OpenMP)` fails **silently** and GraphBLAS builds single-threaded — every mxm/mxv runs on one core. Fixed by wiring Homebrew libomp explicitly with `-Xclang -fopenmp`.

Measured on the medium benchmark graph:
- harmonic centrality: **7174ms -> 790ms** (now ~2x faster than C)
- MSF: **465ms -> 170ms**

Linux/CI builds were never affected (they use the `/opt/libomp` static path).

## Benchmark context (why CI numbers won't move yet)

The CI benchmark's `exact_5/6_hop_traverse_count` queries (`*5..5`/`*6..6`) compare against a C baseline binary built **before** #2156. That binary plans them algebraically (M^n, distinct endpoints, ~8ms). Post-#2156 C — and this PR's Rust — enumerate ~15.8M trails (seconds). Until the baseline is rebuilt from C HEAD, those two queries are semantically incomparable; the slow trail enumeration also monopolizes the worker pool and inflates p50s of unrelated queries in the same run.

## Test plan
- [x] Full CI-gated TCK: 2,456 scenarios passed / 0 failed
- [x] Flow suites: test_variable_length_traversals 15/15, test_relation_patterns 13/13, test_bidirectional_traversals 12/12, test_path_algorithms 9/9, test_shortest_path 7/7, test_all_shortest_paths 7/7
- [x] Diamond-graph `*2..2` sanity check vs C HEAD
- [x] Hop-count distinct-endpoint verification vs C (38,629)
- [ ] CI benchmark run on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Variable-length traversals now follow trail semantics, allowing nodes to repeat while preventing repeated edges in a path.
  * macOS builds now include explicit OpenMP support for better compatibility during setup and compilation.

* **Bug Fixes**
  * Improved cycle handling in variable-length traversal results so valid paths are no longer stopped by node revisits.

* **Tests**
  * Updated traversal coverage to match the new path behavior and expected result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->