### PR TITLE
perf(batch): inline hot Column/Batch value accessors

### DIFF
--- a/graph/src/runtime/batch.rs
+++ b/graph/src/runtime/batch.rs
@@ -289,6 +289,7 @@ pub enum Column {
 impl Column {
     /// Extracts a single [`Value`] from this column at the given row index.
     #[must_use]
+    #[inline]
     pub fn get(
         &self,
         row: usize,
@@ -1142,6 +1143,7 @@ impl<'a> Batch<'a> {
     /// `Column::Unbound`); returns `Some(Value::Null)` for an explicitly-null
     /// binding. Clones the value.
     #[must_use]
+    #[inline]
     pub fn value_at(
         &self,
         var_id: u32,
@@ -1284,6 +1286,7 @@ impl<'b, 'a> BatchRow<'b, 'a> {
 }
 
 impl RowView for BatchRow<'_, '_> {
+    #[inline]
     fn value_at(
         &self,
         var_id: u32,


### PR DESCRIPTION
Extracted from #669 (the attribute-store PR), where this was added on the fly. It is orthogonal to attribute storage and belongs in its own PR.

Adds `#[inline]` to `Column::get`, `Batch::value_at`, and `BatchRow::value_at` — small per-row hot-path accessors that benefit from cross-crate inlining.
