### PR TITLE
fix(ci): grant pull-requests:write to benchmark-edge (Rust Push startup_failure)

### DIFF
--- a/.github/workflows/rust-push.yml
+++ b/.github/workflows/rust-push.yml
@@ -156,6 +156,11 @@ jobs:
     uses: ./.github/workflows/_benchmark.yml
     permissions:
       contents: write
+      # _benchmark.yml's merge job declares pull-requests: write; a reusable
+      # workflow can't request a permission the caller didn't grant, so omitting
+      # this made the whole Rust Push run startup_fail. (The canonical run never
+      # comments — no PR — but the grant must still cover the declaration.)
+      pull-requests: write
     with:
       image_a: docker.io/falkordb/falkordb-server:edge
       image_b: ghcr.io/falkordb/falkordb-server:edge-rs


### PR DESCRIPTION
## Problem
`Rust Push` has been failing with **`startup_failure`** on `main` since #655 merged — e.g. [run 29018901623](https://github.com/FalkorDB/falkordb-rs-next-gen/actions/runs/29018901623) — so **none** of its jobs run, including `promote-edge`.

## Cause
The `benchmark-edge` job (added in #655) calls the reusable `_benchmark.yml`, whose `merge` job declares `pull-requests: write`. `benchmark-edge` only granted `contents: write`. A called workflow can't request a permission the caller didn't grant, so GitHub rejects the whole workflow at load time (`startup_failure`). It slipped through because `rust-push.yml` only runs on push-to-`main`, so `benchmark-edge` was never dispatched until the merge landed.

## Fix
Grant `pull-requests: write` to `benchmark-edge`, matching what `benchmark.yml`'s `run-benchmark` already grants. The canonical trend run never comments (no PR), but the grant must still cover the reusable's declaration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated benchmarking workflow to include the necessary permissions, helping benchmark-related checks run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->