### PR TITLE
Reinstate LAGraph JIT-string patch for cross-platform HLL PreJIT kernels

### DIFF
--- a/build/graphblas/LAGraph_jit_string_portability.patch
+++ b/build/graphblas/LAGraph_jit_string_portability.patch
@@ -1,0 +1,13 @@
+diff --git a/experimental/algorithm/LAGr_HarmonicCentrality.c b/experimental/algorithm/LAGr_HarmonicCentrality.c
+index c7a759a..fdab22a 100644
+--- a/experimental/algorithm/LAGr_HarmonicCentrality.c
++++ b/experimental/algorithm/LAGr_HarmonicCentrality.c
+@@ -208,7 +208,7 @@ LG_HLL_DELTA_STR)
+ 
+ LG_JIT_STRING(
+     void lg_hll_second(HLL *z, bool *x, const HLL *y) {
+-    memcpy(z->registers, y->registers, sizeof(z->registers));
++    *z = *y ;
+ },
+ LG_HLL_SECOND_STR)
+ 

--- a/build/graphblas/PreJIT/GB_jit__AxB_dot4__0000400e1e0e1eca__lg_hll_merge_lg_hll_second.c
+++ b/build/graphblas/PreJIT/GB_jit__AxB_dot4__0000400e1e0e1eca__lg_hll_merge_lg_hll_second.c
@@ -40,9 +40,9 @@ void lg_hll_merge(HLL *z, const HLL *x, const HLL *y) { for (uint32_t i = 0; i <
 #ifndef GB_GUARD_lg_hll_second_DEFINED
 #define GB_GUARD_lg_hll_second_DEFINED
 GB_STATIC_INLINE
-void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { memcpy(z->registers, y->registers, sizeof(z->registers)); }
+void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { *z = *y ; }
 #define GB_lg_hll_second_USER_DEFN \
-"void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { memcpy(z->registers, y->registers, sizeof(z->registers)); }"
+"void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { *z = *y ; }"
 #endif
 #define GB_MULT(z,x,y,i,k,j)  lg_hll_second (&(z), &(x), &(y))
 

--- a/build/graphblas/PreJIT/GB_jit__AxB_dot4__0380400e1e0e1ec6__lg_hll_merge_lg_hll_second.c
+++ b/build/graphblas/PreJIT/GB_jit__AxB_dot4__0380400e1e0e1ec6__lg_hll_merge_lg_hll_second.c
@@ -40,9 +40,9 @@ void lg_hll_merge(HLL *z, const HLL *x, const HLL *y) { for (uint32_t i = 0; i <
 #ifndef GB_GUARD_lg_hll_second_DEFINED
 #define GB_GUARD_lg_hll_second_DEFINED
 GB_STATIC_INLINE
-void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { memcpy(z->registers, y->registers, sizeof(z->registers)); }
+void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { *z = *y ; }
 #define GB_lg_hll_second_USER_DEFN \
-"void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { memcpy(z->registers, y->registers, sizeof(z->registers)); }"
+"void lg_hll_second(HLL *z, _Bool *x, const HLL *y) { *z = *y ; }"
 #endif
 #define GB_MULT(z,x,y,i,k,j)  lg_hll_second (&(z), &(x), &(y))
 

--- a/graphblas.sh
+++ b/graphblas.sh
@@ -244,6 +244,16 @@ LAGRAPH_INSTALL_DIR="${LAGRAPH_INSTALL_DIR:-${SCRIPT_DIR}/lagraph_lib}"
 rm -rf LAGraph
 git clone --branch "${LAGRAPH_VERSION}" --single-branch --depth 1 \
     https://github.com/GraphBLAS/LAGraph.git
+
+# LG_JIT_STRING stringifies op bodies AFTER macro expansion, so a bare
+# `memcpy` in lg_hll_second becomes `__builtin___memcpy_chk(...)` on macOS
+# (Apple fortify headers) but stays `memcpy(...)` on Linux. The JIT defn
+# string then hashes differently per platform, and PreJIT kernels harvested
+# on one OS are rejected by their _query check on the other — HyperBall's
+# dot4 HLL kernels silently punt to generic dot2 (~4x slower harmonic).
+# Replace the memcpy with a struct assignment, which no header macro touches.
+git -C LAGraph apply "${SCRIPT_DIR}/build/graphblas/LAGraph_jit_string_portability.patch"
+
 mkdir -p LAGraph/build
 (
     cd LAGraph/build


### PR DESCRIPTION
## Summary

`algo.HarmonicCentrality` silently fell back from the dot4 HLL fast path to generic `GB_AxB_dot2` (~2x slower) on macOS, because the Linux-harvested PreJIT kernels fail their `_query` hash check there.

**Root cause:** LAGraph's `LG_JIT_STRING` stringifies op bodies AFTER host macro expansion. The bare `memcpy` in `lg_hll_second` stays `memcpy(...)` on Linux but becomes `__builtin___memcpy_chk(...)` on macOS (Apple fortify headers), so the JIT defn string — and its hash — differs per platform. #673's build-time patch (`*z = *y ;` struct assignment, which no header macro touches) made the string platform-stable, but e790e42/948852d dropped it in favor of Linux-only harvest. That fixed CI while leaving every macOS build on generic dot2.

**Fix:**
1. Revert e790e42 — reinstate `build/graphblas/LAGraph_jit_string_portability.patch` and its application in `graphblas.sh`.
2. Regenerate the PreJIT kernel set via `gen_prejit.sh` in the Linux Docker toolchain image. Only the 2 `AxB_dot4__*__lg_hll_merge_lg_hll_second` kernels changed (their defn strings now embed `*z = *y ;`); the other 156 kernels are byte-identical. One harvest now hash-matches on both Linux and macOS.

## Results — medium graph (100k nodes / 1.77M edges), macOS arm64, serial

| engine | harmonic exec | notes |
| --- | --- | --- |
| RS before | ~1.55 s | generic dot2 fallback |
| RS after | **~0.79 s** | dot4 fast path |
| C engine | ~1.6 s | |

Output (count/avg/max score) is identical to the C engine. Linux CI is unaffected functionally — kernels are still harvested there; only the defn string source changed.

## Test plan
- [x] Full flow suite in the Docker harvest run (1312/1313 pass; single failure is the flaky `test_slowlog.test01`)
- [x] macOS rebuild: `strings` confirm `*z = *y ;` in liblagraphx.a + dylib; `nm` shows all 6 dot4 HLL symbols
- [x] Harmonic result parity vs C on medium
- [ ] CI A/B benchmark on x64 to confirm no Linux regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portability of generated GraphBLAS JIT code across macOS and Linux.
  * Prevents previously built kernels from being rejected due to platform-specific differences, reducing build and runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->