### PR TITLE
perf(replication): skip effects-buffer serialization when no replica/AOF consumer

### DIFF
--- a/graph/src/runtime/ops/commit.rs
+++ b/graph/src/runtime/ops/commit.rs
@@ -90,13 +90,22 @@ impl<'a> Iterator for CommitOp<'a> {
             // Commit succeeded — build effects buffer from pending data, then clear.
             {
                 let pending = self.runtime.pending.borrow();
-                if pending.effects_count() > 0 {
-                    let mut buf_ref = self.runtime.effects_buffer.borrow_mut();
-                    let buf = buf_ref.get_or_insert_with(Vec::new);
-                    let n_effects = pending.build_effects_buffer(&self.runtime.g, buf);
-                    self.runtime
-                        .effects_count
-                        .set(self.runtime.effects_count.get() + n_effects);
+                let estimated = pending.effects_count();
+                if estimated > 0 {
+                    if self.runtime.build_effects.get() {
+                        let mut buf_ref = self.runtime.effects_buffer.borrow_mut();
+                        let buf = buf_ref.get_or_insert_with(Vec::new);
+                        let n_effects = pending.build_effects_buffer(&self.runtime.g, buf);
+                        self.runtime
+                            .effects_count
+                            .set(self.runtime.effects_count.get() + n_effects);
+                    } else {
+                        // Keep the count accurate for `modified` bookkeeping
+                        // even when the buffer itself is not needed.
+                        self.runtime
+                            .effects_count
+                            .set(self.runtime.effects_count.get() + estimated);
+                    }
                 }
             }
             self.runtime.pending.borrow_mut().clear();

--- a/graph/src/runtime/runtime.rs
+++ b/graph/src/runtime/runtime.rs
@@ -154,6 +154,11 @@ pub struct Runtime<'a> {
     pub effects_buffer: RefCell<Option<Vec<u8>>>,
     /// Total number of effect records across all commits in this query.
     pub effects_count: Cell<u64>,
+    /// Whether commits should serialize an effects buffer. Callers clear
+    /// this when replication has no possible consumer (no AOF, no replica
+    /// has ever attached); the replication layer then falls back to
+    /// verbatim query propagation, which Redis discards for free.
+    pub build_effects: Cell<bool>,
     /// Timestamp captured at the start of the transaction/query.
     /// Used by `date.transaction()`, `localtime.transaction()`, and `localdatetime.transaction()`
     /// so every call in the same transaction returns the same value.
@@ -392,6 +397,7 @@ impl<'a> Runtime<'a> {
             result_set_size,
             effects_buffer: RefCell::new(None),
             effects_count: Cell::new(0),
+            build_effects: Cell::new(true),
             transaction_timestamp: Utc::now(),
             profile,
             profile_data: RefCell::new(HashMap::new()),

--- a/src/graph_core.rs
+++ b/src/graph_core.rs
@@ -297,6 +297,14 @@ pub mod ffi {
     }
 }
 
+/// Sticky flag: set once any replica has ever attached (ReplicaChange
+/// server event) and never cleared — a disconnected replica may resume
+/// from the replication backlog, so effects buffers must keep being
+/// built after the first attach. While false (and AOF is off) write
+/// queries skip serializing effects entirely; the replication layer's
+/// verbatim-query fallback is then a no-op propagation.
+pub static REPLICATION_CONSUMERS: AtomicBool = AtomicBool::new(false);
+
 pub struct ThreadedGraph {
     pub graph: MvccGraph,
     pub sender: MTx<Array<Box<WriteMessage>>>,
@@ -462,6 +470,10 @@ impl ThreadedGraph {
             timeout_ms,
             QUERY_MEM_CAPACITY.load(Ordering::Relaxed),
             Some(net_thread_usage),
+        );
+        runtime.build_effects.set(
+            REPLICATION_CONSUMERS.load(Ordering::Relaxed)
+                || ctx.get_flags().contains(ContextFlags::AOF),
         );
         let mut result = match runtime.query() {
             Ok(r) => r,

--- a/src/module_init.rs
+++ b/src/module_init.rs
@@ -69,6 +69,10 @@ const REDISMODULE_SUBEVENT_LOADING_FAILED: u64 = 4;
 static RedisModuleEvent_ReplicationRoleChanged: RedisModuleEvent =
     RedisModuleEvent { id: 0, dataver: 1 };
 
+/// Redis event ID for replica attach/detach (REDISMODULE_EVENT_REPLICA_CHANGE).
+#[allow(non_upper_case_globals)]
+static RedisModuleEvent_ReplicaChange: RedisModuleEvent = RedisModuleEvent { id: 6, dataver: 1 };
+
 /// Redis event ID for shutdown. Only wired up under sanitizer/valgrind
 /// runs (gated by `RS_GLOBAL_DTORS`) so workers join cleanly and per-thread
 /// + module-level RediSearch/LAGraph state is released — otherwise these
@@ -402,6 +406,22 @@ pub fn graph_init(
         debug_assert_eq!(res, REDISMODULE_OK as c_int);
     }
 
+    // Latch effects-buffer building as soon as any replica attaches (or if
+    // this instance already changed roles); until then standalone masters
+    // skip serializing per-commit replication effects.
+    unsafe {
+        let res = RedisModule_SubscribeToServerEvent.unwrap()(
+            ctx.ctx,
+            RedisModuleEvent_ReplicaChange,
+            Some(on_replica_change),
+        );
+        debug_assert_eq!(res, REDISMODULE_OK as c_int);
+    }
+    if ctx.get_flags().contains(ContextFlags::SLAVE) {
+        // Loaded on a replica: replication topology already exists.
+        crate::graph_core::REPLICATION_CONSUMERS.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
     // Subscribe to keyspace notifications for graph key rename handling.
     unsafe {
         let res = redis_module::raw::RedisModule_SubscribeToKeyspaceEvents.unwrap()(
@@ -471,6 +491,21 @@ unsafe extern "C" fn on_role_change(
     _data: *mut c_void,
 ) {
     telemetry::set_is_replica(subevent == REDISMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA);
+    // A role change means a replication topology exists (or is being set
+    // up); keep building effects buffers from here on.
+    crate::graph_core::REPLICATION_CONSUMERS.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Any replica attach/detach latches the sticky "replication has
+/// consumers" flag: even after the last replica detaches it may resume
+/// from the replication backlog, so effects buffers must keep being built.
+unsafe extern "C" fn on_replica_change(
+    _ctx: *mut RedisModuleCtx,
+    _eid: RedisModuleEvent,
+    _subevent: u64,
+    _data: *mut c_void,
+) {
+    crate::graph_core::REPLICATION_CONSUMERS.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Loading event callback. After a slave finishes a full RDB resync from


### PR DESCRIPTION
Extracted from #669 (the attribute-store PR), where this was added on the fly. It is orthogonal to attribute storage and belongs in its own PR.

A standalone master with no AOF and no replica ever attached has no consumer for the per-commit replication effects buffer, so serializing it is pure overhead. This latches a sticky `REPLICATION_CONSUMERS` flag — set on the first replica attach (the `ReplicaChange` server event) or on any role change, and never cleared, because a detached replica may resume from the replication backlog — and gates effects-buffer building on it through a new `Runtime::build_effects` cell. When effects aren't built, the replication layer falls back to verbatim query propagation, which Redis discards for free when there is nothing to propagate.

`effects_count` is still tracked accurately for `modified` bookkeeping even when the buffer itself is not serialized.
